### PR TITLE
Add `error_on_overwrite` option in attr-related storage apis

### DIFF
--- a/rustuna_core/src/error.rs
+++ b/rustuna_core/src/error.rs
@@ -18,6 +18,7 @@ pub enum ErrorKind {
     DuplicatedStudy,
     StudyNotFound,
     TrialNotFound,
+    AttrOverwriteNotAllowed,
     InvalidObjectiveValues,
     TrialAlreadyFinished,
     StorageInternalError,

--- a/rustuna_core/src/storage.rs
+++ b/rustuna_core/src/storage.rs
@@ -42,8 +42,21 @@ pub trait Storage: Send + Sync {
     // are designed to receive multiple attributes for bulk insert operations.
     // Furthermore, the `user_attrs` and `system_attrs` are merged into a single HashMap,
     // which simplifies the implementation process for third-party storages.
-    fn set_study_attrs(&mut self, study_id: u32, attrs: Attrs) -> Result<()>;
-    fn set_trial_attrs(&mut self, study_id: u32, trial_number: u32, attrs: Attrs) -> Result<()>;
+    // Note: Some backend implementations (e.g., SQLite) may partially apply attributes across
+    // user/system tables when error_on_overwrite is true.
+    fn set_study_attrs(
+        &mut self,
+        study_id: u32,
+        attrs: Attrs,
+        error_on_overwrite: bool,
+    ) -> Result<()>;
+    fn set_trial_attrs(
+        &mut self,
+        study_id: u32,
+        trial_number: u32,
+        attrs: Attrs,
+        error_on_overwrite: bool,
+    ) -> Result<()>;
     fn get_joint_search_space(&mut self, study_id: u32) -> Result<HashMap<String, Distribution>>;
 }
 
@@ -191,26 +204,43 @@ impl Storage for InMemoryStorage {
         Ok(trial)
     }
 
-    fn set_study_attrs(&mut self, study_id: u32, attrs: Attrs) -> Result<()> {
+    fn set_study_attrs(
+        &mut self,
+        study_id: u32,
+        attrs: Attrs,
+        error_on_overwrite: bool,
+    ) -> Result<()> {
         let study = self
             .studies
             .iter_mut()
             .find(|s| s.id == study_id)
             .ok_or(Error::new(ErrorKind::StudyNotFound))?;
-        attrs.into_iter().for_each(|(key, value)| {
+        for (key, value) in attrs {
+            if error_on_overwrite && study.attrs.contains_key(&key) {
+                return Err(Error::new(ErrorKind::AttrOverwriteNotAllowed));
+            }
             study.attrs.insert(key, value);
-        });
+        }
         Ok(())
     }
 
-    fn set_trial_attrs(&mut self, study_id: u32, trial_number: u32, attrs: Attrs) -> Result<()> {
+    fn set_trial_attrs(
+        &mut self,
+        study_id: u32,
+        trial_number: u32,
+        attrs: Attrs,
+        error_on_overwrite: bool,
+    ) -> Result<()> {
         let trial = get_mut_trials_by_study_id(&mut self.trials, study_id)?
             .get_mut(trial_number as usize)
             .ok_or(Error::new(ErrorKind::TrialNotFound))?;
         check_trial_is_updatable(trial)?;
-        attrs.into_iter().for_each(|(key, value)| {
+        for (key, value) in attrs {
+            if error_on_overwrite && trial.attrs.contains_key(&key) {
+                return Err(Error::new(ErrorKind::AttrOverwriteNotAllowed));
+            }
             trial.attrs.insert(key, value);
-        });
+        }
         Ok(())
     }
 

--- a/rustuna_core/src/study.rs
+++ b/rustuna_core/src/study.rs
@@ -209,7 +209,7 @@ impl Study {
         for (key, value) in attrs {
             a.insert(AttrKey::User(key), value);
         }
-        guard.set_study_attrs(self.id, a)?;
+        guard.set_study_attrs(self.id, a, false)?;
         Ok(())
     }
 }

--- a/rustuna_core/src/trial.rs
+++ b/rustuna_core/src/trial.rs
@@ -126,7 +126,7 @@ impl Trial {
         let mut guard = storage
             .write()
             .map_err(|_| Error::new(ErrorKind::Unexpected))?;
-        guard.set_study_attrs(study_id, category_labels)?;
+        guard.set_study_attrs(study_id, category_labels, false)?;
         Ok(c)
     }
 
@@ -157,7 +157,7 @@ impl Trial {
 
         let key = AttrKey::User(key.to_string());
         attrs.insert(key.clone(), value.clone());
-        guard.set_trial_attrs(self.study_id, self.number, attrs)?;
+        guard.set_trial_attrs(self.study_id, self.number, attrs, false)?;
         self.cached_trial.attrs.insert(key, value);
         Ok(())
     }
@@ -226,7 +226,7 @@ mod tests {
         let mut guard = storage.write().unwrap();
         let mut attrs = Attrs::new();
         attrs.insert(AttrKey::System("key".to_string()), "system".to_string());
-        guard.set_trial_attrs(study.id, 0, attrs).unwrap();
+        guard.set_trial_attrs(study.id, 0, attrs, false).unwrap();
 
         // Check the attributes
         let trial = guard.get_trial(study.id, 0).unwrap();

--- a/rustuna_pyo3/src/pyobject_storage.rs
+++ b/rustuna_pyo3/src/pyobject_storage.rs
@@ -52,7 +52,7 @@ impl PyObjectStorage {
         }?;
         if sync_attrs {
             self.cache
-                .set_study_attrs(cache_study_id, src_study.attrs.clone())?;
+                .set_study_attrs(cache_study_id, src_study.attrs.clone(), false)?;
         }
         Ok(())
     }
@@ -247,7 +247,7 @@ impl PyObjectStorage {
                         rustuna_core::Error::new(rustuna_core::ErrorKind::StorageError)
                     })?;
                     self.cache
-                        .set_study_attrs(cache_study_id, src_study.attrs)?;
+                        .set_study_attrs(cache_study_id, src_study.attrs, false)?;
                 }
                 Ok(())
             }
