### PR TITLE
Avoid using `unwrap()` in `rustuna_pyo3`

### DIFF
--- a/rustuna_pyo3/src/importance.rs
+++ b/rustuna_pyo3/src/importance.rs
@@ -29,7 +29,8 @@ pub fn py_get_param_importance_from_list(
     // TODO(c-bata): Try using https://github.com/PyO3/rust-numpy to make this faster.
     let features_vec = features.iter().map(|x| x.as_slice()).collect();
     let targets_vec = targets.as_slice();
-    let trees = NonZeroUsize::new(n_trees).unwrap();
+    let trees = NonZeroUsize::new(n_trees)
+        .ok_or_else(|| PyValueError::new_err("n_trees must be greater than 0"))?;
     let mut fanova = FanovaOptions::new()
         .random_forest(RandomForestOptions::new().trees(trees).seed(0))
         .fit(features_vec, targets_vec)

--- a/rustuna_pyo3/src/sampler.rs
+++ b/rustuna_pyo3/src/sampler.rs
@@ -81,8 +81,12 @@ impl PySampler {
     }
 
     #[getter]
-    fn support_joint_sampling(&self) -> bool {
-        self.sampler.lock().unwrap().support_joint_sampling()
+    fn support_joint_sampling(&self) -> PyResult<bool> {
+        let guard = self
+            .sampler
+            .lock()
+            .map_err(|_| PyRuntimeError::new_err("Failed to acquire sampler lock"))?;
+        Ok(guard.support_joint_sampling())
     }
 
     fn sample_independent(
@@ -94,7 +98,7 @@ impl PySampler {
     ) -> PyResult<f64> {
         self.sampler
             .lock()
-            .unwrap()
+            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the sampler guard"))?
             .sample_independent(
                 &ctx.context.clone(),
                 storage.storage.clone(),
@@ -112,7 +116,7 @@ impl PySampler {
     ) -> PyResult<HashMap<String, f64>> {
         self.sampler
             .lock()
-            .unwrap()
+            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the sampler guard"))?
             .sample_joint(
                 &ctx.context.clone(),
                 storage.storage.clone(),
@@ -188,7 +192,9 @@ impl Sampler for PyObjectSampler {
         name: &str,
         distribution: &rustuna_core::distribution::Distribution,
     ) -> rustuna_core::Result<f64> {
-        let mut guard = storage.write().unwrap();
+        let mut guard = storage
+            .write()
+            .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::StorageError))?;
         let study = guard.get_study(ctx.study_id)?;
         let study_attrs = study.attrs.clone();
         drop(guard);
@@ -221,7 +227,7 @@ impl Sampler for PyObjectSampler {
         Python::with_gil(|py| {
             self.obj
                 .getattr(py, "support_joint_sampling")
-                .map(|x| x.extract::<bool>(py).unwrap())
+                .and_then(|x| x.extract::<bool>(py))
                 .unwrap_or(false)
         })
     }
@@ -232,7 +238,9 @@ impl Sampler for PyObjectSampler {
         storage: Arc<std::sync::RwLock<dyn Storage>>,
         search_space: &HashMap<String, rustuna_core::distribution::Distribution>,
     ) -> rustuna_core::Result<HashMap<String, f64>> {
-        let mut guard = storage.write().unwrap();
+        let mut guard = storage
+            .write()
+            .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::StorageError))?;
         let study = guard.get_study(ctx.study_id)?;
         let study_attrs = study.attrs.clone();
         drop(guard);
@@ -255,7 +263,9 @@ impl Sampler for PyObjectSampler {
                 .obj
                 .call_method1(py, "sample_joint", (py_ctx, py_storage, py_search_space))
                 .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::SamplerError))?;
-            let py_result = py_result.extract::<HashMap<String, f64>>(py).unwrap();
+            let py_result = py_result
+                .extract::<HashMap<String, f64>>(py)
+                .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::SamplerError))?;
             Ok(py_result)
         })
     }

