### PR TITLE
Reduce the copy of study attributes

### DIFF
--- a/rustuna_pyo3/src/storage.rs
+++ b/rustuna_pyo3/src/storage.rs
@@ -209,13 +209,13 @@ impl PyStorage {
         let mut guard = self.storage.write().unwrap();
         let study_attrs = {
             let study = guard.get_study(study_id).map_err(err_to_exceptions)?;
-            study.attrs.clone()
+            Arc::new(study.attrs.clone())
         };
         let trials = guard.get_trials(study_id).map_err(err_to_exceptions)?;
         // TODO(c-bata): Filter category_labels attrs and clone them only.
         let py_trials: Vec<PyPersistedTrial> = trials
             .iter()
-            .map(|t| PyPersistedTrial::new(t.clone(), study_attrs.clone()))
+            .map(|t| PyPersistedTrial::new_with_arc(t.clone(), study_attrs.clone()))
             .collect();
         Ok(py_trials)
     }
@@ -226,12 +226,14 @@ impl PyStorage {
             .get_trial(study_id, trial_number)
             .map_err(err_to_exceptions)?
             .clone();
-        let study_attrs = guard
-            .get_study(study_id)
-            .map_err(err_to_exceptions)?
-            .attrs
-            .clone();
-        Ok(PyPersistedTrial::new(trial, study_attrs))
+        let study_attrs = Arc::new(
+            guard
+                .get_study(study_id)
+                .map_err(err_to_exceptions)?
+                .attrs
+                .clone(),
+        );
+        Ok(PyPersistedTrial::new_with_arc(trial, study_attrs))
     }
 
     fn set_study_system_attrs(&mut self, study_id: u32, attrs: PyObject) -> PyResult<()> {

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -305,12 +305,16 @@ impl PyStudy {
             .get_trial(self.study.id, trial_number)
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind)))?
             .clone();
-        let study_attrs = guard
-            .get_study(self.study.id)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get the study: {:?}", e.kind)))?
-            .attrs
-            .clone();
-        let trial = PyPersistedTrial::new(trial, study_attrs);
+        let study_attrs = Arc::new(
+            guard
+                .get_study(self.study.id)
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to get the study: {:?}", e.kind))
+                })?
+                .attrs
+                .clone(),
+        );
+        let trial = PyPersistedTrial::new_with_arc(trial, study_attrs);
         Ok(trial)
     }
 
@@ -321,15 +325,19 @@ impl PyStudy {
             .get_trials(self.study.id)
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind)))?
             .clone();
-        let study_attrs = guard
-            .get_study(self.study.id)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get the study: {:?}", e.kind)))?
-            .attrs
-            .clone();
+        let study_attrs = Arc::new(
+            guard
+                .get_study(self.study.id)
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to get the study: {:?}", e.kind))
+                })?
+                .attrs
+                .clone(),
+        );
 
         let trials: Vec<PyPersistedTrial> = trials_vec
             .iter()
-            .map(|t| PyPersistedTrial::new(t.clone(), study_attrs.clone()))
+            .map(|t| PyPersistedTrial::new_with_arc(t.clone(), study_attrs.clone()))
             .collect();
         Ok(trials)
     }
@@ -363,18 +371,22 @@ impl PyStudy {
                     PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind))
                 })?
                 .clone();
-            let study_attrs = guard
-                .get_study(self.study.id)
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to get the study: {:?}", e.kind))
-                })?
-                .attrs
-                .clone();
+            let study_attrs = Arc::new(
+                guard
+                    .get_study(self.study.id)
+                    .map_err(|e| {
+                        PyRuntimeError::new_err(format!("Failed to get the study: {:?}", e.kind))
+                    })?
+                    .attrs
+                    .clone(),
+            );
             (trials_vec, study_attrs)
         };
         let best_trials = pareto_front_numbers
             .iter()
-            .map(|n| PyPersistedTrial::new(trials_vec[*n as usize].clone(), study_attrs.clone()))
+            .map(|n| {
+                PyPersistedTrial::new_with_arc(trials_vec[*n as usize].clone(), study_attrs.clone())
+            })
             .collect();
         Ok(best_trials)
     }

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
@@ -152,9 +153,12 @@ impl PyTrial {
 #[derive(Debug)]
 #[pyclass(name = "PersistedTrial")]
 #[pyo3(module = "rustuna")]
-pub struct PyPersistedTrial(PersistedTrial, Attrs);
+pub struct PyPersistedTrial(PersistedTrial, Arc<Attrs>);
 impl PyPersistedTrial {
     pub fn new(trial: PersistedTrial, study_attrs: Attrs) -> Self {
+        PyPersistedTrial(trial, Arc::new(study_attrs))
+    }
+    pub fn new_with_arc(trial: PersistedTrial, study_attrs: Arc<Attrs>) -> Self {
         PyPersistedTrial(trial, study_attrs)
     }
 }
@@ -213,7 +217,7 @@ impl PyPersistedTrial {
         trial.attrs = trial_attrs;
 
         let study_attrs = Attrs::new();
-        Ok(PyPersistedTrial(trial, study_attrs))
+        Ok(PyPersistedTrial(trial, Arc::new(study_attrs)))
     }
 
     #[getter]


### PR DESCRIPTION
Currently, study.system_attrs are cloned n_trials times, increasing the memory usage. This PR wraps study.attrs with Arc, so that `.clone()` only increases the reference count.