@@ -305,7 +305,7 @@ impl PyObjectStorage {
         };
         let cache_trial = cache_trial.clone();
         self.cache
-            .set_trial_attrs(cache_study_id, cache_trial.number, src_trial.attrs)?;
+            .set_trial_attrs(cache_study_id, cache_trial.number, src_trial.attrs, false)?;
 
         for (name, distribution) in src_trial.distributions {
             let internal_repr =
@@ -509,10 +509,12 @@ impl Storage for PyObjectStorage {
         &mut self,
         study_id: u32,
         attrs: rustuna_core::attr::Attrs,
+        _error_on_overwrite: bool,
     ) -> rustuna_core::Result<()> {
+        // TODO(c-bata): Emit warnings if error_on_overwrite is true, since Optuna storage cannot support it.
         self.obj_set_study_attrs(study_id, attrs.clone())
             .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::StorageError))?;
-        match self.cache.set_study_attrs(study_id, attrs) {
+        match self.cache.set_study_attrs(study_id, attrs, false) {
             Ok(_) => Ok(()),
             Err(e) => match e.kind {
                 rustuna_core::ErrorKind::StudyNotFound => {
@@ -529,10 +531,15 @@ impl Storage for PyObjectStorage {
         study_id: u32,
         trial_number: u32,
         attrs: rustuna_core::attr::Attrs,
+        _error_on_overwrite: bool,
     ) -> rustuna_core::Result<()> {
+        // TODO(c-bata): Emit warnings if error_on_overwrite is true, since Optuna storage cannot support it.
         self.obj_set_trial_attrs(study_id, trial_number, attrs.clone())
             .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::StorageError))?;
-        match self.cache.set_trial_attrs(study_id, trial_number, attrs) {
+        match self
+            .cache
+            .set_trial_attrs(study_id, trial_number, attrs, false)
+        {
             Ok(_) => Ok(()),
             Err(e) => match e.kind {
                 rustuna_core::ErrorKind::StudyNotFound | rustuna_core::ErrorKind::TrialNotFound => {

--- a/rustuna_pyo3/src/storage.rs
+++ b/rustuna_pyo3/src/storage.rs
@@ -91,7 +91,10 @@ impl PyStorage {
         distribution: PyDistribution,
         value: f64,
     ) -> PyResult<()> {
-        let mut guard = self.storage.write().unwrap();
+        let mut guard = self
+            .storage
+            .write()
+            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
         let distribution: Distribution = distribution.into();
         guard
             .set_trial_param(study_id, trial_number, &name, &distribution, value)
@@ -105,7 +108,6 @@ impl PyStorage {
         param_name: String,
         choices: Vec<PyObject>,
     ) -> PyResult<()> {
-        // TODO(c-bata): Add validation to detect changes of the choices.
         let category_labels = Python::with_gil(|py| {
             let mut labels: Vec<CategoryLabel> = Vec::with_capacity(choices.len());
             for choice in choices {
@@ -121,10 +123,26 @@ impl PyStorage {
             .storage
             .write()
             .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
-        guard
-            .set_study_attrs(study_id, attrs)
-            .map_err(err_to_exceptions)?;
-        Ok(())
+        match guard.set_study_attrs(study_id, attrs, true) {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                if matches!(e.kind, rustuna_core::ErrorKind::AttrOverwriteNotAllowed) {
+                    let study = guard.get_study(study_id).map_err(err_to_exceptions)?;
+                    let existing_labels =
+                        get_category_labels(&study.attrs, &param_name, category_labels.len());
+                    if let Some(existing) = existing_labels {
+                        if existing == category_labels {
+                            return Ok(());
+                        }
+                    }
+                    return Err(PyValueError::new_err(format!(
+                        "Cannot overwrite category labels for parameter '{}'",
+                        param_name
+                    )));
+                }
+                Err(err_to_exceptions(e))
+            }
+        }
     }
 
     fn get_category_labels(
@@ -234,7 +252,7 @@ impl PyStorage {
         })?;
         let mut guard = self.storage.write().unwrap();
         guard
-            .set_study_attrs(study_id, system_attrs)
+            .set_study_attrs(study_id, system_attrs, false)
             .map_err(err_to_exceptions)?;
         Ok(())
     }
@@ -246,7 +264,7 @@ impl PyStorage {
         })?;
         let mut guard = self.storage.write().unwrap();
         guard
-            .set_study_attrs(study_id, user_attrs)
+            .set_study_attrs(study_id, user_attrs, false)
             .map_err(err_to_exceptions)?;
         Ok(())
     }
@@ -263,7 +281,7 @@ impl PyStorage {
         })?;
         let mut guard = self.storage.write().unwrap();
         guard
-            .set_trial_attrs(study_id, trial_number, system_attrs)
+            .set_trial_attrs(study_id, trial_number, system_attrs, false)
             .map_err(err_to_exceptions)?;
         Ok(())
     }
@@ -280,7 +298,7 @@ impl PyStorage {
         })?;
         let mut guard = self.storage.write().unwrap();
         guard
-            .set_trial_attrs(study_id, trial_number, user_attrs)
+            .set_trial_attrs(study_id, trial_number, user_attrs, false)
             .map_err(err_to_exceptions)?;
         Ok(())
     }

--- a/rustuna_samplers/src/nsgaii.rs
+++ b/rustuna_samplers/src/nsgaii.rs
@@ -229,7 +229,7 @@ impl Sampler for NSGAIISampler {
             AttrKey::System("generation".to_string()),
             (child_generation as f64).to_string(),
         );
-        guard.set_trial_attrs(ctx.study_id, ctx.trial_number, attrs)?;
+        guard.set_trial_attrs(ctx.study_id, ctx.trial_number, attrs, false)?;
         drop(guard);
 
         if parent_generation < 0 {

--- a/rustuna_storages/src/cache.rs
+++ b/rustuna_storages/src/cache.rs
@@ -37,8 +37,19 @@ pub trait CachedStorageBackend: Send + Sync {
     fn get_studies(&mut self) -> Result<Vec<PersistedStudy>>;
     fn get_study(&mut self, study_id: u32) -> Result<PersistedStudy>;
     fn get_trial(&mut self, study_id: u32, trial_number: u32) -> Result<PersistedTrial>;
-    fn set_study_attrs(&mut self, study_id: u32, attrs: Attrs) -> Result<()>;
-    fn set_trial_attrs(&mut self, study_id: u32, trial_number: u32, attrs: Attrs) -> Result<()>;
+    fn set_study_attrs(
+        &mut self,
+        study_id: u32,
+        attrs: Attrs,
+        error_on_overwrite: bool,
+    ) -> Result<()>;
+    fn set_trial_attrs(
+        &mut self,
+        study_id: u32,
+        trial_number: u32,
+        attrs: Attrs,
+        error_on_overwrite: bool,
+    ) -> Result<()>;
 
     // Return trials that need refreshing: unfinished trials in `included_numbers`
     // and trials with trial_number greater than `trial_number_greater_than`.
@@ -280,8 +291,14 @@ impl rustuna_core::storage::Storage for CachedStorage {
         Ok(trial)
     }
 
-    fn set_study_attrs(&mut self, study_id: u32, attrs: Attrs) -> Result<()> {
-        self.backend.set_study_attrs(study_id, attrs.clone())?;
+    fn set_study_attrs(
+        &mut self,
+        study_id: u32,
+        attrs: Attrs,
+        error_on_overwrite: bool,
+    ) -> Result<()> {
+        self.backend
+            .set_study_attrs(study_id, attrs.clone(), error_on_overwrite)?;
         self.studies = self.backend.get_studies()?;
         let study = self
             .studies
@@ -294,9 +311,15 @@ impl rustuna_core::storage::Storage for CachedStorage {
         Ok(())
     }
 
-    fn set_trial_attrs(&mut self, study_id: u32, trial_number: u32, attrs: Attrs) -> Result<()> {
+    fn set_trial_attrs(
+        &mut self,
+        study_id: u32,
+        trial_number: u32,
+        attrs: Attrs,
+        error_on_overwrite: bool,
+    ) -> Result<()> {
         self.backend
-            .set_trial_attrs(study_id, trial_number, attrs.clone())?;
+            .set_trial_attrs(study_id, trial_number, attrs.clone(), error_on_overwrite)?;
         self.refresh_trials(study_id)?;
         let trials = self
             .trials
@@ -415,8 +438,14 @@ mod tests {
             Ok(self.inner.get_trial(study_id, trial_number)?.clone())
         }
 
-        fn set_study_attrs(&mut self, study_id: u32, attrs: Attrs) -> Result<()> {
-            self.inner.set_study_attrs(study_id, attrs)
+        fn set_study_attrs(
+            &mut self,
+            study_id: u32,
+            attrs: Attrs,
+            error_on_overwrite: bool,
+        ) -> Result<()> {
+            self.inner
+                .set_study_attrs(study_id, attrs, error_on_overwrite)
         }
 
         fn set_trial_attrs(
@@ -424,8 +453,10 @@ mod tests {
             study_id: u32,
             trial_number: u32,
             attrs: Attrs,
+            error_on_overwrite: bool,
         ) -> Result<()> {
-            self.inner.set_trial_attrs(study_id, trial_number, attrs)
+            self.inner
+                .set_trial_attrs(study_id, trial_number, attrs, error_on_overwrite)
         }
     }
 
@@ -608,7 +639,7 @@ mod tests {
 
         let mut s_attrs = Attrs::new();
         s_attrs.insert(AttrKey::User("foo".to_string()), "bar".to_string());
-        storage.set_study_attrs(study_id, s_attrs)?;
+        storage.set_study_attrs(study_id, s_attrs, false)?;
         let study = storage.get_study(study_id)?;
         assert_eq!(
             study.attrs.get(&AttrKey::User("foo".to_string())).unwrap(),
@@ -617,7 +648,7 @@ mod tests {
 
         let mut t_attrs = Attrs::new();
         t_attrs.insert(AttrKey::System("key".to_string()), "val".to_string());
-        storage.set_trial_attrs(study_id, 0, t_attrs)?;
+        storage.set_trial_attrs(study_id, 0, t_attrs, false)?;
         let trial = storage.get_trial(study_id, 0)?;
         assert_eq!(
             trial

--- a/rustuna_storages/src/sqlite3.rs
+++ b/rustuna_storages/src/sqlite3.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 
 use crate::cache::CachedStorageBackend;
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection, Error as RusqliteError, OptionalExtension};
 use rustuna_core::attr::{AttrKey, Attrs, CategoryLabel};
 use rustuna_core::distribution::Distribution;
 use rustuna_core::study::{Direction, PersistedStudy};
@@ -427,6 +427,7 @@ impl CachedStorageBackend for SQLite3Storage {
         &mut self,
         study_id: u32,
         attrs: rustuna_core::attr::Attrs,
+        error_on_overwrite: bool,
     ) -> rustuna_core::Result<()> {
         self.validate_study_id(study_id)?;
 
@@ -439,26 +440,42 @@ impl CachedStorageBackend for SQLite3Storage {
             }
         }
 
-        let guard = self.conn.lock().unwrap();
+        let mut guard = self.conn.lock().unwrap();
+        let tx = guard
+            .transaction()
+            .map_err(|_e| Error::new(ErrorKind::StorageError))?;
+
         if !user_attrs.is_empty() {
             let placeholders = user_attrs
                 .iter()
                 .map(|_| "(?, ?, ?)")
                 .collect::<Vec<_>>()
                 .join(", ");
-            let sql = format!(
-                "INSERT INTO study_user_attributes (study_id, key, value_json) VALUES {placeholders} \
+            let sql = if error_on_overwrite {
+                format!(
+                    "INSERT INTO study_user_attributes (study_id, key, value_json) VALUES {placeholders}"
+                )
+            } else {
+                format!(
+                    "INSERT INTO study_user_attributes (study_id, key, value_json) VALUES {placeholders} \
                  ON CONFLICT(study_id, key) DO UPDATE SET value_json=excluded.value_json"
-            );
+                )
+            };
             let mut params: Vec<&dyn rusqlite::ToSql> = Vec::new();
             for (key, value) in &user_attrs {
                 params.push(&study_id);
                 params.push(key);
                 params.push(value);
             }
-            guard
-                .execute(&sql, params.as_slice())
-                .map_err(|_e| Error::new(ErrorKind::StorageError))?;
+            let res = tx.execute(&sql, params.as_slice());
+            if let Err(RusqliteError::SqliteFailure(_, _)) = res {
+                if error_on_overwrite {
+                    return Err(Error::new(ErrorKind::AttrOverwriteNotAllowed));
+                }
+                return Err(Error::new(ErrorKind::StorageError));
+            } else if res.is_err() {
+                return Err(Error::new(ErrorKind::StorageError));
+            }
         }
 
         if !system_attrs.is_empty() {
@@ -467,21 +484,35 @@ impl CachedStorageBackend for SQLite3Storage {
                 .map(|_| "(?, ?, ?)")
                 .collect::<Vec<_>>()
                 .join(", ");
-            let sql = format!(
-                "INSERT INTO study_system_attributes (study_id, key, value_json) VALUES {placeholders} \
+            let sql = if error_on_overwrite {
+                format!(
+                    "INSERT INTO study_system_attributes (study_id, key, value_json) VALUES {placeholders}"
+                )
+            } else {
+                format!(
+                    "INSERT INTO study_system_attributes (study_id, key, value_json) VALUES {placeholders} \
                  ON CONFLICT(study_id, key) DO UPDATE SET value_json=excluded.value_json"
-            );
+                )
+            };
             let mut params: Vec<&dyn rusqlite::ToSql> = Vec::new();
             for (key, value) in &system_attrs {
                 params.push(&study_id);
                 params.push(key);
                 params.push(value);
             }
-            guard
-                .execute(&sql, params.as_slice())
-                .map_err(|_e| Error::new(ErrorKind::StorageError))?;
+            let res = tx.execute(&sql, params.as_slice());
+            if let Err(RusqliteError::SqliteFailure(_, _)) = res {
+                if error_on_overwrite {
+                    return Err(Error::new(ErrorKind::AttrOverwriteNotAllowed));
+                }
+                return Err(Error::new(ErrorKind::StorageError));
+            } else if res.is_err() {
+                return Err(Error::new(ErrorKind::StorageError));
+            }
         }
 
+        tx.commit()
+            .map_err(|_e| Error::new(ErrorKind::StorageError))?;
         Ok(())
     }
 
@@ -490,6 +521,7 @@ impl CachedStorageBackend for SQLite3Storage {
         study_id: u32,
         trial_number: u32,
         attrs: rustuna_core::attr::Attrs,
+        error_on_overwrite: bool,
     ) -> rustuna_core::Result<()> {
         let mut user_attrs = Vec::new();
         let mut system_attrs = Vec::new();
@@ -500,7 +532,7 @@ impl CachedStorageBackend for SQLite3Storage {
             }
         }
 
-        let guard = self.conn.lock().unwrap();
+        let mut guard = self.conn.lock().unwrap();
         let trial_id: Option<u32> = guard
             .query_row(
                 "SELECT trial_id FROM trials WHERE study_id = ? AND number = ?",
@@ -511,25 +543,41 @@ impl CachedStorageBackend for SQLite3Storage {
             .map_err(|_e| Error::new(ErrorKind::StorageError))?;
         let trial_id = trial_id.ok_or(Error::new(ErrorKind::TrialNotFound))?;
 
+        let tx = guard
+            .transaction()
+            .map_err(|_e| Error::new(ErrorKind::StorageError))?;
+
         if !user_attrs.is_empty() {
             let placeholders = user_attrs
                 .iter()
                 .map(|_| "(?, ?, ?)")
                 .collect::<Vec<_>>()
                 .join(", ");
-            let sql = format!(
-                "INSERT INTO trial_user_attributes (trial_id, key, value_json) VALUES {placeholders} \
+            let sql = if error_on_overwrite {
+                format!(
+                    "INSERT INTO trial_user_attributes (trial_id, key, value_json) VALUES {placeholders}"
+                )
+            } else {
+                format!(
+                    "INSERT INTO trial_user_attributes (trial_id, key, value_json) VALUES {placeholders} \
                  ON CONFLICT(trial_id, key) DO UPDATE SET value_json=excluded.value_json"
-            );
+                )
+            };
             let mut params: Vec<&dyn rusqlite::ToSql> = Vec::new();
             for (key, value) in &user_attrs {
                 params.push(&trial_id);
                 params.push(key);
                 params.push(value);
             }
-            guard
-                .execute(&sql, params.as_slice())
-                .map_err(|_e| Error::new(ErrorKind::StorageError))?;
+            let res = tx.execute(&sql, params.as_slice());
+            if let Err(RusqliteError::SqliteFailure(_, _)) = res {
+                if error_on_overwrite {
+                    return Err(Error::new(ErrorKind::AttrOverwriteNotAllowed));
+                }
+                return Err(Error::new(ErrorKind::StorageError));
+            } else if res.is_err() {
+                return Err(Error::new(ErrorKind::StorageError));
+            }
         }
 
         if !system_attrs.is_empty() {
@@ -538,21 +586,35 @@ impl CachedStorageBackend for SQLite3Storage {
                 .map(|_| "(?, ?, ?)")
                 .collect::<Vec<_>>()
                 .join(", ");
-            let sql = format!(
-                "INSERT INTO trial_system_attributes (trial_id, key, value_json) VALUES {placeholders} \
+            let sql = if error_on_overwrite {
+                format!(
+                    "INSERT INTO trial_system_attributes (trial_id, key, value_json) VALUES {placeholders}"
+                )
+            } else {
+                format!(
+                    "INSERT INTO trial_system_attributes (trial_id, key, value_json) VALUES {placeholders} \
                  ON CONFLICT(trial_id, key) DO UPDATE SET value_json=excluded.value_json"
-            );
+                )
+            };
             let mut params: Vec<&dyn rusqlite::ToSql> = Vec::new();
             for (key, value) in &system_attrs {
                 params.push(&trial_id);
                 params.push(key);
                 params.push(value);
             }
-            guard
-                .execute(&sql, params.as_slice())
-                .map_err(|_e| Error::new(ErrorKind::StorageError))?;
+            let res = tx.execute(&sql, params.as_slice());
+            if let Err(RusqliteError::SqliteFailure(_, _)) = res {
+                if error_on_overwrite {
+                    return Err(Error::new(ErrorKind::AttrOverwriteNotAllowed));
+                }
+                return Err(Error::new(ErrorKind::StorageError));
+            } else if res.is_err() {
+                return Err(Error::new(ErrorKind::StorageError));
+            }
         }
 
+        tx.commit()
+            .map_err(|_e| Error::new(ErrorKind::StorageError))?;
         Ok(())
     }
 
@@ -1089,7 +1151,7 @@ mod tests {
             "system_value".to_string(),
         );
 
-        storage.set_study_attrs(study_id, attrs)?;
+        storage.set_study_attrs(study_id, attrs, false)?;
 
         let study = storage.get_study(study_id)?;
         assert_eq!(study.attrs.len(), 2);
@@ -1101,6 +1163,47 @@ mod tests {
             study.attrs.get(&AttrKey::System("system_key".to_string())),
             Some(&"system_value".to_string())
         );
+        Ok(())
+    }
+
+    #[test]
+    fn set_study_attrs_error_on_overwrite_rollback() -> Result<()> {
+        let mut storage = init_storage()?;
+        let study_id = storage
+            .create_new_study("example", vec![Direction::Minimize])?
+            .id;
+
+        let mut attrs = Attrs::new();
+        attrs.insert(
+            AttrKey::User("user_key".to_string()),
+            "user_value".to_string(),
+        );
+        storage.set_study_attrs(study_id, attrs, false)?;
+
+        let mut overwrite = Attrs::new();
+        overwrite.insert(
+            AttrKey::User("user_key".to_string()),
+            "user_value_overwrite".to_string(),
+        );
+        overwrite.insert(
+            AttrKey::User("another_key".to_string()),
+            "another_value".to_string(),
+        );
+        let err = storage
+            .set_study_attrs(study_id, overwrite, true)
+            .err()
+            .unwrap();
+        assert!(matches!(err.kind, ErrorKind::AttrOverwriteNotAllowed));
+
+        let study = storage.get_study(study_id)?;
+        assert_eq!(
+            study.attrs.get(&AttrKey::User("user_key".to_string())),
+            Some(&"user_value".to_string())
+        );
+        assert!(!study
+            .attrs
+            .contains_key(&AttrKey::User("another_key".to_string())));
+
         Ok(())
     }
 
@@ -1122,7 +1225,7 @@ mod tests {
             "trial_system_value".to_string(),
         );
 
-        storage.set_trial_attrs(study_id, trial.number, attrs)?;
+        storage.set_trial_attrs(study_id, trial.number, attrs, false)?;
 
         let trial = storage.get_trial(study_id, trial.number)?;
         assert_eq!(trial.attrs.len(), 2);
@@ -1138,6 +1241,50 @@ mod tests {
                 .get(&AttrKey::System("trial_system_key".to_string())),
             Some(&"trial_system_value".to_string())
         );
+        Ok(())
+    }
+
+    #[test]
+    fn set_trial_attrs_error_on_overwrite_rollback() -> Result<()> {
+        let mut storage = init_storage()?;
+        let study_id = storage
+            .create_new_study("example", vec![Direction::Minimize])?
+            .id;
+        let trial = storage.create_new_trial(study_id)?;
+
+        let mut attrs = Attrs::new();
+        attrs.insert(
+            AttrKey::User("trial_user_key".to_string()),
+            "trial_user_value".to_string(),
+        );
+        storage.set_trial_attrs(study_id, trial.number, attrs, false)?;
+
+        let mut overwrite = Attrs::new();
+        overwrite.insert(
+            AttrKey::User("trial_user_key".to_string()),
+            "overwritten".to_string(),
+        );
+        overwrite.insert(
+            AttrKey::User("new_user_key".to_string()),
+            "new_value".to_string(),
+        );
+        let err = storage
+            .set_trial_attrs(study_id, trial.number, overwrite, true)
+            .err()
+            .unwrap();
+        assert!(matches!(err.kind, ErrorKind::AttrOverwriteNotAllowed));
+
+        let trial = storage.get_trial(study_id, trial.number)?;
+        assert_eq!(
+            trial
+                .attrs
+                .get(&AttrKey::User("trial_user_key".to_string())),
+            Some(&"trial_user_value".to_string())
+        );
+        assert!(!trial
+            .attrs
+            .contains_key(&AttrKey::User("new_user_key".to_string())));
+
         Ok(())
     }
 


### PR DESCRIPTION
Currently, `CategoricalDistribution`'s choices field is stored in study_system_attrs. For the atomic updates, this PR introduces `error_on_overwrite` option to `set_study_attrs()` and `set_trial_attrs` storage methods.