--- a/rustuna_pyo3/src/storage.rs
+++ b/rustuna_pyo3/src/storage.rs
@@ -77,13 +77,19 @@ impl PyStorage {
     }
 
     fn delete_study(&mut self, study_id: u32) -> PyResult<()> {
-        let mut guard = self.storage.write().unwrap();
+        let mut guard = self
+            .storage
+            .write()
+            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
         guard.delete_study(study_id).map_err(err_to_exceptions)?;
         Ok(())
     }
 
     fn create_new_trial(&mut self, study_id: u32) -> PyResult<PyPersistedTrial> {
-        let mut guard = self.storage.write().unwrap();
+        let mut guard = self
+            .storage
+            .write()
+            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
         let trial = guard
             .create_new_trial(study_id)
             .map_err(err_to_exceptions)?;
@@ -171,7 +177,10 @@ impl PyStorage {
         state: PyTrialState,
         values: Option<Vec<f64>>,
     ) -> PyResult<()> {
-        let mut guard = self.storage.write().unwrap();
+        let mut guard = self
+            .storage
+            .write()
+            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
 
         let state_values = match state {
             PyTrialState::COMPLETE => {
@@ -192,7 +201,10 @@ impl PyStorage {
     }
 
     fn get_studies(&mut self) -> PyResult<Vec<PyPersistedStudy>> {
-        let mut guard = self.storage.write().unwrap();
+        let mut guard = self
+            .storage
+            .write()
+            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
         let studies = guard
             .get_studies()
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to get studies: {:?}", e.kind)))?;
@@ -200,13 +212,19 @@ impl PyStorage {
     }
 
     fn get_study(&mut self, study_id: u32) -> PyResult<PyPersistedStudy> {
-        let mut guard = self.storage.write().unwrap();
+        let mut guard = self
+            .storage
+            .write()
+            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
         let study = guard.get_study(study_id).map_err(err_to_exceptions)?;
         Ok(study.clone().into())
     }
 
     fn get_trials(&mut self, study_id: u32) -> PyResult<Vec<PyPersistedTrial>> {
-        let mut guard = self.storage.write().unwrap();
+        let mut guard = self
+            .storage
+            .write()
+            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
         let study_attrs = {
             let study = guard.get_study(study_id).map_err(err_to_exceptions)?;
             Arc::new(study.attrs.clone())
@@ -221,7 +239,10 @@ impl PyStorage {
     }
 
     fn get_trial(&mut self, study_id: u32, trial_number: u32) -> PyResult<PyPersistedTrial> {
-        let mut guard = self.storage.write().unwrap();
+        let mut guard = self
+            .storage
+            .write()
+            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
         let trial = guard
             .get_trial(study_id, trial_number)
             .map_err(err_to_exceptions)?
@@ -241,7 +262,10 @@ impl PyStorage {
             let attrs = attrs.as_ref(py);
             pyobj_to_system_attrs(attrs)
         })?;
-        let mut guard = self.storage.write().unwrap();
+        let mut guard = self
+            .storage
+            .write()
+            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
         guard
             .set_study_attrs(study_id, system_attrs, false)
             .map_err(err_to_exceptions)?;
@@ -253,7 +277,10 @@ impl PyStorage {
             let attrs = attrs.as_ref(py);
             pyobj_to_user_attrs(attrs)
         })?;
-        let mut guard = self.storage.write().unwrap();
+        let mut guard = self
+            .storage
+            .write()
+            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
         guard
             .set_study_attrs(study_id, user_attrs, false)
             .map_err(err_to_exceptions)?;
@@ -270,7 +297,10 @@ impl PyStorage {
             let attrs = attrs.as_ref(py);
             pyobj_to_system_attrs(attrs)
         })?;
-        let mut guard = self.storage.write().unwrap();
+        let mut guard = self
+            .storage
+            .write()
+            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
         guard
             .set_trial_attrs(study_id, trial_number, system_attrs, false)
             .map_err(err_to_exceptions)?;
@@ -287,7 +317,10 @@ impl PyStorage {
             let attrs = attrs.as_ref(py);
             pyobj_to_user_attrs(attrs)
         })?;
-        let mut guard = self.storage.write().unwrap();
+        let mut guard = self
+            .storage
+            .write()
+            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
         guard
             .set_trial_attrs(study_id, trial_number, user_attrs, false)
             .map_err(err_to_exceptions)?;

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -114,7 +114,9 @@ pub fn py_load_study(
         }
     });
     let storage = storage?;
-    let mut guard = storage.write().unwrap();
+    let mut guard = storage
+        .write()
+        .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
     let (study_id, directions) = guard
         .get_studies()
         .map_err(|e| PyRuntimeError::new_err(format!("Failed to get the studies: {:?}", e.kind)))?
@@ -320,7 +322,11 @@ impl PyStudy {
 
     #[getter]
     pub fn trials(&mut self) -> PyResult<Vec<PyPersistedTrial>> {
-        let mut guard = self.study.storage.write().unwrap();
+        let mut guard = self
+            .study
+            .storage
+            .write()
+            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
         let trials_vec = guard
             .get_trials(self.study.id)
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind)))?
@@ -364,7 +370,11 @@ impl PyStudy {
             PyRuntimeError::new_err(format!("Failed to get the pareto front: {:?}", e.kind))
         })?;
         let (trials_vec, study_attrs) = {
-            let mut guard = self.study.storage.write().unwrap();
+            let mut guard = self
+                .study
+                .storage
+                .write()
+                .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
             let trials_vec = guard
                 .get_trials(self.study.id)
                 .map_err(|e| {


### PR DESCRIPTION
Follow-up #10 

This PR adds improvements on error handling by removing the use of `unwrap()` under the `rustuna_pyo3` crate.