### PR TITLE
Introduce `OptunaCompatibleStorage` trait and corresponding Python APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,6 +754,7 @@ version = "0.1.0"
 dependencies = [
  "rusqlite",
  "rustuna_core",
+ "serde",
  "serde_json",
  "tempfile",
 ]

--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -1,5 +1,5 @@
 import enum
-from typing import Callable, Literal, Protocol, Sequence, TypedDict
+from typing import Callable, Literal, Protocol, TypedDict
 
 CategoricalChoiceType = float | int | str | bool | None
 DistributionDict = (
@@ -215,54 +215,37 @@ class StorageProtocol(Protocol):
     def set_trial_user_attrs(
         self, study_id: int, trial_number: int, attrs: dict[str, str]
     ) -> None: ...
-
-class Storage:
-    @classmethod
-    def in_memory(cls) -> Storage: ...
-    @classmethod
-    def sqlite3(cls, file_path: str, *, create_database: bool = False) -> Storage: ...
-    def create_new_study(
-        self, study_name: str, directions: list[StudyDirection]
-    ) -> PersistedStudy: ...
-    def create_new_trial(self, study_id: int) -> PersistedTrial: ...
-    def set_trial_param(
-        self,
-        study_id: int,
-        trial_number: int,
-        name: str,
-        distribution: Distribution,
-        value: float,
-    ) -> None: ...
     def set_category_labels(
         self,
         study_id: int,
         param_name: str,
-        labels: list[None | bool | int | float | str],
+        choices: list[CategoricalChoiceType],
     ) -> None: ...
     def get_category_labels(
         self,
         study_id: int,
         param_name: str,
-    ) -> list[None | bool | int | float | str]: ...
-    def set_trial_state_values(
-        self,
-        study_id: int,
-        trial_number: int,
-        state: TrialState,
-        values: None | list[float] = None,
+        cardinality: int,
+    ) -> list[CategoricalChoiceType]: ...
+
+class OptunaStorageProtocol(StorageProtocol, Protocol):
+    def get_study_id_trial_number_from_trial_id(
+        self, trial_id: int
+    ) -> tuple[int, int]: ...
+    def get_trial_id_from_study_id_trial_number(
+        self, study_id: int, trial_number: int
+    ) -> int: ...
+    def set_trial_intermediate_value(
+        self, trial_id: int, step: int, intermediate_value: float
     ) -> None: ...
-    def get_studies(self) -> list[PersistedStudy]: ...
-    def get_study(self, study_id: int) -> PersistedStudy: ...
-    def get_trials(self, study_id: int) -> list[PersistedTrial]: ...
-    def get_trial(self, study_id: int, trial_number: int) -> PersistedTrial: ...
-    def set_study_system_attrs(self, study_id: int, attrs: dict[str, str]) -> None: ...
-    def set_study_user_attrs(self, study_id: int, attrs: dict[str, str]) -> None: ...
-    def set_trial_system_attrs(
-        self, study_id: int, trial_number: int, attrs: dict[str, str]
-    ) -> None: ...
-    def set_trial_user_attrs(
-        self, study_id: int, trial_number: int, attrs: dict[str, str]
-    ) -> None: ...
+
+class Storage:
+    @classmethod
+    def in_memory(cls) -> StorageProtocol: ...
+    @classmethod
+    def sqlite3(
+        cls, file_path: str, *, create_database: bool = False
+    ) -> OptunaStorageProtocol: ...
 
 # Sampler
 class SamplerContext:

--- a/rustuna_pyo3/rustuna/exceptions.py
+++ b/rustuna_pyo3/rustuna/exceptions.py
@@ -4,10 +4,28 @@ class RustunaError(Exception):
     pass
 
 
+class StorageInternalError(RustunaError):
+    """Exception for storage operation.
+
+    This error is raised when an operation failed in backend DB of storage.
+    """
+
+    pass
+
+
 class DuplicatedStudyError(RustunaError):
     """Exception for a duplicated study name.
 
     This error is raised when a specified study name already exists in the storage.
+    """
+
+    pass
+
+
+class UpdateFinishedTrialError(RustunaError, RuntimeError):
+    """Exception for updating a finished trial.
+
+    This error is raised when attempting to update a finished trial.
     """
 
     pass

--- a/rustuna_pyo3/src/distribution.rs
+++ b/rustuna_pyo3/src/distribution.rs
@@ -13,7 +13,7 @@ use rustuna_core::distribution::Distribution;
 #[pyo3(module = "rustuna")]
 pub struct PyDistribution {
     pub distribution: Distribution,
-    category_labels: Option<Vec<CategoryLabel>>,
+    pub category_labels: Option<Vec<CategoryLabel>>,
 }
 impl PyDistribution {
     pub fn new(distribution: Distribution, name: &str, study_attrs: &Attrs) -> PyDistribution {

--- a/rustuna_pyo3/src/exception.rs
+++ b/rustuna_pyo3/src/exception.rs
@@ -1,16 +1,27 @@
-use pyo3::exceptions::{PyKeyError, PyRuntimeError};
+use pyo3::exceptions::{PyKeyError, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 
 mod exceptions {
     pyo3::import_exception!(rustuna.exceptions, DuplicatedStudyError);
+    pyo3::import_exception!(rustuna.exceptions, UpdateFinishedTrialError);
+    pyo3::import_exception!(rustuna.exceptions, StorageInternalError);
 }
 
 pub fn err_to_exceptions(e: rustuna_core::Error) -> PyErr {
     match e.kind {
         rustuna_core::ErrorKind::TrialNotFound => PyKeyError::new_err("Trial not found"),
         rustuna_core::ErrorKind::StudyNotFound => PyKeyError::new_err("Study not found"),
+        rustuna_core::ErrorKind::TrialAlreadyFinished => {
+            exceptions::UpdateFinishedTrialError::new_err("Trial already finished")
+        }
+        rustuna_core::ErrorKind::StorageInternalError => {
+            exceptions::StorageInternalError::new_err("storage internal error")
+        }
         rustuna_core::ErrorKind::DuplicatedStudy => {
             exceptions::DuplicatedStudyError::new_err("Duplicate study name")
+        }
+        rustuna_core::ErrorKind::IncompatibleDistribution => {
+            PyValueError::new_err("Incompatible distribution for the parameter")
         }
         _ => PyRuntimeError::new_err(format!("Storage Errors: {:?}", e.kind)),
     }

--- a/rustuna_pyo3/src/sampler.rs
+++ b/rustuna_pyo3/src/sampler.rs
@@ -197,6 +197,7 @@ impl Sampler for PyObjectSampler {
             let py_ctx = PySamplerContext::from(ctx.clone());
             let py_storage = PyStorage {
                 storage: storage.clone(),
+                optuna_compatible: None,
                 kind: "unset",
             };
             let py_distribution = PyDistribution::new(distribution.clone(), name, &study_attrs);
@@ -240,6 +241,7 @@ impl Sampler for PyObjectSampler {
             let py_ctx = PySamplerContext::from(ctx.clone());
             let py_storage = PyStorage {
                 storage: storage.clone(),
+                optuna_compatible: None,
                 kind: "unset",
             };
             let py_search_space = PyDict::new(py);

--- a/rustuna_pyo3/src/storage.rs
+++ b/rustuna_pyo3/src/storage.rs
@@ -10,6 +10,7 @@ use rustuna_core::storage::{InMemoryStorage, Storage};
 use rustuna_core::study::Direction;
 use rustuna_core::trial::TrialStateValues;
 use rustuna_storages::cache::CachedStorage;
+use rustuna_storages::optuna::OptunaCompatibleStorage;
 use rustuna_storages::sqlite3::SQLite3Storage;
 
 use crate::attrs::{pyobj_to_system_attrs, pyobj_to_user_attrs};
@@ -23,6 +24,7 @@ use crate::trial::{PyPersistedTrial, PyTrialState};
 #[pyo3(module = "rustuna")]
 pub struct PyStorage {
     pub storage: Arc<RwLock<dyn Storage>>,
+    pub optuna_compatible: Option<Arc<RwLock<dyn OptunaCompatibleStorage>>>,
     pub kind: &'static str,
 }
 
@@ -32,6 +34,7 @@ impl PyStorage {
     fn in_memory(_cls: &PyType) -> PyResult<Self> {
         Ok(PyStorage {
             storage: Arc::new(RwLock::new(InMemoryStorage::new())),
+            optuna_compatible: None,
             kind: "in_memory",
         })
     }
@@ -39,16 +42,19 @@ impl PyStorage {
     #[classmethod]
     #[pyo3(name = "sqlite3", signature = (file_path, *, create_database = false))]
     fn sqlite3(_cls: &PyType, file_path: &str, create_database: bool) -> PyResult<Self> {
-        let sqlite3 = SQLite3Storage::new(file_path).map_err(|e| {
+        let backend = SQLite3Storage::new(file_path).map_err(|e| {
             PyRuntimeError::new_err(format!("Failed to open the SQLite3 file: {e:?}"))
         })?;
         if create_database {
-            sqlite3.create_database().map_err(|e| {
+            backend.create_database().map_err(|e| {
                 PyRuntimeError::new_err(format!("Failed to create the database: {e:?}"))
             })?;
         }
+
+        let arc_storage = Arc::new(RwLock::new(CachedStorage::new(Box::new(backend))));
         Ok(PyStorage {
-            storage: Arc::new(RwLock::new(CachedStorage::new(Box::new(sqlite3)))),
+            storage: arc_storage.clone(),
+            optuna_compatible: Some(arc_storage),
             kind: "sqlite3",
         })
     }
@@ -91,11 +97,17 @@ impl PyStorage {
         distribution: PyDistribution,
         value: f64,
     ) -> PyResult<()> {
+        let category_labels = distribution.category_labels.clone();
+        let distribution: Distribution = distribution.into();
+
+        if let Some(labels) = category_labels {
+            self.set_category_labels_internal(study_id, name.clone(), labels)?;
+        }
+
         let mut guard = self
             .storage
             .write()
             .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
-        let distribution: Distribution = distribution.into();
         guard
             .set_trial_param(study_id, trial_number, &name, &distribution, value)
             .map_err(err_to_exceptions)?;
@@ -118,31 +130,7 @@ impl PyStorage {
             }
             Ok(labels)
         })?;
-        let attrs = category_labels_to_attrs(&param_name, &category_labels);
-        let mut guard = self
-            .storage
-            .write()
-            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
-        match guard.set_study_attrs(study_id, attrs, true) {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                if matches!(e.kind, rustuna_core::ErrorKind::AttrOverwriteNotAllowed) {
-                    let study = guard.get_study(study_id).map_err(err_to_exceptions)?;
-                    let existing_labels =
-                        get_category_labels(&study.attrs, &param_name, category_labels.len());
-                    if let Some(existing) = existing_labels {
-                        if existing == category_labels {
-                            return Ok(());
-                        }
-                    }
-                    return Err(PyValueError::new_err(format!(
-                        "Cannot overwrite category labels for parameter '{}'",
-                        param_name
-                    )));
-                }
-                Err(err_to_exceptions(e))
-            }
-        }
+        self.set_category_labels_internal(study_id, param_name, category_labels)
     }
 
     fn get_category_labels(
@@ -301,5 +289,90 @@ impl PyStorage {
             .set_trial_attrs(study_id, trial_number, user_attrs, false)
             .map_err(err_to_exceptions)?;
         Ok(())
+    }
+
+    fn get_trial_id_from_study_id_trial_number(
+        &mut self,
+        study_id: u32,
+        trial_number: u32,
+    ) -> PyResult<u32> {
+        let optuna_storage = self.optuna_compatible.as_ref().ok_or_else(|| {
+            PyRuntimeError::new_err("This storage does not support Optuna-compatible operations")
+        })?;
+        let mut guard = optuna_storage
+            .write()
+            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
+        let trial_id = guard
+            .get_trial_id_from_study_id_trial_number(study_id, trial_number)
+            .map_err(err_to_exceptions)?;
+        Ok(trial_id)
+    }
+
+    fn get_study_id_trial_number_from_trial_id(&mut self, trial_id: u32) -> PyResult<(u32, u32)> {
+        let optuna_storage = self.optuna_compatible.as_ref().ok_or_else(|| {
+            PyRuntimeError::new_err("This storage does not support Optuna-compatible operations")
+        })?;
+        let mut guard = optuna_storage
+            .write()
+            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
+        let (study_id, trial_number) = guard
+            .get_study_id_trial_number_from_trial_id(trial_id)
+            .map_err(err_to_exceptions)?;
+        Ok((study_id, trial_number))
+    }
+
+    fn set_trial_intermediate_value(
+        &mut self,
+        trial_id: u32,
+        step: u32,
+        intermediate_value: f64,
+    ) -> PyResult<()> {
+        let optuna_storage = self.optuna_compatible.as_ref().ok_or_else(|| {
+            PyRuntimeError::new_err("This storage does not support Optuna-compatible operations")
+        })?;
+        let mut guard = optuna_storage
+            .write()
+            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
+        let mut intermediate_values = std::collections::HashMap::new();
+        intermediate_values.insert(step, intermediate_value);
+        guard
+            .set_trial_intermediate_values(trial_id, intermediate_values)
+            .map_err(err_to_exceptions)?;
+        Ok(())
+    }
+}
+
+impl PyStorage {
+    fn set_category_labels_internal(
+        &mut self,
+        study_id: u32,
+        param_name: String,
+        category_labels: Vec<CategoryLabel>,
+    ) -> PyResult<()> {
+        let attrs = category_labels_to_attrs(&param_name, &category_labels);
+        let mut guard = self
+            .storage
+            .write()
+            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
+        match guard.set_study_attrs(study_id, attrs, true) {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                if matches!(e.kind, rustuna_core::ErrorKind::AttrOverwriteNotAllowed) {
+                    let study = guard.get_study(study_id).map_err(err_to_exceptions)?;
+                    let existing_labels =
+                        get_category_labels(&study.attrs, &param_name, category_labels.len());
+                    if let Some(existing) = existing_labels {
+                        if existing == category_labels {
+                            return Ok(());
+                        }
+                    }
+                    return Err(PyValueError::new_err(format!(
+                        "Cannot overwrite category labels for parameter '{}'",
+                        param_name
+                    )));
+                }
+                Err(err_to_exceptions(e))
+            }
+        }
     }
 }

--- a/rustuna_storages/Cargo.toml
+++ b/rustuna_storages/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 [dependencies]
 rustuna_core = { workspace = true }
 rusqlite = "0.37.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [dev-dependencies]

--- a/rustuna_storages/src/cache.rs
+++ b/rustuna_storages/src/cache.rs
@@ -7,6 +7,8 @@ use rustuna_core::study_cache::StudyCache;
 use rustuna_core::trial::{PersistedTrial, TrialStateValues};
 use rustuna_core::{Error, ErrorKind, Result};
 
+use crate::optuna::OptunaCompatibleStorage;
+
 pub trait CachedStorageBackend: Send + Sync {
     // Design Note:
     // This trait is intended for backends that return owned values (not references) so that
@@ -61,6 +63,8 @@ pub trait CachedStorageBackend: Send + Sync {
     ) -> Result<Vec<PersistedTrial>>;
 }
 
+pub trait OptunaCachedStorageBackend: CachedStorageBackend + OptunaCompatibleStorage {}
+
 pub struct CachedStorage {
     studies: Vec<PersistedStudy>,
     trials: HashMap<u32, HashMap<u32, PersistedTrial>>,
@@ -69,11 +73,11 @@ pub struct CachedStorage {
     last_finished_trial_number: HashMap<u32, i32>,
     trials_sorted_buffer: Vec<PersistedTrial>,
 
-    backend: Box<dyn CachedStorageBackend>,
+    backend: Box<dyn OptunaCachedStorageBackend>,
 }
 
 impl CachedStorage {
-    pub fn new(backend: Box<dyn CachedStorageBackend>) -> CachedStorage {
+    pub fn new(backend: Box<dyn OptunaCachedStorageBackend>) -> CachedStorage {
         CachedStorage {
             studies: Vec::new(),
             trials: HashMap::new(),
@@ -184,6 +188,25 @@ impl rustuna_core::storage::Storage for CachedStorage {
         distribution: &Distribution,
         value: f64,
     ) -> Result<()> {
+        self.refresh_trials(study_id)?;
+        if let Some(trials) = self.trials.get(&study_id) {
+            if let Some(trial) = trials.get(&trial_number) {
+                if trial.is_finished() {
+                    return Err(Error::new(ErrorKind::TrialAlreadyFinished));
+                }
+            }
+        }
+
+        if let Some(existing) = self
+            .study_caches
+            .entry(study_id)
+            .or_default()
+            .param_distribution
+            .get(name)
+        {
+            existing.check_compatibility(distribution)?;
+        }
+
         self.backend
             .set_trial_param(study_id, trial_number, name, distribution, value)?;
         self.unfinished_trials
@@ -206,10 +229,11 @@ impl rustuna_core::storage::Storage for CachedStorage {
 
         let mut trials_vec: Vec<_> = trials.values().cloned().collect();
         trials_vec.sort_by_key(|t| t.number);
-        self.study_caches
-            .entry(study_id)
-            .or_default()
-            .update(&trials_vec);
+        let study_cache = self.study_caches.entry(study_id).or_default();
+        study_cache
+            .param_distribution
+            .insert(name.to_string(), distribution.clone());
+        study_cache.update(&trials_vec);
         Ok(())
     }
 
@@ -281,6 +305,7 @@ impl rustuna_core::storage::Storage for CachedStorage {
     }
 
     fn get_trial(&mut self, study_id: u32, trial_number: u32) -> Result<&PersistedTrial> {
+        self.refresh_trials(study_id)?;
         let trials = self
             .trials
             .get(&study_id)
@@ -318,6 +343,19 @@ impl rustuna_core::storage::Storage for CachedStorage {
         attrs: Attrs,
         error_on_overwrite: bool,
     ) -> Result<()> {
+        self.refresh_trials(study_id)?;
+        {
+            let trials = self
+                .trials
+                .get(&study_id)
+                .ok_or_else(|| Error::new(ErrorKind::StudyNotFound))?;
+            let trial = trials
+                .get(&trial_number)
+                .ok_or_else(|| Error::new(ErrorKind::TrialNotFound))?;
+            if trial.is_finished() {
+                return Err(Error::new(ErrorKind::TrialAlreadyFinished));
+            }
+        }
         self.backend
             .set_trial_attrs(study_id, trial_number, attrs.clone(), error_on_overwrite)?;
         self.refresh_trials(study_id)?;
@@ -344,6 +382,35 @@ impl rustuna_core::storage::Storage for CachedStorage {
         let cache = self.study_caches.entry(study_id).or_default();
         cache.update(&trials_vec);
         Ok(cache.get_joint_search_space())
+    }
+}
+
+impl OptunaCompatibleStorage for CachedStorage {
+    fn get_study_id_trial_number_from_trial_id(&mut self, trial_id: u32) -> Result<(u32, u32)> {
+        self.backend
+            .get_study_id_trial_number_from_trial_id(trial_id)
+    }
+
+    fn get_trial_id_from_study_id_trial_number(
+        &mut self,
+        study_id: u32,
+        trial_number: u32,
+    ) -> Result<u32> {
+        self.backend
+            .get_trial_id_from_study_id_trial_number(study_id, trial_number)
+    }
+
+    fn set_trial_intermediate_values(
+        &mut self,
+        trial_id: u32,
+        intermediate_values: HashMap<u32, f64>,
+    ) -> Result<()> {
+        if intermediate_values.is_empty() {
+            return Ok(());
+        }
+        self.backend
+            .set_trial_intermediate_values(trial_id, intermediate_values)?;
+        Ok(())
     }
 }
 
@@ -459,6 +526,31 @@ mod tests {
                 .set_trial_attrs(study_id, trial_number, attrs, error_on_overwrite)
         }
     }
+    impl OptunaCompatibleStorage for DummyBackend {
+        fn get_study_id_trial_number_from_trial_id(
+            &mut self,
+            _trial_id: u32,
+        ) -> Result<(u32, u32)> {
+            todo!()
+        }
+
+        fn get_trial_id_from_study_id_trial_number(
+            &mut self,
+            _study_id: u32,
+            _trial_number: u32,
+        ) -> Result<u32> {
+            todo!()
+        }
+
+        fn set_trial_intermediate_values(
+            &mut self,
+            _trial_id: u32,
+            _intermediate_values: HashMap<u32, f64>,
+        ) -> Result<()> {
+            todo!()
+        }
+    }
+    impl OptunaCachedStorageBackend for DummyBackend {}
 
     #[test]
     fn create_new_study_updates_cache() -> Result<()> {
@@ -470,7 +562,7 @@ mod tests {
         assert_eq!(name, "example");
         assert_eq!(directions, vec![Direction::Minimize]);
         assert_eq!(storage.studies.len(), 1);
-        assert!(storage.trials.get(&study_id).is_some());
+        assert!(storage.trials.contains_key(&study_id));
         Ok(())
     }
 
@@ -686,6 +778,85 @@ mod tests {
                 log: false
             })
         );
+        Ok(())
+    }
+
+    #[test]
+    fn set_trial_param() -> Result<()> {
+        let mut storage = CachedStorage::new(Box::new(DummyBackend::new()));
+
+        // Setup test across multiple studies and trials.
+        let study_id = storage
+            .create_new_study("test1", vec![Direction::Minimize])?
+            .id;
+        storage.create_new_study("test2", vec![Direction::Minimize])?;
+        let trial_1 = storage.create_new_trial(study_id)?;
+        let trial_1_number = trial_1.number;
+        let trial_2 = storage.create_new_trial(study_id)?;
+        let trial_2_number = trial_2.number;
+
+        // Setup distributions
+        let distribution_x = Distribution::Float {
+            low: 1.0,
+            high: 2.0,
+            step: None,
+            log: false,
+        };
+        let distribution_y_1 = Distribution::Categorical { cardinality: 3 };
+        // let distribution_y_2 = Distribution::Categorical { cardinality: 2 };
+        let distribution_z = Distribution::Float {
+            low: 1.0,
+            high: 100.0,
+            step: None,
+            log: true,
+        };
+
+        // Set new params.
+        storage.set_trial_param(study_id, trial_1_number, "x", &distribution_x, 0.5)?;
+        storage.set_trial_param(study_id, trial_1_number, "y", &distribution_y_1, 2.0)?;
+        let trial = storage.get_trial(study_id, trial_1_number)?;
+        assert_eq!(trial.internal_params["x"], 0.5);
+        assert_eq!(trial.internal_params["y"], 2.0);
+
+        // Set params to another trial
+        storage.set_trial_param(study_id, trial_2_number, "x", &distribution_x, 0.3)?;
+        storage.set_trial_param(study_id, trial_2_number, "z", &distribution_z, 0.1)?;
+        let trial = storage.get_trial(study_id, trial_2_number)?;
+        assert_eq!(trial.internal_params["x"], 0.3);
+        assert_eq!(trial.internal_params["z"], 0.1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn set_trial_param_rejects_incompatible_distribution_across_trials() -> Result<()> {
+        let mut storage = CachedStorage::new(Box::new(DummyBackend::new()));
+        let study_id = storage
+            .create_new_study("test", vec![Direction::Minimize])?
+            .id;
+
+        let float_dist = Distribution::Float {
+            low: 0.0,
+            high: 1.0,
+            step: None,
+            log: false,
+        };
+        let int_dist = Distribution::Int {
+            low: 0,
+            high: 5,
+            step: None,
+            log: false,
+        };
+
+        let trial0 = storage.create_new_trial(study_id)?.clone();
+        storage.set_trial_param(study_id, trial0.number, "x", &float_dist, 0.5)?;
+
+        let trial1 = storage.create_new_trial(study_id)?.clone();
+        let err = storage
+            .set_trial_param(study_id, trial1.number, "x", &int_dist, 1.0)
+            .err()
+            .unwrap();
+        assert!(matches!(err.kind, ErrorKind::IncompatibleDistribution));
         Ok(())
     }
 }

--- a/rustuna_storages/src/lib.rs
+++ b/rustuna_storages/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod cache;
+pub mod optuna;
 pub mod sqlite3;

--- a/rustuna_storages/src/optuna.rs
+++ b/rustuna_storages/src/optuna.rs
@@ -1,0 +1,39 @@
+use std::collections::HashMap;
+
+use rustuna_core::Result;
+use serde::{Deserialize, Serialize};
+
+pub trait OptunaCompatibleStorage: Send + Sync {
+    fn get_study_id_trial_number_from_trial_id(&mut self, trial_id: u32) -> Result<(u32, u32)>;
+    fn get_trial_id_from_study_id_trial_number(
+        &mut self,
+        study_id: u32,
+        trial_number: u32,
+    ) -> Result<u32>;
+    fn set_trial_intermediate_values(
+        &mut self,
+        trial_id: u32,
+        intermediate_values: HashMap<u32, f64>,
+    ) -> Result<()>;
+}
+
+/// Intermediate value entry for JSON serialization.
+///
+/// This structure is used to serialize intermediate values with their type information,
+/// preserving special float values (NaN, Infinity, -Infinity) that cannot be represented
+/// in standard JSON format.
+///
+/// # Fields
+/// * `step` - The step number (epoch, iteration, etc.) for this intermediate value
+/// * `value` - The actual f64 value. None for special values (NaN, Infinity, -Infinity)
+/// * `value_type` - Type discriminator. One of:
+///   - "FINITE": Normal floating-point value (value is Some)
+///   - "NAN": Not a Number (value is None)
+///   - "INF_POS": Positive infinity (value is None)
+///   - "INF_NEG": Negative infinity (value is None)
+#[derive(Debug, Serialize, Deserialize)]
+pub struct IntermediateValueEntry {
+    pub step: u32,
+    pub value: Option<f64>,
+    pub value_type: String,
+}

--- a/rustuna_storages/src/sqlite3.rs
+++ b/rustuna_storages/src/sqlite3.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 use std::sync::Mutex;
 
-use crate::cache::CachedStorageBackend;
+use crate::cache::{CachedStorageBackend, OptunaCachedStorageBackend};
+use crate::optuna::{IntermediateValueEntry, OptunaCompatibleStorage};
 use rusqlite::{params, Connection, Error as RusqliteError, OptionalExtension};
 use rustuna_core::attr::{AttrKey, Attrs, CategoryLabel};
 use rustuna_core::distribution::Distribution;
@@ -138,6 +139,7 @@ impl CachedStorageBackend for SQLite3Storage {
         distribution: &rustuna_core::distribution::Distribution,
         value: f64,
     ) -> rustuna_core::Result<()> {
+        // Note: Compatibility between distributions across trials is enforced by CachedStorage.
         let guard = self.conn.lock().unwrap();
         let trial_id: Option<u32> = guard
             .query_row(
@@ -169,15 +171,19 @@ impl CachedStorageBackend for SQLite3Storage {
         state_values: rustuna_core::trial::TrialStateValues,
     ) -> rustuna_core::Result<()> {
         let guard = self.conn.lock().unwrap();
-        let trial_id: Option<u32> = guard
+        let result: Option<(u32, String)> = guard
             .query_row(
-                "SELECT trial_id FROM trials WHERE study_id = ? AND number = ?",
+                "SELECT trial_id, state FROM trials WHERE study_id = ? AND number = ?",
                 params![study_id, trial_number],
-                |row| row.get(0),
+                |row| Ok((row.get(0)?, row.get(1)?)),
             )
             .optional()
             .map_err(|_e| Error::new(ErrorKind::StorageError))?;
-        let trial_id = trial_id.ok_or(Error::new(ErrorKind::TrialNotFound))?;
+        let (trial_id, current_state) = result.ok_or(Error::new(ErrorKind::TrialNotFound))?;
+
+        if matches!(current_state.as_str(), "COMPLETE" | "FAIL" | "PRUNED") {
+            return Err(Error::new(ErrorKind::TrialAlreadyFinished));
+        }
 
         match &state_values {
             TrialStateValues::Complete(values) => {
@@ -414,7 +420,38 @@ impl CachedStorageBackend for SQLite3Storage {
             attrs.insert(AttrKey::System(key), value);
         }
 
-        // TODO(c-bata): Populate intermediate values into system attrs if needed.
+        // Intermediate values
+        let mut stmt = guard
+            .prepare("SELECT step, intermediate_value, intermediate_value_type FROM trial_intermediate_values WHERE trial_id = ? ORDER BY step")
+            .map_err(|_e| Error::new(ErrorKind::StorageError))?;
+        let intermediate_rows = stmt
+            .query_map(params![trial_id], |row| {
+                Ok((
+                    row.get::<_, u32>(0)?,
+                    row.get::<_, Option<f64>>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            })
+            .map_err(|_e| Error::new(ErrorKind::StorageError))?;
+        let mut intermediate_entries = Vec::new();
+        for row in intermediate_rows {
+            let (step, stored_value, value_type) =
+                row.map_err(|_e| Error::new(ErrorKind::StorageError))?;
+            intermediate_entries.push(IntermediateValueEntry {
+                step,
+                value: stored_value,
+                value_type,
+            });
+        }
+        if !intermediate_entries.is_empty() {
+            let intermediate_json = serde_json::to_string(&intermediate_entries)
+                .map_err(|_e| Error::new(ErrorKind::StorageError))?;
+            attrs.insert(
+                AttrKey::System("intermediate_values".to_string()),
+                intermediate_json,
+            );
+        }
+
         let mut trial = PersistedTrial::new(study_id, trial_number);
         trial.state_values = state_values;
         trial.internal_params = internal_params;
@@ -630,11 +667,8 @@ impl CachedStorageBackend for SQLite3Storage {
         let mut sql = String::from("SELECT trial_id, number, state FROM trials WHERE study_id = ?");
         let mut params: Vec<Box<dyn rusqlite::ToSql>> = vec![Box::new(study_id)];
 
-        // Filter by trial_number_greater_than
-        if trial_number_greater_than >= 0 {
-            sql.push_str(" AND number > ?");
-            params.push(Box::new(trial_number_greater_than));
-        }
+        let mut trial_filters = vec!["number > ?".to_string()];
+        params.push(Box::new(trial_number_greater_than));
 
         // Filter by included_numbers if provided
         if !included_numbers.is_empty() {
@@ -643,12 +677,15 @@ impl CachedStorageBackend for SQLite3Storage {
                 .map(|_| "?")
                 .collect::<Vec<_>>()
                 .join(", ");
-            sql.push_str(&format!(" OR number IN ({placeholders})"));
+            trial_filters.push(format!("number IN ({placeholders})"));
             for &num in included_numbers {
                 params.push(Box::new(num));
             }
         }
 
+        sql.push_str(" AND (");
+        sql.push_str(&trial_filters.join(" OR "));
+        sql.push(')');
         sql.push_str(" ORDER BY trial_id");
 
         let mut stmt = guard
@@ -744,6 +781,38 @@ impl CachedStorageBackend for SQLite3Storage {
                 attrs.insert(AttrKey::System(key), value);
             }
 
+            // Intermediate values
+            let mut intermediate_stmt = guard
+                .prepare("SELECT step, intermediate_value, intermediate_value_type FROM trial_intermediate_values WHERE trial_id = ? ORDER BY step")
+                .map_err(|_e| Error::new(ErrorKind::StorageError))?;
+            let intermediate_rows = intermediate_stmt
+                .query_map(params![trial_id], |row| {
+                    Ok((
+                        row.get::<_, u32>(0)?,
+                        row.get::<_, Option<f64>>(1)?,
+                        row.get::<_, String>(2)?,
+                    ))
+                })
+                .map_err(|_e| Error::new(ErrorKind::StorageError))?;
+            let mut intermediate_entries = Vec::new();
+            for row in intermediate_rows {
+                let (step, stored_value, value_type) =
+                    row.map_err(|_e| Error::new(ErrorKind::StorageError))?;
+                intermediate_entries.push(IntermediateValueEntry {
+                    step,
+                    value: stored_value,
+                    value_type,
+                });
+            }
+            if !intermediate_entries.is_empty() {
+                let intermediate_json = serde_json::to_string(&intermediate_entries)
+                    .map_err(|_e| Error::new(ErrorKind::StorageError))?;
+                attrs.insert(
+                    AttrKey::System("intermediate_values".to_string()),
+                    intermediate_json,
+                );
+            }
+
             let mut trial = PersistedTrial::new(study_id, number);
             trial.state_values = state_values;
             trial.internal_params = internal_params;
@@ -829,6 +898,106 @@ impl CachedStorageBackend for SQLite3Storage {
         Ok(())
     }
 }
+
+impl OptunaCompatibleStorage for SQLite3Storage {
+    fn get_study_id_trial_number_from_trial_id(&mut self, trial_id: u32) -> Result<(u32, u32)> {
+        let guard = self.conn.lock().unwrap();
+        let result: Option<(u32, u32)> = guard
+            .query_row(
+                "SELECT study_id, number FROM trials WHERE trial_id = ?",
+                params![trial_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()
+            .map_err(|_e| Error::new(ErrorKind::StorageError))?;
+        result.ok_or_else(|| Error::new(ErrorKind::TrialNotFound))
+    }
+
+    fn get_trial_id_from_study_id_trial_number(
+        &mut self,
+        study_id: u32,
+        trial_number: u32,
+    ) -> Result<u32> {
+        let guard = self.conn.lock().unwrap();
+        let trial_id: Option<u32> = guard
+            .query_row(
+                "SELECT trial_id FROM trials WHERE study_id = ? AND number = ?",
+                params![study_id, trial_number],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|_e| Error::new(ErrorKind::StorageError))?;
+        trial_id.ok_or_else(|| Error::new(ErrorKind::TrialNotFound))
+    }
+
+    fn set_trial_intermediate_values(
+        &mut self,
+        trial_id: u32,
+        intermediate_values: HashMap<u32, f64>,
+    ) -> Result<()> {
+        if intermediate_values.is_empty() {
+            return Ok(());
+        }
+
+        let guard = self.conn.lock().unwrap();
+
+        // TODO(c-bata): Check if Optuna enables PRAGMA foreign_keys and if we can skip this check
+        // Explicitly check trial existence and state since the schema might be created by Optuna
+        let trial_state: Option<String> = guard
+            .query_row(
+                "SELECT state FROM trials WHERE trial_id = ?",
+                params![trial_id],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|_e| Error::new(ErrorKind::StorageError))?;
+
+        let state = trial_state.ok_or_else(|| Error::new(ErrorKind::TrialNotFound))?;
+
+        if matches!(state.as_str(), "COMPLETE" | "FAIL" | "PRUNED") {
+            return Err(Error::new(ErrorKind::TrialAlreadyFinished));
+        }
+
+        let placeholders = intermediate_values
+            .iter()
+            .map(|_| "(?, ?, ?, ?)")
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+        "INSERT INTO trial_intermediate_values (trial_id, step, intermediate_value, intermediate_value_type) VALUES {placeholders} \
+         ON CONFLICT(trial_id, step) DO UPDATE SET intermediate_value=excluded.intermediate_value, intermediate_value_type=excluded.intermediate_value_type"
+    );
+
+        let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+        for (step, value) in &intermediate_values {
+            let (stored_value, value_type) = if value.is_nan() {
+                (None, "NAN")
+            } else if value.is_infinite() {
+                if value.is_sign_positive() {
+                    (None, "INF_POS")
+                } else {
+                    (None, "INF_NEG")
+                }
+            } else {
+                (Some(*value), "FINITE")
+            };
+
+            params.push(Box::new(trial_id));
+            params.push(Box::new(*step));
+            params.push(Box::new(stored_value));
+            params.push(Box::new(value_type.to_string()));
+        }
+
+        let param_refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|p| p.as_ref()).collect();
+        guard
+            .execute(&sql, param_refs.as_slice())
+            .map_err(|_e| Error::new(ErrorKind::StorageError))?;
+
+        Ok(())
+    }
+}
+
+impl OptunaCachedStorageBackend for SQLite3Storage {}
 
 fn distribution_to_json(distribution: &Distribution, labels: Option<&[CategoryLabel]>) -> String {
     let (name, attributes) = match distribution {
@@ -1361,6 +1530,61 @@ mod tests {
     }
 
     #[test]
+    fn get_trials_diff_with_large_trial_number_greater_than() -> Result<()> {
+        let mut storage = init_storage()?;
+        let study_id = storage
+            .create_new_study("example", vec![Direction::Minimize])?
+            .id;
+
+        storage.create_new_trial(study_id)?;
+
+        // trial_number_greater_than is much larger than existing trial numbers
+        let trials = storage.get_trials_diff(study_id, &[], 500000)?;
+        assert_eq!(trials.len(), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    #[ignore = "TODO(c-bata): Add support for large inclusion list"]
+    fn get_trials_diff_with_large_included_numbers() -> Result<()> {
+        let mut storage = init_storage()?;
+        let study_id = storage
+            .create_new_study("example", vec![Direction::Minimize])?
+            .id;
+
+        storage.create_new_trial(study_id)?;
+
+        // A large inclusion list used to raise errors in some implementations.
+        // Check that it is not an issue. See https://github.com/optuna/optuna/issues/1457.
+        let large_numbers: Vec<u32> = (0..500000).collect();
+        let trials = storage.get_trials_diff(study_id, &large_numbers, 500000)?;
+        assert_eq!(trials.len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn get_trials_diff_with_negative_trial_number_greater_than() -> Result<()> {
+        let mut storage = init_storage()?;
+        let study_id = storage
+            .create_new_study("example", vec![Direction::Minimize])?
+            .id;
+
+        storage.create_new_trial(study_id)?;
+
+        // trial_number_greater_than = -1 should return all trials
+        let trials = storage.get_trials_diff(study_id, &[], -1)?;
+        assert_eq!(trials.len(), 1);
+
+        // trial_number_greater_than much larger than existing trials
+        let trials = storage.get_trials_diff(study_id, &[], 500001)?;
+        assert_eq!(trials.len(), 0);
+
+        Ok(())
+    }
+
+    #[test]
     fn run_optimization() -> Result<()> {
         let storage = SQLite3Storage::new(":memory:")?;
         storage.create_database()?;
@@ -1380,6 +1604,135 @@ mod tests {
             100,
         )?;
         assert_eq!(study.get_trials()?.len(), 100);
+        Ok(())
+    }
+
+    #[test]
+    fn set_trial_intermediate_values() -> Result<()> {
+        let mut storage = init_storage()?;
+        let study_id = storage
+            .create_new_study("example", vec![Direction::Minimize])?
+            .id;
+        let trial1 = storage.create_new_trial(study_id)?;
+        let trial2 = storage.create_new_trial(study_id)?;
+        let study_id2 = storage
+            .create_new_study("example2", vec![Direction::Minimize])?
+            .id;
+        let trial3 = storage.create_new_trial(study_id2)?;
+        let trial4 = storage.create_new_trial(study_id)?;
+
+        // Get trial_ids via OptunaCompatibleStorage
+        let trial_id_1 =
+            storage.get_trial_id_from_study_id_trial_number(study_id, trial1.number)?;
+        let trial_id_3 =
+            storage.get_trial_id_from_study_id_trial_number(study_id2, trial3.number)?;
+        let trial_id_4 =
+            storage.get_trial_id_from_study_id_trial_number(study_id, trial4.number)?;
+
+        // Test setting new values
+        let mut values1 = HashMap::new();
+        values1.insert(0, 0.3);
+        values1.insert(2, 0.4);
+        storage.set_trial_intermediate_values(trial_id_1, values1)?;
+
+        let mut values3 = HashMap::new();
+        values3.insert(0, 0.1);
+        values3.insert(1, 0.4);
+        values3.insert(2, 0.5);
+        values3.insert(3, f64::INFINITY);
+        storage.set_trial_intermediate_values(trial_id_3, values3)?;
+
+        let mut values4 = HashMap::new();
+        values4.insert(0, f64::NAN);
+        storage.set_trial_intermediate_values(trial_id_4, values4)?;
+
+        // Verify trial 1
+        let trial1_result = storage.get_trial(study_id, trial1.number)?;
+        let intermediate_json = trial1_result
+            .attrs
+            .get(&AttrKey::System("intermediate_values".to_string()))
+            .unwrap();
+        let intermediate_entries: Vec<IntermediateValueEntry> =
+            serde_json::from_str(intermediate_json).unwrap();
+        assert_eq!(intermediate_entries.len(), 2);
+        assert_eq!(intermediate_entries[0].step, 0);
+        assert_eq!(intermediate_entries[0].value, Some(0.3));
+        assert_eq!(intermediate_entries[0].value_type, "FINITE");
+        assert_eq!(intermediate_entries[1].step, 2);
+        assert_eq!(intermediate_entries[1].value, Some(0.4));
+        assert_eq!(intermediate_entries[1].value_type, "FINITE");
+
+        // Verify trial 2 (no intermediate values)
+        let trial2_result = storage.get_trial(study_id, trial2.number)?;
+        assert!(!trial2_result
+            .attrs
+            .contains_key(&AttrKey::System("intermediate_values".to_string())));
+
+        // Verify trial 3
+        let trial3_result = storage.get_trial(study_id2, trial3.number)?;
+        let intermediate_json = trial3_result
+            .attrs
+            .get(&AttrKey::System("intermediate_values".to_string()))
+            .unwrap();
+        let intermediate_entries: Vec<IntermediateValueEntry> =
+            serde_json::from_str(intermediate_json).unwrap();
+        assert_eq!(intermediate_entries.len(), 4);
+        assert_eq!(intermediate_entries[0].step, 0);
+        assert_eq!(intermediate_entries[0].value, Some(0.1));
+        assert_eq!(intermediate_entries[0].value_type, "FINITE");
+        assert_eq!(intermediate_entries[1].step, 1);
+        assert_eq!(intermediate_entries[1].value, Some(0.4));
+        assert_eq!(intermediate_entries[1].value_type, "FINITE");
+        assert_eq!(intermediate_entries[2].step, 2);
+        assert_eq!(intermediate_entries[2].value, Some(0.5));
+        assert_eq!(intermediate_entries[2].value_type, "FINITE");
+        assert_eq!(intermediate_entries[3].step, 3);
+        assert_eq!(intermediate_entries[3].value, None);
+        assert_eq!(intermediate_entries[3].value_type, "INF_POS");
+
+        // Verify trial 4 (NaN value)
+        let trial4_result = storage.get_trial(study_id, trial4.number)?;
+        let intermediate_json = trial4_result
+            .attrs
+            .get(&AttrKey::System("intermediate_values".to_string()))
+            .unwrap();
+        let intermediate_entries: Vec<IntermediateValueEntry> =
+            serde_json::from_str(intermediate_json).unwrap();
+        assert_eq!(intermediate_entries.len(), 1);
+        assert_eq!(intermediate_entries[0].step, 0);
+        assert_eq!(intermediate_entries[0].value, None);
+        assert_eq!(intermediate_entries[0].value_type, "NAN");
+
+        // Test overwriting existing step
+        let mut values1_update = HashMap::new();
+        values1_update.insert(0, 0.2);
+        storage.set_trial_intermediate_values(trial_id_1, values1_update)?;
+
+        let trial1_updated = storage.get_trial(study_id, trial1.number)?;
+        let intermediate_json = trial1_updated
+            .attrs
+            .get(&AttrKey::System("intermediate_values".to_string()))
+            .unwrap();
+        let intermediate_entries: Vec<IntermediateValueEntry> =
+            serde_json::from_str(intermediate_json).unwrap();
+        assert_eq!(intermediate_entries.len(), 2);
+        assert_eq!(intermediate_entries[0].step, 0);
+        assert_eq!(intermediate_entries[0].value, Some(0.2));
+        assert_eq!(intermediate_entries[0].value_type, "FINITE");
+        assert_eq!(intermediate_entries[1].step, 2);
+        assert_eq!(intermediate_entries[1].value, Some(0.4));
+        assert_eq!(intermediate_entries[1].value_type, "FINITE");
+
+        // Test non-existent trial
+        let non_existent_trial_id = trial_id_4 + 1000;
+        let mut invalid_values = HashMap::new();
+        invalid_values.insert(0, 0.5);
+        let err = storage
+            .set_trial_intermediate_values(non_existent_trial_id, invalid_values)
+            .err()
+            .unwrap();
+        assert!(matches!(err.kind, ErrorKind::TrialNotFound));
+
         Ok(())
     }
 }

--- a/rustuna_storages/src/sqlite3.rs
+++ b/rustuna_storages/src/sqlite3.rs
@@ -1545,24 +1545,24 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    #[ignore = "TODO(c-bata): Add support for large inclusion list"]
-    fn get_trials_diff_with_large_included_numbers() -> Result<()> {
-        let mut storage = init_storage()?;
-        let study_id = storage
-            .create_new_study("example", vec![Direction::Minimize])?
-            .id;
+    // TODO(c-bata): Fix this test case
+    // #[test]
+    // fn get_trials_diff_with_large_included_numbers() -> Result<()> {
+    //     let mut storage = init_storage()?;
+    //     let study_id = storage
+    //         .create_new_study("example", vec![Direction::Minimize])?
+    //         .id;
 
-        storage.create_new_trial(study_id)?;
+    //     storage.create_new_trial(study_id)?;
 
-        // A large inclusion list used to raise errors in some implementations.
-        // Check that it is not an issue. See https://github.com/optuna/optuna/issues/1457.
-        let large_numbers: Vec<u32> = (0..500000).collect();
-        let trials = storage.get_trials_diff(study_id, &large_numbers, 500000)?;
-        assert_eq!(trials.len(), 1);
+    //     // A large inclusion list used to raise errors in some implementations.
+    //     // Check that it is not an issue. See https://github.com/optuna/optuna/issues/1457.
+    //     let large_numbers: Vec<u32> = (0..500000).collect();
+    //     let trials = storage.get_trials_diff(study_id, &large_numbers, 500000)?;
+    //     assert_eq!(trials.len(), 1);
 
-        Ok(())
-    }
+    //     Ok(())
+    // }
 
     #[test]
     fn get_trials_diff_with_negative_trial_number_greater_than() -> Result<()> {

--- a/rustuna_storages/src/sqlite3_schema.sql
+++ b/rustuna_storages/src/sqlite3_schema.sql
@@ -109,3 +109,4 @@ CREATE TABLE IF NOT EXISTS "trial_values" (
 	UNIQUE (trial_id, objective)
 );
 CREATE INDEX trials_study_id_key ON trials (study_id);
+INSERT INTO version_info (version_info_id, schema_version, library_version) VALUES (1, 12, '4.6.0.dev')

--- a/rustuna_storages/tests/sqlite3.rs
+++ b/rustuna_storages/tests/sqlite3.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::Path;
 use std::process::Command;
 
 use rustuna_core::distribution::Distribution;
@@ -8,7 +8,7 @@ use rustuna_core::{Error, ErrorKind, Result};
 use rustuna_storages::cache::{CachedStorage, CachedStorageBackend};
 use rustuna_storages::sqlite3::SQLite3Storage;
 
-fn run_optuna_script(python: &str, db_path: &PathBuf, script: &str) -> Result<()> {
+fn run_optuna_script(python: &str, db_path: &Path, script: &str) -> Result<()> {
     let output = Command::new(python)
         .args(["-c", script, db_path.to_string_lossy().as_ref()])
         .output()


### PR DESCRIPTION
Currently, Rustuna's Storage trait does not support all functionality that Optuna's Storage interface requires. This PR introduces `OptunaCompatibleStorage` trait, so that Rustua's SQLite3Storage can also be used from Optuna.