### PR TITLE
Add `CachedStorage` in `rustuna_core` crate.

### DIFF
--- a/rustuna_core/src/lib.rs
+++ b/rustuna_core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod attr;
 pub mod distribution;
 pub mod sampler;
 pub mod storage;
+pub mod storage_cache;
 pub mod study;
 pub mod trial;
 

--- a/rustuna_core/src/storage.rs
+++ b/rustuna_core/src/storage.rs
@@ -28,10 +28,14 @@ pub trait Storage: Send + Sync {
         trial_number: u32,
         state_values: TrialStateValues,
     ) -> Result<()>;
-    fn get_studies(&self) -> Result<&Vec<PersistedStudy>>;
-    fn get_study(&self, study_id: u32) -> Result<&PersistedStudy>;
-    fn get_trials(&self, study_id: u32) -> Result<&Vec<PersistedTrial>>;
-    fn get_trial(&self, study_id: u32, trial_number: u32) -> Result<&PersistedTrial>;
+    // Design Note:
+    // get_* methods take &mut self to allow in-place cache refresh in wrapper implementations
+    // (e.g., CachedStorage). With &self it is impossible to safely update caches and return
+    // references without relying on unsafe patterns.
+    fn get_studies(&mut self) -> Result<&Vec<PersistedStudy>>;
+    fn get_study(&mut self, study_id: u32) -> Result<&PersistedStudy>;
+    fn get_trials(&mut self, study_id: u32) -> Result<&Vec<PersistedTrial>>;
+    fn get_trial(&mut self, study_id: u32, trial_number: u32) -> Result<&PersistedTrial>;
     // Design Note:
     // Unlike the storage APIs in Optuna, the `set_study_attrs` and `set_trial_attrs` methods
     // are designed to receive multiple attributes for bulk insert operations.
@@ -147,11 +151,11 @@ impl Storage for InMemoryStorage {
         Ok(())
     }
 
-    fn get_studies(&self) -> Result<&Vec<PersistedStudy>> {
+    fn get_studies(&mut self) -> Result<&Vec<PersistedStudy>> {
         Ok(&self.studies)
     }
 
-    fn get_study(&self, study_id: u32) -> Result<&PersistedStudy> {
+    fn get_study(&mut self, study_id: u32) -> Result<&PersistedStudy> {
         let study = self
             .studies
             .get(study_id as usize)
@@ -159,11 +163,11 @@ impl Storage for InMemoryStorage {
         Ok(study)
     }
 
-    fn get_trials(&self, study_id: u32) -> Result<&Vec<PersistedTrial>> {
+    fn get_trials(&mut self, study_id: u32) -> Result<&Vec<PersistedTrial>> {
         get_trials_by_study_id(&self.trials, study_id)
     }
 
-    fn get_trial(&self, study_id: u32, trial_number: u32) -> Result<&PersistedTrial> {
+    fn get_trial(&mut self, study_id: u32, trial_number: u32) -> Result<&PersistedTrial> {
         let trial = get_trials_by_study_id(&self.trials, study_id)?
             .get(trial_number as usize)
             .ok_or(Error::new(ErrorKind::TrialNotFound))?;

--- a/rustuna_core/src/storage_cache.rs
+++ b/rustuna_core/src/storage_cache.rs
@@ -1,0 +1,220 @@
+use std::collections::HashMap;
+
+use crate::attr::Attrs;
+use crate::distribution::Distribution;
+use crate::study::{Direction, PersistedStudy};
+use crate::study_cache::StudyCache;
+use crate::trial::{PersistedTrial, TrialStateValues};
+use crate::{Result};
+
+
+pub trait CachedStorageBackend: Send + Sync {
+    // Design Note:
+    // This trait is intended for backends that return owned values (not references) so that
+    // a wrapper (e.g., CachedStorage) can materialize in-memory caches and then hand out
+    // references required by the Storage trait. This mirrors Optuna's _CachedStorage pattern:
+    // backend focuses on persistence, wrapper handles caching and reference semantics.
+    fn create_new_study(
+        &mut self,
+        study_name: &str,
+        directions: Vec<Direction>,
+    ) -> Result<PersistedStudy>;
+    fn create_new_trial(&mut self, study_id: u32) -> Result<PersistedTrial>;
+    fn set_trial_param(
+        &mut self,
+        study_id: u32,
+        trial_number: u32,
+        name: &str,
+        distribution: &Distribution,
+        value: f64,
+    ) -> Result<()>;
+    fn set_trial_state_values(
+        &mut self,
+        study_id: u32,
+        trial_number: u32,
+        state_values: TrialStateValues,
+    ) -> Result<()>;
+    fn get_studies(&self) -> Result<Vec<PersistedStudy>>;
+    fn get_study(&self, study_id: u32) -> Result<PersistedStudy>;
+    fn get_trials(&self, study_id: u32) -> Result<Vec<PersistedTrial>>;
+    fn get_trial(&self, study_id: u32, trial_number: u32) -> Result<PersistedTrial>;
+    // Design Note:
+    // Unlike the storage APIs in Optuna, the `set_study_attrs` and `set_trial_attrs` methods
+    // are designed to receive multiple attributes for bulk insert operations.
+    // Furthermore, the `user_attrs` and `system_attrs` are merged into a single HashMap,
+    // which simplifies the implementation process for third-party storages.
+    fn set_study_attrs(&mut self, study_id: u32, attrs: Attrs) -> Result<()>;
+    fn set_trial_attrs(&mut self, study_id: u32, trial_number: u32, attrs: Attrs) -> Result<()>;
+    fn get_joint_search_space(&mut self, study_id: u32) -> Result<HashMap<String, Distribution>>;
+}
+
+
+pub struct CachedStorage {
+    studies: Vec<PersistedStudy>,
+    trials: HashMap<u32, Vec<PersistedTrial>>,
+    study_caches: HashMap<u32, StudyCache>,
+
+    backend: Box<dyn CachedStorageBackend>,
+}
+
+impl CachedStorage {
+    pub fn new(backend: Box<dyn CachedStorageBackend>) -> CachedStorage {
+        CachedStorage {
+            studies: Vec::new(),
+            trials: HashMap::new(),
+            study_caches: HashMap::new(),
+            backend,
+        }
+    }
+}
+
+impl crate::storage::Storage for CachedStorage {
+    fn create_new_study(
+        &mut self,
+        study_name: &str,
+        directions: Vec<Direction>,
+    ) -> Result<&PersistedStudy> {
+        todo!()
+    }
+
+    fn create_new_trial(&mut self, study_id: u32) -> Result<&PersistedTrial> {
+        todo!()
+    }
+
+    fn set_trial_param(
+        &mut self,
+        study_id: u32,
+        trial_number: u32,
+        name: &str,
+        distribution: &Distribution,
+        value: f64,
+    ) -> Result<()> {
+        todo!()
+    }
+
+    fn set_trial_state_values(
+        &mut self,
+        study_id: u32,
+        trial_number: u32,
+        state_values: TrialStateValues,
+    ) -> Result<()> {
+        todo!()
+    }
+
+    fn get_studies(&self) -> Result<&Vec<PersistedStudy>> {
+        todo!()
+    }
+
+    fn get_study(&self, study_id: u32) -> Result<&PersistedStudy> {
+        todo!()
+    }
+
+    fn get_trials(&self, study_id: u32) -> Result<&Vec<PersistedTrial>> {
+        todo!()
+    }
+
+    fn get_trial(&self, study_id: u32, trial_number: u32) -> Result<&PersistedTrial> {
+        todo!()
+    }
+
+    fn set_study_attrs(&mut self, study_id: u32, attrs: Attrs) -> Result<()> {
+        todo!()
+    }
+
+    fn set_trial_attrs(&mut self, study_id: u32, trial_number: u32, attrs: Attrs) -> Result<()> {
+        todo!()
+    }
+
+    fn get_joint_search_space(&mut self, study_id: u32) -> Result<HashMap<String, Distribution>> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::Storage;
+
+    struct DummyBackend {
+        inner: crate::storage::InMemoryStorage,
+    }
+
+    impl DummyBackend {
+        fn new() -> Self {
+            DummyBackend {
+                inner: crate::storage::InMemoryStorage::new(),
+            }
+        }
+    }
+
+    impl CachedStorageBackend for DummyBackend {
+        fn create_new_study(
+            &mut self,
+            study_name: &str,
+            directions: Vec<Direction>,
+        ) -> Result<PersistedStudy> {
+            let study = self.inner.create_new_study(study_name, directions)?.clone();
+            Ok(study)
+        }
+
+        fn create_new_trial(&mut self, study_id: u32) -> Result<PersistedTrial> {
+            let trial = self.inner.create_new_trial(study_id)?.clone();
+            Ok(trial)
+        }
+
+        fn set_trial_param(
+            &mut self,
+            study_id: u32,
+            trial_number: u32,
+            name: &str,
+            distribution: &Distribution,
+            value: f64,
+        ) -> Result<()> {
+            self.inner
+                .set_trial_param(study_id, trial_number, name, distribution, value)
+        }
+
+        fn set_trial_state_values(
+            &mut self,
+            study_id: u32,
+            trial_number: u32,
+            state_values: TrialStateValues,
+        ) -> Result<()> {
+            self.inner
+                .set_trial_state_values(study_id, trial_number, state_values)
+        }
+
+        fn get_studies(&self) -> Result<Vec<PersistedStudy>> {
+            Ok(self.inner.get_studies()?.clone())
+        }
+
+        fn get_study(&self, study_id: u32) -> Result<PersistedStudy> {
+            Ok(self.inner.get_study(study_id)?.clone())
+        }
+
+        fn get_trials(&self, study_id: u32) -> Result<Vec<PersistedTrial>> {
+            Ok(self.inner.get_trials(study_id)?.clone())
+        }
+
+        fn get_trial(&self, study_id: u32, trial_number: u32) -> Result<PersistedTrial> {
+            Ok(self.inner.get_trial(study_id, trial_number)?.clone())
+        }
+
+        fn set_study_attrs(&mut self, study_id: u32, attrs: Attrs) -> Result<()> {
+            self.inner.set_study_attrs(study_id, attrs)
+        }
+
+        fn set_trial_attrs(
+            &mut self,
+            study_id: u32,
+            trial_number: u32,
+            attrs: Attrs,
+        ) -> Result<()> {
+            self.inner.set_trial_attrs(study_id, trial_number, attrs)
+        }
+
+        fn get_joint_search_space(&mut self, study_id: u32) -> Result<HashMap<String, Distribution>> {
+            self.inner.get_joint_search_space(study_id)
+        }
+    }
+}

--- a/rustuna_core/src/storage_cache.rs
+++ b/rustuna_core/src/storage_cache.rs
@@ -5,8 +5,7 @@ use crate::distribution::Distribution;
 use crate::study::{Direction, PersistedStudy};
 use crate::study_cache::StudyCache;
 use crate::trial::{PersistedTrial, TrialStateValues};
-use crate::{Result};
-
+use crate::Result;
 
 pub trait CachedStorageBackend: Send + Sync {
     // Design Note:
@@ -48,7 +47,6 @@ pub trait CachedStorageBackend: Send + Sync {
     fn get_joint_search_space(&mut self, study_id: u32) -> Result<HashMap<String, Distribution>>;
 }
 
-
 pub struct CachedStorage {
     studies: Vec<PersistedStudy>,
     trials: HashMap<u32, Vec<PersistedTrial>>,
@@ -74,7 +72,12 @@ impl crate::storage::Storage for CachedStorage {
         study_name: &str,
         directions: Vec<Direction>,
     ) -> Result<&PersistedStudy> {
-        todo!()
+        let study = self.backend.create_new_study(study_name, directions)?;
+        let study_id = study.id;
+        self.studies.push(study);
+        self.trials.insert(study_id, vec![]);
+        self.study_caches.insert(study_id, StudyCache::new());
+        Ok(self.studies.last().unwrap())
     }
 
     fn create_new_trial(&mut self, study_id: u32) -> Result<&PersistedTrial> {
@@ -134,6 +137,7 @@ impl crate::storage::Storage for CachedStorage {
 mod tests {
     use super::*;
     use crate::storage::Storage;
+    use crate::ErrorKind;
 
     struct DummyBackend {
         inner: crate::storage::InMemoryStorage,
@@ -213,8 +217,39 @@ mod tests {
             self.inner.set_trial_attrs(study_id, trial_number, attrs)
         }
 
-        fn get_joint_search_space(&mut self, study_id: u32) -> Result<HashMap<String, Distribution>> {
+        fn get_joint_search_space(
+            &mut self,
+            study_id: u32,
+        ) -> Result<HashMap<String, Distribution>> {
             self.inner.get_joint_search_space(study_id)
+        }
+    }
+
+    #[test]
+    fn create_new_study_updates_cache() {
+        let mut storage = CachedStorage::new(Box::new(DummyBackend::new()));
+        let (study_id, name, directions) = {
+            let study = storage
+                .create_new_study("example", vec![Direction::Minimize])
+                .unwrap();
+            (study.id, study.name.clone(), study.directions.clone())
+        };
+        assert_eq!(name, "example");
+        assert_eq!(directions, vec![Direction::Minimize]);
+        assert_eq!(storage.studies.len(), 1);
+        assert!(storage.trials.get(&study_id).is_some());
+    }
+
+    #[test]
+    fn create_new_study_rejects_duplicate() {
+        let mut storage = CachedStorage::new(Box::new(DummyBackend::new()));
+        storage
+            .create_new_study("example", vec![Direction::Minimize])
+            .unwrap();
+        let res = storage.create_new_study("example", vec![Direction::Minimize]);
+        match res {
+            Err(e) => assert!(matches!(e.kind, ErrorKind::DuplicatedStudy)),
+            Ok(_) => panic!("Expected duplicate study error"),
         }
     }
 }

--- a/rustuna_core/src/storage_cache.rs
+++ b/rustuna_core/src/storage_cache.rs
@@ -94,7 +94,7 @@ impl CachedStorage {
             return Ok(());
         }
 
-        let trials = self.trials.entry(study_id).or_insert_with(HashMap::new);
+        let trials = self.trials.entry(study_id).or_default();
         for trial in loaded {
             trials.insert(trial.number, trial);
         }
@@ -141,7 +141,7 @@ impl crate::storage::Storage for CachedStorage {
 
     fn create_new_trial(&mut self, study_id: u32) -> Result<&PersistedTrial> {
         let trial = self.backend.create_new_trial(study_id)?;
-        let trials = self.trials.entry(study_id).or_insert_with(HashMap::new);
+        let trials = self.trials.entry(study_id).or_default();
         let number = trial.number;
         trials.insert(number, trial);
         let trial_ref = trials.get(&number).unwrap();
@@ -155,7 +155,7 @@ impl crate::storage::Storage for CachedStorage {
         study_cache.update(&trials_vec);
         self.unfinished_trials
             .entry(study_id)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(trial_ref.number);
         Ok(trial_ref)
     }
@@ -172,7 +172,7 @@ impl crate::storage::Storage for CachedStorage {
             .set_trial_param(study_id, trial_number, name, distribution, value)?;
         self.unfinished_trials
             .entry(study_id)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(trial_number);
         self.refresh_trials(study_id)?;
 
@@ -208,7 +208,7 @@ impl crate::storage::Storage for CachedStorage {
 
         self.unfinished_trials
             .entry(study_id)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(trial_number);
         self.refresh_trials(study_id)?;
 
@@ -248,11 +248,7 @@ impl crate::storage::Storage for CachedStorage {
     }
 
     fn get_trials(&mut self, study_id: u32) -> Result<&Vec<PersistedTrial>> {
-        if !self.trials.contains_key(&study_id) {
-            self.refresh_trials(study_id)?;
-        } else {
-            self.refresh_trials(study_id)?;
-        }
+        self.refresh_trials(study_id)?;
         let trials_map = self
             .trials
             .get(&study_id)

--- a/rustuna_core/src/storage_cache.rs
+++ b/rustuna_core/src/storage_cache.rs
@@ -5,7 +5,7 @@ use crate::distribution::Distribution;
 use crate::study::{Direction, PersistedStudy};
 use crate::study_cache::StudyCache;
 use crate::trial::{PersistedTrial, TrialStateValues};
-use crate::Result;
+use crate::{Error, ErrorKind, Result};
 
 pub trait CachedStorageBackend: Send + Sync {
     // Design Note:
@@ -33,10 +33,10 @@ pub trait CachedStorageBackend: Send + Sync {
         trial_number: u32,
         state_values: TrialStateValues,
     ) -> Result<()>;
-    fn get_studies(&self) -> Result<Vec<PersistedStudy>>;
-    fn get_study(&self, study_id: u32) -> Result<PersistedStudy>;
-    fn get_trials(&self, study_id: u32) -> Result<Vec<PersistedTrial>>;
-    fn get_trial(&self, study_id: u32, trial_number: u32) -> Result<PersistedTrial>;
+    fn get_studies(&mut self) -> Result<Vec<PersistedStudy>>;
+    fn get_study(&mut self, study_id: u32) -> Result<PersistedStudy>;
+    fn get_trials(&mut self, study_id: u32) -> Result<Vec<PersistedTrial>>;
+    fn get_trial(&mut self, study_id: u32, trial_number: u32) -> Result<PersistedTrial>;
     fn set_study_attrs(&mut self, study_id: u32, attrs: Attrs) -> Result<()>;
     fn set_trial_attrs(&mut self, study_id: u32, trial_number: u32, attrs: Attrs) -> Result<()>;
     fn get_joint_search_space(&mut self, study_id: u32) -> Result<HashMap<String, Distribution>>;
@@ -109,11 +109,15 @@ impl crate::storage::Storage for CachedStorage {
         todo!()
     }
 
-    fn get_studies(&self) -> Result<&Vec<PersistedStudy>> {
+    fn get_studies(&mut self) -> Result<&Vec<PersistedStudy>> {
+        let loaded = self.backend.get_studies()?;
+        self.studies = loaded;
         Ok(&self.studies)
     }
 
-    fn get_study(&self, study_id: u32) -> Result<&PersistedStudy> {
+    fn get_study(&mut self, study_id: u32) -> Result<&PersistedStudy> {
+        let loaded = self.backend.get_studies()?;
+        self.studies = loaded;
         let study = self
             .studies
             .iter()
@@ -122,12 +126,25 @@ impl crate::storage::Storage for CachedStorage {
         Ok(study)
     }
 
-    fn get_trials(&self, study_id: u32) -> Result<&Vec<PersistedTrial>> {
-        todo!()
+    fn get_trials(&mut self, study_id: u32) -> Result<&Vec<PersistedTrial>> {
+        if !self.trials.contains_key(&study_id) {
+            let loaded = self.backend.get_trials(study_id)?;
+            self.trials.insert(study_id, loaded);
+        }
+        self.trials
+            .get(&study_id)
+            .ok_or_else(|| Error::new(ErrorKind::StudyNotFound))
     }
 
-    fn get_trial(&self, study_id: u32, trial_number: u32) -> Result<&PersistedTrial> {
-        todo!()
+    fn get_trial(&mut self, study_id: u32, trial_number: u32) -> Result<&PersistedTrial> {
+        let trials = self
+            .trials
+            .get(&study_id)
+            .ok_or_else(|| Error::new(ErrorKind::StudyNotFound))?;
+        let trial = trials
+            .get(trial_number as usize)
+            .ok_or_else(|| Error::new(ErrorKind::TrialNotFound))?;
+        Ok(trial)
     }
 
     fn set_study_attrs(&mut self, study_id: u32, attrs: Attrs) -> Result<()> {
@@ -198,19 +215,19 @@ mod tests {
                 .set_trial_state_values(study_id, trial_number, state_values)
         }
 
-        fn get_studies(&self) -> Result<Vec<PersistedStudy>> {
+        fn get_studies(&mut self) -> Result<Vec<PersistedStudy>> {
             Ok(self.inner.get_studies()?.clone())
         }
 
-        fn get_study(&self, study_id: u32) -> Result<PersistedStudy> {
+        fn get_study(&mut self, study_id: u32) -> Result<PersistedStudy> {
             Ok(self.inner.get_study(study_id)?.clone())
         }
 
-        fn get_trials(&self, study_id: u32) -> Result<Vec<PersistedTrial>> {
+        fn get_trials(&mut self, study_id: u32) -> Result<Vec<PersistedTrial>> {
             Ok(self.inner.get_trials(study_id)?.clone())
         }
 
-        fn get_trial(&self, study_id: u32, trial_number: u32) -> Result<PersistedTrial> {
+        fn get_trial(&mut self, study_id: u32, trial_number: u32) -> Result<PersistedTrial> {
             Ok(self.inner.get_trial(study_id, trial_number)?.clone())
         }
 
@@ -295,5 +312,60 @@ mod tests {
         assert_eq!(t1_num, 1);
         let trials = storage.trials.get(&study).unwrap();
         assert_eq!(trials.len(), 2);
+    }
+
+    #[test]
+    fn get_trials_and_get_trial_return_cached_refs() {
+        let mut storage = CachedStorage::new(Box::new(DummyBackend::new()));
+        let study_id = storage
+            .create_new_study("s", vec![Direction::Minimize])
+            .unwrap()
+            .id;
+        storage.create_new_trial(study_id).unwrap();
+        storage.create_new_trial(study_id).unwrap();
+
+        let trials = storage.get_trials(study_id).unwrap();
+        assert_eq!(trials.len(), 2);
+        let t0 = storage.get_trial(study_id, 0).unwrap();
+        assert_eq!(t0.number, 0);
+        let t1 = storage.get_trial(study_id, 1).unwrap();
+        assert_eq!(t1.number, 1);
+    }
+
+    #[test]
+    fn get_trials_loads_from_backend_when_empty() {
+        let mut storage = CachedStorage::new(Box::new(DummyBackend::new()));
+        let study_id = storage
+            .create_new_study("s", vec![Direction::Minimize])
+            .unwrap()
+            .id;
+        storage.create_new_trial(study_id).unwrap();
+
+        storage.trials.clear();
+        let trials = storage.get_trials(study_id).unwrap();
+        assert_eq!(trials.len(), 1);
+    }
+
+    #[test]
+    fn get_studies_refreshes_from_backend_every_time() {
+        let mut backend = DummyBackend::new();
+        let study = backend
+            .create_new_study("s", vec![Direction::Minimize])
+            .unwrap();
+        let mut storage = CachedStorage::new(Box::new(backend));
+
+        // First load
+        let studies = storage.get_studies().unwrap();
+        assert_eq!(studies.len(), 1);
+
+        // Add another study directly to backend and ensure get_studies reflects it.
+        let _ = storage
+            .backend
+            .create_new_study("s2", vec![Direction::Maximize])
+            .unwrap();
+        let studies = storage.get_studies().unwrap();
+        assert_eq!(studies.len(), 2);
+        assert!(studies.iter().any(|s| s.name == study.name));
+        assert!(studies.iter().any(|s| s.name == "s2"));
     }
 }

--- a/rustuna_core/src/storage_cache.rs
+++ b/rustuna_core/src/storage_cache.rs
@@ -37,6 +37,14 @@ pub trait CachedStorageBackend: Send + Sync {
     fn get_study(&mut self, study_id: u32) -> Result<PersistedStudy>;
     fn get_trials(&mut self, study_id: u32) -> Result<Vec<PersistedTrial>>;
     fn get_trial(&mut self, study_id: u32, trial_number: u32) -> Result<PersistedTrial>;
+    // Return trials that need refreshing: unfinished trials in `included_numbers`
+    // and trials with trial_number greater than `trial_number_greater_than`.
+    fn get_trials_diff(
+        &mut self,
+        study_id: u32,
+        included_numbers: &[u32],
+        trial_number_greater_than: i32,
+    ) -> Result<Vec<PersistedTrial>>;
     fn set_study_attrs(&mut self, study_id: u32, attrs: Attrs) -> Result<()>;
     fn set_trial_attrs(&mut self, study_id: u32, trial_number: u32, attrs: Attrs) -> Result<()>;
     fn get_joint_search_space(&mut self, study_id: u32) -> Result<HashMap<String, Distribution>>;
@@ -44,8 +52,12 @@ pub trait CachedStorageBackend: Send + Sync {
 
 pub struct CachedStorage {
     studies: Vec<PersistedStudy>,
-    trials: HashMap<u32, Vec<PersistedTrial>>,
+    trials: HashMap<u32, HashMap<u32, PersistedTrial>>,
     study_caches: HashMap<u32, StudyCache>,
+    unfinished_trials: HashMap<u32, Vec<u32>>,
+    // Track last finished trial number to load diffs from backend (mirrors Optuna's cached storage).
+    last_finished_trial_number: HashMap<u32, i32>,
+    trials_sorted_buffer: Vec<PersistedTrial>,
 
     backend: Box<dyn CachedStorageBackend>,
 }
@@ -56,9 +68,64 @@ impl CachedStorage {
             studies: Vec::new(),
             trials: HashMap::new(),
             study_caches: HashMap::new(),
+            unfinished_trials: HashMap::new(),
+            last_finished_trial_number: HashMap::new(),
+            trials_sorted_buffer: Vec::new(),
             backend,
         }
     }
+
+    fn refresh_trials(&mut self, study_id: u32) -> Result<()> {
+        let unfinished = self
+            .unfinished_trials
+            .get(&study_id)
+            .cloned()
+            .unwrap_or_default();
+        let last_finished = self
+            .last_finished_trial_number
+            .get(&study_id)
+            .copied()
+            .unwrap_or(-1);
+        let loaded = self
+            .backend
+            .get_trials_diff(study_id, &unfinished, last_finished)?;
+
+        if loaded.is_empty() {
+            return Ok(());
+        }
+
+        let trials = self
+            .trials
+            .entry(study_id)
+            .or_insert_with(HashMap::new);
+        for trial in loaded {
+            trials.insert(trial.number, trial);
+        }
+
+        let study_cache = self
+            .study_caches
+            .entry(study_id)
+            .or_insert_with(StudyCache::new);
+        // Update cache with trials sorted by number.
+        let mut trials_vec: Vec<_> = trials.values().cloned().collect();
+        trials_vec.sort_by_key(|t| t.number);
+        study_cache.update(&trials_vec);
+
+        let mut unfinished_next = vec![];
+        let mut last_finished_next = last_finished;
+        for trial in trials.values() {
+            if trial.is_finished() {
+                last_finished_next = last_finished_next.max(trial.number as i32);
+            } else {
+                unfinished_next.push(trial.number);
+            }
+        }
+        self.unfinished_trials.insert(study_id, unfinished_next);
+        self.last_finished_trial_number
+            .insert(study_id, last_finished_next);
+        Ok(())
+    }
+
 }
 
 impl crate::storage::Storage for CachedStorage {
@@ -70,22 +137,35 @@ impl crate::storage::Storage for CachedStorage {
         let study = self.backend.create_new_study(study_name, directions)?;
         let study_id = study.id;
         self.studies.push(study);
-        self.trials.insert(study_id, vec![]);
+        self.trials.insert(study_id, HashMap::new());
         self.study_caches.insert(study_id, StudyCache::new());
+        self.unfinished_trials.insert(study_id, vec![]);
+        self.last_finished_trial_number.insert(study_id, -1);
         Ok(self.studies.last().unwrap())
     }
 
     fn create_new_trial(&mut self, study_id: u32) -> Result<&PersistedTrial> {
         let trial = self.backend.create_new_trial(study_id)?;
-        let trials = self.trials.entry(study_id).or_insert_with(Vec::new);
-        trials.push(trial);
-        let trial_ref = trials.last().unwrap();
+        let trials = self
+            .trials
+            .entry(study_id)
+            .or_insert_with(HashMap::new);
+        let number = trial.number;
+        trials.insert(number, trial);
+        let trial_ref = trials.get(&number).unwrap();
 
         let study_cache = self
             .study_caches
             .entry(study_id)
             .or_insert_with(StudyCache::new);
-        study_cache.update(trials);
+        let mut trials_vec: Vec<_> = trials.values().cloned().collect();
+        trials_vec.sort_by_key(|t| t.number);
+        study_cache.update(&trials_vec);
+        self
+            .unfinished_trials
+            .entry(study_id)
+            .or_insert_with(Vec::new)
+            .push(trial_ref.number);
         Ok(trial_ref)
     }
 
@@ -128,12 +208,23 @@ impl crate::storage::Storage for CachedStorage {
 
     fn get_trials(&mut self, study_id: u32) -> Result<&Vec<PersistedTrial>> {
         if !self.trials.contains_key(&study_id) {
-            let loaded = self.backend.get_trials(study_id)?;
-            self.trials.insert(study_id, loaded);
+            self.refresh_trials(study_id)?;
+        } else {
+            self.refresh_trials(study_id)?;
         }
-        self.trials
+        let trials_map = self
+            .trials
             .get(&study_id)
-            .ok_or_else(|| Error::new(ErrorKind::StudyNotFound))
+            .ok_or_else(|| Error::new(ErrorKind::StudyNotFound))?;
+        let mut trials_vec: Vec<_> = trials_map.values().cloned().collect();
+        trials_vec.sort_by_key(|t| t.number);
+        self.trials_sorted_buffer.clear();
+        self.trials_sorted_buffer.extend(trials_vec);
+        self.study_caches
+            .entry(study_id)
+            .or_insert_with(StudyCache::new)
+            .update(&self.trials_sorted_buffer);
+        Ok(&self.trials_sorted_buffer)
     }
 
     fn get_trial(&mut self, study_id: u32, trial_number: u32) -> Result<&PersistedTrial> {
@@ -142,7 +233,7 @@ impl crate::storage::Storage for CachedStorage {
             .get(&study_id)
             .ok_or_else(|| Error::new(ErrorKind::StudyNotFound))?;
         let trial = trials
-            .get(trial_number as usize)
+            .get(&trial_number)
             .ok_or_else(|| Error::new(ErrorKind::TrialNotFound))?;
         Ok(trial)
     }
@@ -225,6 +316,22 @@ mod tests {
 
         fn get_trials(&mut self, study_id: u32) -> Result<Vec<PersistedTrial>> {
             Ok(self.inner.get_trials(study_id)?.clone())
+        }
+
+        fn get_trials_diff(
+            &mut self,
+            study_id: u32,
+            included_numbers: &[u32],
+            trial_number_greater_than: i32,
+        ) -> Result<Vec<PersistedTrial>> {
+            let all = self.inner.get_trials(study_id)?.clone();
+            let mut trials = Vec::new();
+            for t in all {
+                if included_numbers.contains(&t.number) || (t.number as i32) > trial_number_greater_than {
+                    trials.push(t);
+                }
+            }
+            Ok(trials)
         }
 
         fn get_trial(&mut self, study_id: u32, trial_number: u32) -> Result<PersistedTrial> {
@@ -367,5 +474,23 @@ mod tests {
         assert_eq!(studies.len(), 2);
         assert!(studies.iter().any(|s| s.name == study.name));
         assert!(studies.iter().any(|s| s.name == "s2"));
+    }
+
+    #[test]
+    fn get_trials_refreshes_when_backend_updates() {
+        let mut backend = DummyBackend::new();
+        let study_id = backend
+            .create_new_study("s", vec![Direction::Minimize])
+            .unwrap()
+            .id;
+        backend.create_new_trial(study_id).unwrap();
+
+        let mut storage = CachedStorage::new(Box::new(backend));
+        let trials1 = storage.get_trials(study_id).unwrap();
+        assert_eq!(trials1.len(), 1);
+
+        let _ = storage.backend.create_new_trial(study_id).unwrap();
+        let trials2 = storage.get_trials(study_id).unwrap();
+        assert_eq!(trials2.len(), 2);
     }
 }

--- a/rustuna_core/src/storage_cache.rs
+++ b/rustuna_core/src/storage_cache.rs
@@ -37,6 +37,10 @@ pub trait CachedStorageBackend: Send + Sync {
     fn get_study(&mut self, study_id: u32) -> Result<PersistedStudy>;
     fn get_trials(&mut self, study_id: u32) -> Result<Vec<PersistedTrial>>;
     fn get_trial(&mut self, study_id: u32, trial_number: u32) -> Result<PersistedTrial>;
+    fn set_study_attrs(&mut self, study_id: u32, attrs: Attrs) -> Result<()>;
+    fn set_trial_attrs(&mut self, study_id: u32, trial_number: u32, attrs: Attrs) -> Result<()>;
+    fn get_joint_search_space(&mut self, study_id: u32) -> Result<HashMap<String, Distribution>>;
+
     // Return trials that need refreshing: unfinished trials in `included_numbers`
     // and trials with trial_number greater than `trial_number_greater_than`.
     fn get_trials_diff(
@@ -45,9 +49,6 @@ pub trait CachedStorageBackend: Send + Sync {
         included_numbers: &[u32],
         trial_number_greater_than: i32,
     ) -> Result<Vec<PersistedTrial>>;
-    fn set_study_attrs(&mut self, study_id: u32, attrs: Attrs) -> Result<()>;
-    fn set_trial_attrs(&mut self, study_id: u32, trial_number: u32, attrs: Attrs) -> Result<()>;
-    fn get_joint_search_space(&mut self, study_id: u32) -> Result<HashMap<String, Distribution>>;
 }
 
 pub struct CachedStorage {
@@ -205,7 +206,6 @@ impl crate::storage::Storage for CachedStorage {
         self.backend
             .set_trial_state_values(study_id, trial_number, state_values.clone())?;
 
-        // Ensure trial is tracked as unfinished until refreshed.
         self.unfinished_trials
             .entry(study_id)
             .or_insert_with(Vec::new)
@@ -311,7 +311,18 @@ impl crate::storage::Storage for CachedStorage {
     }
 
     fn get_joint_search_space(&mut self, study_id: u32) -> Result<HashMap<String, Distribution>> {
-        todo!()
+        let trials_vec = {
+            let trials = self.get_trials(study_id)?;
+            let mut v = trials.clone();
+            v.sort_by_key(|t| t.number);
+            v
+        };
+        let cache = self
+            .study_caches
+            .entry(study_id)
+            .or_insert_with(StudyCache::new);
+        cache.update(&trials_vec);
+        Ok(cache.get_joint_search_space())
     }
 }
 
@@ -574,6 +585,32 @@ mod tests {
             .unwrap();
         let trial = storage.get_trial(study_id, 0).unwrap();
         assert!(matches!(trial.state_values, TrialStateValues::Complete(_)));
+    }
+
+    #[test]
+    fn get_joint_search_space_uses_cache_update() {
+        let mut storage = CachedStorage::new(Box::new(DummyBackend::new()));
+        let study_id = storage
+            .create_new_study("s", vec![Direction::Minimize])
+            .unwrap()
+            .id;
+
+        let dist = Distribution::Float {
+            low: 0.0,
+            high: 1.0,
+            step: None,
+            log: false,
+        };
+        storage.create_new_trial(study_id).unwrap();
+        storage
+            .set_trial_param(study_id, 0, "x", &dist, 0.5)
+            .unwrap();
+        storage
+            .set_trial_state_values(study_id, 0, TrialStateValues::Complete(vec![0.0]))
+            .unwrap();
+
+        let search_space = storage.get_joint_search_space(study_id).unwrap();
+        assert!(search_space.contains_key("x"));
     }
 
     #[test]

--- a/rustuna_core/src/storage_cache.rs
+++ b/rustuna_core/src/storage_cache.rs
@@ -37,11 +37,6 @@ pub trait CachedStorageBackend: Send + Sync {
     fn get_study(&self, study_id: u32) -> Result<PersistedStudy>;
     fn get_trials(&self, study_id: u32) -> Result<Vec<PersistedTrial>>;
     fn get_trial(&self, study_id: u32, trial_number: u32) -> Result<PersistedTrial>;
-    // Design Note:
-    // Unlike the storage APIs in Optuna, the `set_study_attrs` and `set_trial_attrs` methods
-    // are designed to receive multiple attributes for bulk insert operations.
-    // Furthermore, the `user_attrs` and `system_attrs` are merged into a single HashMap,
-    // which simplifies the implementation process for third-party storages.
     fn set_study_attrs(&mut self, study_id: u32, attrs: Attrs) -> Result<()>;
     fn set_trial_attrs(&mut self, study_id: u32, trial_number: u32, attrs: Attrs) -> Result<()>;
     fn get_joint_search_space(&mut self, study_id: u32) -> Result<HashMap<String, Distribution>>;
@@ -81,7 +76,17 @@ impl crate::storage::Storage for CachedStorage {
     }
 
     fn create_new_trial(&mut self, study_id: u32) -> Result<&PersistedTrial> {
-        todo!()
+        let trial = self.backend.create_new_trial(study_id)?;
+        let trials = self.trials.entry(study_id).or_insert_with(Vec::new);
+        trials.push(trial);
+        let trial_ref = trials.last().unwrap();
+
+        let study_cache = self
+            .study_caches
+            .entry(study_id)
+            .or_insert_with(StudyCache::new);
+        study_cache.update(trials);
+        Ok(trial_ref)
     }
 
     fn set_trial_param(
@@ -275,5 +280,20 @@ mod tests {
         assert_eq!(s1.name, "s1");
         let s2 = storage.get_study(1).unwrap();
         assert_eq!(s2.name, "s2");
+    }
+
+    #[test]
+    fn create_new_trial_appends_cache() {
+        let mut storage = CachedStorage::new(Box::new(DummyBackend::new()));
+        let study = storage
+            .create_new_study("s", vec![Direction::Minimize])
+            .unwrap()
+            .id;
+        let t0_num = storage.create_new_trial(study).unwrap().number;
+        let t1_num = storage.create_new_trial(study).unwrap().number;
+        assert_eq!(t0_num, 0);
+        assert_eq!(t1_num, 1);
+        let trials = storage.trials.get(&study).unwrap();
+        assert_eq!(trials.len(), 2);
     }
 }

--- a/rustuna_core/src/storage_cache.rs
+++ b/rustuna_core/src/storage_cache.rs
@@ -35,11 +35,9 @@ pub trait CachedStorageBackend: Send + Sync {
     ) -> Result<()>;
     fn get_studies(&mut self) -> Result<Vec<PersistedStudy>>;
     fn get_study(&mut self, study_id: u32) -> Result<PersistedStudy>;
-    fn get_trials(&mut self, study_id: u32) -> Result<Vec<PersistedTrial>>;
     fn get_trial(&mut self, study_id: u32, trial_number: u32) -> Result<PersistedTrial>;
     fn set_study_attrs(&mut self, study_id: u32, attrs: Attrs) -> Result<()>;
     fn set_trial_attrs(&mut self, study_id: u32, trial_number: u32, attrs: Attrs) -> Result<()>;
-    fn get_joint_search_space(&mut self, study_id: u32) -> Result<HashMap<String, Distribution>>;
 
     // Return trials that need refreshing: unfinished trials in `included_numbers`
     // and trials with trial_number greater than `trial_number_greater_than`.
@@ -386,10 +384,6 @@ mod tests {
             Ok(self.inner.get_study(study_id)?.clone())
         }
 
-        fn get_trials(&mut self, study_id: u32) -> Result<Vec<PersistedTrial>> {
-            Ok(self.inner.get_trials(study_id)?.clone())
-        }
-
         fn get_trials_diff(
             &mut self,
             study_id: u32,
@@ -423,13 +417,6 @@ mod tests {
             attrs: Attrs,
         ) -> Result<()> {
             self.inner.set_trial_attrs(study_id, trial_number, attrs)
-        }
-
-        fn get_joint_search_space(
-            &mut self,
-            study_id: u32,
-        ) -> Result<HashMap<String, Distribution>> {
-            self.inner.get_joint_search_space(study_id)
         }
     }
 

--- a/rustuna_core/src/storage_cache.rs
+++ b/rustuna_core/src/storage_cache.rs
@@ -55,7 +55,6 @@ pub struct CachedStorage {
     trials: HashMap<u32, HashMap<u32, PersistedTrial>>,
     study_caches: HashMap<u32, StudyCache>,
     unfinished_trials: HashMap<u32, Vec<u32>>,
-    // Track last finished trial number to load diffs from backend (mirrors Optuna's cached storage).
     last_finished_trial_number: HashMap<u32, i32>,
     trials_sorted_buffer: Vec<PersistedTrial>,
 
@@ -94,10 +93,7 @@ impl CachedStorage {
             return Ok(());
         }
 
-        let trials = self
-            .trials
-            .entry(study_id)
-            .or_insert_with(HashMap::new);
+        let trials = self.trials.entry(study_id).or_insert_with(HashMap::new);
         for trial in loaded {
             trials.insert(trial.number, trial);
         }
@@ -106,7 +102,6 @@ impl CachedStorage {
             .study_caches
             .entry(study_id)
             .or_insert_with(StudyCache::new);
-        // Update cache with trials sorted by number.
         let mut trials_vec: Vec<_> = trials.values().cloned().collect();
         trials_vec.sort_by_key(|t| t.number);
         study_cache.update(&trials_vec);
@@ -125,7 +120,6 @@ impl CachedStorage {
             .insert(study_id, last_finished_next);
         Ok(())
     }
-
 }
 
 impl crate::storage::Storage for CachedStorage {
@@ -146,10 +140,7 @@ impl crate::storage::Storage for CachedStorage {
 
     fn create_new_trial(&mut self, study_id: u32) -> Result<&PersistedTrial> {
         let trial = self.backend.create_new_trial(study_id)?;
-        let trials = self
-            .trials
-            .entry(study_id)
-            .or_insert_with(HashMap::new);
+        let trials = self.trials.entry(study_id).or_insert_with(HashMap::new);
         let number = trial.number;
         trials.insert(number, trial);
         let trial_ref = trials.get(&number).unwrap();
@@ -161,8 +152,7 @@ impl crate::storage::Storage for CachedStorage {
         let mut trials_vec: Vec<_> = trials.values().cloned().collect();
         trials_vec.sort_by_key(|t| t.number);
         study_cache.update(&trials_vec);
-        self
-            .unfinished_trials
+        self.unfinished_trials
             .entry(study_id)
             .or_insert_with(Vec::new)
             .push(trial_ref.number);
@@ -239,11 +229,34 @@ impl crate::storage::Storage for CachedStorage {
     }
 
     fn set_study_attrs(&mut self, study_id: u32, attrs: Attrs) -> Result<()> {
-        todo!()
+        self.backend.set_study_attrs(study_id, attrs.clone())?;
+        self.studies = self.backend.get_studies()?;
+        let study = self
+            .studies
+            .iter_mut()
+            .find(|s| s.id == study_id)
+            .ok_or_else(|| Error::new(ErrorKind::StudyNotFound))?;
+        for (k, v) in attrs {
+            study.attrs.insert(k, v);
+        }
+        Ok(())
     }
 
     fn set_trial_attrs(&mut self, study_id: u32, trial_number: u32, attrs: Attrs) -> Result<()> {
-        todo!()
+        self.backend
+            .set_trial_attrs(study_id, trial_number, attrs.clone())?;
+        self.refresh_trials(study_id)?;
+        let trials = self
+            .trials
+            .get_mut(&study_id)
+            .ok_or_else(|| Error::new(ErrorKind::StudyNotFound))?;
+        let trial = trials
+            .get_mut(&trial_number)
+            .ok_or_else(|| Error::new(ErrorKind::TrialNotFound))?;
+        for (k, v) in attrs {
+            trial.attrs.insert(k, v);
+        }
+        Ok(())
     }
 
     fn get_joint_search_space(&mut self, study_id: u32) -> Result<HashMap<String, Distribution>> {
@@ -254,6 +267,7 @@ impl crate::storage::Storage for CachedStorage {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::attr::AttrKey;
     use crate::storage::Storage;
     use crate::ErrorKind;
 
@@ -327,7 +341,9 @@ mod tests {
             let all = self.inner.get_trials(study_id)?.clone();
             let mut trials = Vec::new();
             for t in all {
-                if included_numbers.contains(&t.number) || (t.number as i32) > trial_number_greater_than {
+                if included_numbers.contains(&t.number)
+                    || (t.number as i32) > trial_number_greater_than
+                {
                     trials.push(t);
                 }
             }
@@ -461,11 +477,9 @@ mod tests {
             .unwrap();
         let mut storage = CachedStorage::new(Box::new(backend));
 
-        // First load
         let studies = storage.get_studies().unwrap();
         assert_eq!(studies.len(), 1);
 
-        // Add another study directly to backend and ensure get_studies reflects it.
         let _ = storage
             .backend
             .create_new_study("s2", vec![Direction::Maximize])
@@ -492,5 +506,36 @@ mod tests {
         let _ = storage.backend.create_new_trial(study_id).unwrap();
         let trials2 = storage.get_trials(study_id).unwrap();
         assert_eq!(trials2.len(), 2);
+    }
+
+    #[test]
+    fn set_study_and_trial_attrs_update_cache() {
+        let mut storage = CachedStorage::new(Box::new(DummyBackend::new()));
+        let study_id = storage
+            .create_new_study("s", vec![Direction::Minimize])
+            .unwrap()
+            .id;
+        storage.create_new_trial(study_id).unwrap();
+
+        let mut s_attrs = Attrs::new();
+        s_attrs.insert(AttrKey::User("foo".to_string()), "bar".to_string());
+        storage.set_study_attrs(study_id, s_attrs).unwrap();
+        let study = storage.get_study(study_id).unwrap();
+        assert_eq!(
+            study.attrs.get(&AttrKey::User("foo".to_string())).unwrap(),
+            "bar"
+        );
+
+        let mut t_attrs = Attrs::new();
+        t_attrs.insert(AttrKey::System("key".to_string()), "val".to_string());
+        storage.set_trial_attrs(study_id, 0, t_attrs).unwrap();
+        let trial = storage.get_trial(study_id, 0).unwrap();
+        assert_eq!(
+            trial
+                .attrs
+                .get(&AttrKey::System("key".to_string()))
+                .unwrap(),
+            "val"
+        );
     }
 }

--- a/rustuna_core/src/storage_cache.rs
+++ b/rustuna_core/src/storage_cache.rs
@@ -202,7 +202,32 @@ impl crate::storage::Storage for CachedStorage {
         trial_number: u32,
         state_values: TrialStateValues,
     ) -> Result<()> {
-        todo!()
+        self.backend
+            .set_trial_state_values(study_id, trial_number, state_values.clone())?;
+
+        // Ensure trial is tracked as unfinished until refreshed.
+        self.unfinished_trials
+            .entry(study_id)
+            .or_insert_with(Vec::new)
+            .push(trial_number);
+        self.refresh_trials(study_id)?;
+
+        let trials = self
+            .trials
+            .get_mut(&study_id)
+            .ok_or_else(|| Error::new(ErrorKind::StudyNotFound))?;
+        let trial = trials
+            .get_mut(&trial_number)
+            .ok_or_else(|| Error::new(ErrorKind::TrialNotFound))?;
+        trial.state_values = state_values;
+
+        let mut trials_vec: Vec<_> = trials.values().cloned().collect();
+        trials_vec.sort_by_key(|t| t.number);
+        self.study_caches
+            .entry(study_id)
+            .or_insert_with(StudyCache::new)
+            .update(&trials_vec);
+        Ok(())
     }
 
     fn get_studies(&mut self) -> Result<&Vec<PersistedStudy>> {
@@ -532,6 +557,23 @@ mod tests {
         let _ = storage.backend.create_new_trial(study_id).unwrap();
         let trials2 = storage.get_trials(study_id).unwrap();
         assert_eq!(trials2.len(), 2);
+    }
+
+    #[test]
+    fn set_trial_state_values_updates_cache() {
+        let mut backend = DummyBackend::new();
+        let study_id = backend
+            .create_new_study("s", vec![Direction::Minimize])
+            .unwrap()
+            .id;
+        backend.create_new_trial(study_id).unwrap();
+
+        let mut storage = CachedStorage::new(Box::new(backend));
+        storage
+            .set_trial_state_values(study_id, 0, TrialStateValues::Complete(vec![1.0]))
+            .unwrap();
+        let trial = storage.get_trial(study_id, 0).unwrap();
+        assert!(matches!(trial.state_values, TrialStateValues::Complete(_)));
     }
 
     #[test]

--- a/rustuna_core/src/storage_cache.rs
+++ b/rustuna_core/src/storage_cache.rs
@@ -105,11 +105,16 @@ impl crate::storage::Storage for CachedStorage {
     }
 
     fn get_studies(&self) -> Result<&Vec<PersistedStudy>> {
-        todo!()
+        Ok(&self.studies)
     }
 
     fn get_study(&self, study_id: u32) -> Result<&PersistedStudy> {
-        todo!()
+        let study = self
+            .studies
+            .iter()
+            .find(|s| s.id == study_id)
+            .ok_or_else(|| crate::Error::new(crate::ErrorKind::StudyNotFound))?;
+        Ok(study)
     }
 
     fn get_trials(&self, study_id: u32) -> Result<&Vec<PersistedTrial>> {
@@ -251,5 +256,24 @@ mod tests {
             Err(e) => assert!(matches!(e.kind, ErrorKind::DuplicatedStudy)),
             Ok(_) => panic!("Expected duplicate study error"),
         }
+    }
+
+    #[test]
+    fn get_study_and_get_studies_use_cache() {
+        let mut storage = CachedStorage::new(Box::new(DummyBackend::new()));
+        storage
+            .create_new_study("s1", vec![Direction::Minimize])
+            .unwrap();
+        storage
+            .create_new_study("s2", vec![Direction::Maximize])
+            .unwrap();
+
+        let all = storage.get_studies().unwrap();
+        assert_eq!(all.len(), 2);
+
+        let s1 = storage.get_study(0).unwrap();
+        assert_eq!(s1.name, "s1");
+        let s2 = storage.get_study(1).unwrap();
+        assert_eq!(s2.name, "s2");
     }
 }

--- a/rustuna_core/src/storage_cache.rs
+++ b/rustuna_core/src/storage_cache.rs
@@ -167,7 +167,33 @@ impl crate::storage::Storage for CachedStorage {
         distribution: &Distribution,
         value: f64,
     ) -> Result<()> {
-        todo!()
+        self.backend
+            .set_trial_param(study_id, trial_number, name, distribution, value)?;
+        self.unfinished_trials
+            .entry(study_id)
+            .or_insert_with(Vec::new)
+            .push(trial_number);
+        self.refresh_trials(study_id)?;
+
+        let trials = self
+            .trials
+            .get_mut(&study_id)
+            .ok_or_else(|| Error::new(ErrorKind::StudyNotFound))?;
+        let trial = trials
+            .get_mut(&trial_number)
+            .ok_or_else(|| Error::new(ErrorKind::TrialNotFound))?;
+        trial
+            .distributions
+            .insert(name.to_string(), distribution.clone());
+        trial.internal_params.insert(name.to_string(), value);
+
+        let mut trials_vec: Vec<_> = trials.values().cloned().collect();
+        trials_vec.sort_by_key(|t| t.number);
+        self.study_caches
+            .entry(study_id)
+            .or_insert_with(StudyCache::new)
+            .update(&trials_vec);
+        Ok(())
     }
 
     fn set_trial_state_values(
@@ -536,6 +562,39 @@ mod tests {
                 .get(&AttrKey::System("key".to_string()))
                 .unwrap(),
             "val"
+        );
+    }
+
+    #[test]
+    fn set_trial_param_updates_cache_and_refreshes() {
+        let mut backend = DummyBackend::new();
+        let study_id = backend
+            .create_new_study("s", vec![Direction::Minimize])
+            .unwrap()
+            .id;
+        backend.create_new_trial(study_id).unwrap();
+
+        let mut storage = CachedStorage::new(Box::new(backend));
+        let dist = Distribution::Float {
+            low: 0.0,
+            high: 1.0,
+            step: None,
+            log: false,
+        };
+        storage
+            .set_trial_param(study_id, 0, "x", &dist, 0.5)
+            .unwrap();
+
+        let trial = storage.get_trial(study_id, 0).unwrap();
+        assert_eq!(trial.internal_params.get("x"), Some(&0.5));
+        assert_eq!(
+            trial.distributions.get("x"),
+            Some(&Distribution::Float {
+                low: 0.0,
+                high: 1.0,
+                step: None,
+                log: false
+            })
         );
     }
 }

--- a/rustuna_core/src/study.rs
+++ b/rustuna_core/src/study.rs
@@ -64,8 +64,8 @@ impl Study {
     }
 
     pub fn from_id(id: u32, storage: Arc<RwLock<dyn Storage>>) -> Result<Self> {
-        let guard = storage
-            .read()
+        let mut guard = storage
+            .write()
             .map_err(|_| Error::new(ErrorKind::Unexpected))?;
         let study = guard.get_study(id)?;
         let name = study.name.clone();
@@ -75,8 +75,8 @@ impl Study {
     }
 
     pub fn from_name(name: String, storage: Arc<RwLock<dyn Storage>>) -> Result<Self> {
-        let guard = storage
-            .read()
+        let mut guard = storage
+            .write()
             .map_err(|_| Error::new(ErrorKind::Unexpected))?;
         let studies = guard.get_studies()?;
         let study = studies
@@ -181,15 +181,15 @@ impl Study {
     }
 
     pub fn get_trials(&self) -> Result<Vec<PersistedTrial>> {
-        let guard = self.storage.read().unwrap();
+        let mut guard = self.storage.write().unwrap();
         let trials = guard.get_trials(self.id)?;
         Ok(trials.clone())
     }
 
     pub fn get_user_attr(&self, key: String) -> Result<Option<String>> {
-        let guard = self
+        let mut guard = self
             .storage
-            .read()
+            .write()
             .map_err(|_| Error::new(ErrorKind::Unexpected))?;
         let study = guard.get_study(self.id)?;
 
@@ -254,7 +254,7 @@ impl PersistedStudy {
 }
 
 pub fn get_best_trial(study: &Study) -> Result<u32> {
-    let guard = study.storage.read().unwrap();
+    let mut guard = study.storage.write().unwrap();
     let trials = guard.get_trials(study.id)?;
 
     let best_trial = trials
@@ -283,7 +283,7 @@ pub fn get_best_trial(study: &Study) -> Result<u32> {
 
 // TODO(HideakiImamura): Support the faster algorithm for `len(directions) == 2`.
 pub fn get_pareto_front(study: &Study) -> Result<Vec<u32>> {
-    let guard = study.storage.read().unwrap();
+    let mut guard = study.storage.write().unwrap();
     let trials = guard
         .get_trials(study.id)?
         .iter()

--- a/rustuna_importance/src/fanova.rs
+++ b/rustuna_importance/src/fanova.rs
@@ -5,9 +5,9 @@ use rustuna_core::trial::{PersistedTrial, TrialStateValues};
 use rustuna_core::{Error, ErrorKind, Result};
 
 pub fn get_param_importance(study: &Study) -> Result<Vec<Vec<f64>>> {
-    let guard = study
+    let mut guard = study
         .storage
-        .read()
+        .write()
         .map_err(|_e| Error::new(ErrorKind::Unexpected))?;
     // TODO(c-bata): Avoid to clone trials.
     let completed_trials: Vec<PersistedTrial> = guard

--- a/rustuna_js/src/study.rs
+++ b/rustuna_js/src/study.rs
@@ -40,17 +40,22 @@ impl JsStudy {
     #[wasm_bindgen(getter)]
     pub fn best_trial(&mut self) -> JsResult<JsPersistedTrial> {
         let number = get_best_trial(&self.0).map_err(|e| JsError::new(&format!("{:?}", e)))?;
-        let guard =
-            self.0.storage.read().map_err(|e| {
+        let (trials, study_attrs) = {
+            let mut guard = self.0.storage.write().map_err(|e| {
                 JsError::new(&format!("Failed to acquire the storage guard: {:?}", e))
             })?;
-        let trials = guard
-            .get_trials(self.0.id)
-            .map_err(|e| JsError::new(&format!("Failed to get trials: {:?}", e.kind)))?;
-        let study = guard
-            .get_study(self.0.id)
-            .map_err(|e| JsError::new(&format!("Failed to get study: {:?}", e.kind)))?;
-        let trial = JsPersistedTrial::new(trials[number as usize].clone(), study.attrs.clone());
+            let trials = guard
+                .get_trials(self.0.id)
+                .map_err(|e| JsError::new(&format!("Failed to get trials: {:?}", e.kind)))?
+                .clone();
+            let study_attrs = guard
+                .get_study(self.0.id)
+                .map_err(|e| JsError::new(&format!("Failed to get study: {:?}", e.kind)))?
+                .attrs
+                .clone();
+            (trials, study_attrs)
+        };
+        let trial = JsPersistedTrial::new(trials[number as usize].clone(), study_attrs);
         Ok(trial)
     }
 }

--- a/rustuna_pyo3/src/pyobject_storage.rs
+++ b/rustuna_pyo3/src/pyobject_storage.rs
@@ -465,26 +465,26 @@ impl Storage for PyObjectStorage {
         }
     }
 
-    fn get_studies(&self) -> rustuna_core::Result<&Vec<rustuna_core::study::PersistedStudy>> {
+    fn get_studies(&mut self) -> rustuna_core::Result<&Vec<rustuna_core::study::PersistedStudy>> {
         self.cache.get_studies()
     }
 
     fn get_study(
-        &self,
+        &mut self,
         study_id: u32,
     ) -> rustuna_core::Result<&rustuna_core::study::PersistedStudy> {
         self.cache.get_study(study_id)
     }
 
     fn get_trials(
-        &self,
+        &mut self,
         study_id: u32,
     ) -> rustuna_core::Result<&Vec<rustuna_core::trial::PersistedTrial>> {
         self.cache.get_trials(study_id)
     }
 
     fn get_trial(
-        &self,
+        &mut self,
         study_id: u32,
         trial_number: u32,
     ) -> rustuna_core::Result<&rustuna_core::trial::PersistedTrial> {

--- a/rustuna_pyo3/src/sampler.rs
+++ b/rustuna_pyo3/src/sampler.rs
@@ -188,7 +188,7 @@ impl Sampler for PyObjectSampler {
         name: &str,
         distribution: &rustuna_core::distribution::Distribution,
     ) -> rustuna_core::Result<f64> {
-        let guard = storage.read().unwrap();
+        let mut guard = storage.write().unwrap();
         let study = guard.get_study(ctx.study_id)?;
         let study_attrs = study.attrs.clone();
         drop(guard);
@@ -231,7 +231,7 @@ impl Sampler for PyObjectSampler {
         storage: Arc<std::sync::RwLock<dyn Storage>>,
         search_space: &HashMap<String, rustuna_core::distribution::Distribution>,
     ) -> rustuna_core::Result<HashMap<String, f64>> {
-        let guard = storage.read().unwrap();
+        let mut guard = storage.write().unwrap();
         let study = guard.get_study(ctx.study_id)?;
         let study_attrs = study.attrs.clone();
         drop(guard);

--- a/rustuna_pyo3/src/storage.rs
+++ b/rustuna_pyo3/src/storage.rs
@@ -108,9 +108,9 @@ impl PyStorage {
         param_name: String,
         cardinality: usize,
     ) -> PyResult<PyObject> {
-        let guard = self
+        let mut guard = self
             .storage
-            .read()
+            .write()
             .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
         let study = guard.get_study(study_id).map_err(err_to_exceptions)?;
         Python::with_gil(
@@ -159,39 +159,47 @@ impl PyStorage {
         Ok(())
     }
 
-    fn get_studies(&self) -> PyResult<Vec<PyPersistedStudy>> {
-        let guard = self.storage.read().unwrap();
+    fn get_studies(&mut self) -> PyResult<Vec<PyPersistedStudy>> {
+        let mut guard = self.storage.write().unwrap();
         let studies = guard
             .get_studies()
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to get studies: {:?}", e.kind)))?;
         Ok(studies.iter().map(|s| s.clone().into()).collect())
     }
 
-    fn get_study(&self, study_id: u32) -> PyResult<PyPersistedStudy> {
-        let guard = self.storage.read().unwrap();
+    fn get_study(&mut self, study_id: u32) -> PyResult<PyPersistedStudy> {
+        let mut guard = self.storage.write().unwrap();
         let study = guard.get_study(study_id).map_err(err_to_exceptions)?;
         Ok(study.clone().into())
     }
 
-    fn get_trials(&self, study_id: u32) -> PyResult<Vec<PyPersistedTrial>> {
-        let guard = self.storage.read().unwrap();
-        let study = guard.get_study(study_id).map_err(err_to_exceptions)?;
+    fn get_trials(&mut self, study_id: u32) -> PyResult<Vec<PyPersistedTrial>> {
+        let mut guard = self.storage.write().unwrap();
+        let study_attrs = {
+            let study = guard.get_study(study_id).map_err(err_to_exceptions)?;
+            study.attrs.clone()
+        };
         let trials = guard.get_trials(study_id).map_err(err_to_exceptions)?;
         // TODO(c-bata): Filter category_labels attrs and clone them only.
         let py_trials: Vec<PyPersistedTrial> = trials
             .iter()
-            .map(|t| PyPersistedTrial::new(t.clone(), study.attrs.clone()))
+            .map(|t| PyPersistedTrial::new(t.clone(), study_attrs.clone()))
             .collect();
         Ok(py_trials)
     }
 
-    fn get_trial(&self, study_id: u32, trial_number: u32) -> PyResult<PyPersistedTrial> {
-        let guard = self.storage.read().unwrap();
-        let study = guard.get_study(study_id).map_err(err_to_exceptions)?;
+    fn get_trial(&mut self, study_id: u32, trial_number: u32) -> PyResult<PyPersistedTrial> {
+        let mut guard = self.storage.write().unwrap();
         let trial = guard
             .get_trial(study_id, trial_number)
-            .map_err(err_to_exceptions)?;
-        Ok(PyPersistedTrial::new(trial.clone(), study.attrs.clone()))
+            .map_err(err_to_exceptions)?
+            .clone();
+        let study_attrs = guard
+            .get_study(study_id)
+            .map_err(err_to_exceptions)?
+            .attrs
+            .clone();
+        Ok(PyPersistedTrial::new(trial, study_attrs))
     }
 
     fn set_study_system_attrs(&mut self, study_id: u32, attrs: PyObject) -> PyResult<()> {

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -114,7 +114,7 @@ pub fn py_load_study(
         }
     });
     let storage = storage?;
-    let guard = storage.read().unwrap();
+    let mut guard = storage.write().unwrap();
     let (study_id, directions) = guard
         .get_studies()
         .map_err(|e| PyRuntimeError::new_err(format!("Failed to get the studies: {:?}", e.kind)))?
@@ -293,37 +293,43 @@ impl PyStudy {
     }
 
     #[getter]
-    pub fn best_trial(&self) -> PyResult<PyPersistedTrial> {
+    pub fn best_trial(&mut self) -> PyResult<PyPersistedTrial> {
         let trial_number = get_best_trial(&self.study).map_err(|e| {
             PyRuntimeError::new_err(format!("Failed to get the best trial: {:?}", e.kind))
         })?;
 
-        let guard = self.study.storage.read().map_err(|e| {
+        let mut guard = self.study.storage.write().map_err(|e| {
             PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
         })?;
         let trial = guard
             .get_trial(self.study.id, trial_number)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind)))?;
-        let study = guard.get_study(self.study.id).map_err(|e| {
-            PyRuntimeError::new_err(format!("Failed to get the study: {:?}", e.kind))
-        })?;
-        let trial = PyPersistedTrial::new(trial.clone(), study.attrs.clone());
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind)))?
+            .clone();
+        let study_attrs = guard
+            .get_study(self.study.id)
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get the study: {:?}", e.kind)))?
+            .attrs
+            .clone();
+        let trial = PyPersistedTrial::new(trial, study_attrs);
         Ok(trial)
     }
 
     #[getter]
-    pub fn trials(&self) -> PyResult<Vec<PyPersistedTrial>> {
-        let guard = self.study.storage.read().unwrap();
-        let trials = guard
+    pub fn trials(&mut self) -> PyResult<Vec<PyPersistedTrial>> {
+        let mut guard = self.study.storage.write().unwrap();
+        let trials_vec = guard
             .get_trials(self.study.id)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind)))?;
-        let study = guard.get_study(self.study.id).map_err(|e| {
-            PyRuntimeError::new_err(format!("Failed to get the study: {:?}", e.kind))
-        })?;
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind)))?
+            .clone();
+        let study_attrs = guard
+            .get_study(self.study.id)
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get the study: {:?}", e.kind)))?
+            .attrs
+            .clone();
 
-        let trials: Vec<PyPersistedTrial> = trials
+        let trials: Vec<PyPersistedTrial> = trials_vec
             .iter()
-            .map(|t| PyPersistedTrial::new((*t).clone(), study.attrs.clone()))
+            .map(|t| PyPersistedTrial::new(t.clone(), study_attrs.clone()))
             .collect();
         Ok(trials)
     }
@@ -345,20 +351,23 @@ impl PyStudy {
     }
 
     #[getter]
-    pub fn best_trials(&self) -> PyResult<Vec<PyPersistedTrial>> {
-        let guard = self.study.storage.read().unwrap();
-        let trials = guard
+    pub fn best_trials(&mut self) -> PyResult<Vec<PyPersistedTrial>> {
+        let mut guard = self.study.storage.write().unwrap();
+        let trials_vec = guard
             .get_trials(self.study.id)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind)))?;
-        let study = guard.get_study(self.study.id).map_err(|e| {
-            PyRuntimeError::new_err(format!("Failed to get the study: {:?}", e.kind))
-        })?;
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind)))?
+            .clone();
+        let study_attrs = guard
+            .get_study(self.study.id)
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get the study: {:?}", e.kind)))?
+            .attrs
+            .clone();
         let pareto_front_numbers = get_pareto_front(&self.study).map_err(|e| {
             PyRuntimeError::new_err(format!("Failed to get the pareto front: {:?}", e.kind))
         })?;
         let best_trials = pareto_front_numbers
             .iter()
-            .map(|n| PyPersistedTrial::new(trials[*n as usize].clone(), study.attrs.clone()))
+            .map(|n| PyPersistedTrial::new(trials_vec[*n as usize].clone(), study_attrs.clone()))
             .collect();
         Ok(best_trials)
     }

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -352,19 +352,26 @@ impl PyStudy {
 
     #[getter]
     pub fn best_trials(&mut self) -> PyResult<Vec<PyPersistedTrial>> {
-        let mut guard = self.study.storage.write().unwrap();
-        let trials_vec = guard
-            .get_trials(self.study.id)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind)))?
-            .clone();
-        let study_attrs = guard
-            .get_study(self.study.id)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get the study: {:?}", e.kind)))?
-            .attrs
-            .clone();
         let pareto_front_numbers = get_pareto_front(&self.study).map_err(|e| {
             PyRuntimeError::new_err(format!("Failed to get the pareto front: {:?}", e.kind))
         })?;
+        let (trials_vec, study_attrs) = {
+            let mut guard = self.study.storage.write().unwrap();
+            let trials_vec = guard
+                .get_trials(self.study.id)
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind))
+                })?
+                .clone();
+            let study_attrs = guard
+                .get_study(self.study.id)
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to get the study: {:?}", e.kind))
+                })?
+                .attrs
+                .clone();
+            (trials_vec, study_attrs)
+        };
         let best_trials = pareto_front_numbers
             .iter()
             .map(|n| PyPersistedTrial::new(trials_vec[*n as usize].clone(), study_attrs.clone()))

--- a/rustuna_samplers/src/nsgaii.rs
+++ b/rustuna_samplers/src/nsgaii.rs
@@ -128,8 +128,8 @@ impl NSGAIISampler {
         population_numbers: Vec<u32>,
         search_space: &HashMap<String, Distribution>,
     ) -> Result<(HashMap<String, f64>, HashMap<String, f64>)> {
-        let guard = storage
-            .read()
+        let mut guard = storage
+            .write()
             .map_err(|_e| Error::new(ErrorKind::Unexpected))?;
         let trials = guard.get_trials(ctx.study_id)?;
         let population_params = trials

--- a/rustuna_samplers/src/tpe.rs
+++ b/rustuna_samplers/src/tpe.rs
@@ -63,8 +63,8 @@ impl Sampler for TpeSampler {
         .map_err(|_e| Error::new(ErrorKind::SamplerError))?;
         let mut optimizer = tpe::TpeOptimizer::new(tpe::parzen_estimator(), tpe_param);
 
-        let guard = storage
-            .read()
+        let mut guard = storage
+            .write()
             .map_err(|_e| Error::new(ErrorKind::Unexpected))?;
         let trials = guard.get_trials(ctx.study_id)?;
         let direction = &ctx.directions[0];


### PR DESCRIPTION
This PR introduces `CachedStorage` with a `CachedStorageBackend` that returns owned values, mirroring Optuna’s cached wrapper so backends can focus on persistence while the wrapper maintains reference-based cache required by Rustuna's Storage.
