### PR TITLE
Avoid using `unwrap()` in `rustuna_core` crate

### DIFF
--- a/rustuna_core/src/attr.rs
+++ b/rustuna_core/src/attr.rs
@@ -108,7 +108,7 @@ mod tests {
 
         for c in categories {
             let s = c.serialize();
-            let c2 = CategoryLabel::deserialize(&s).unwrap();
+            let c2 = CategoryLabel::deserialize(&s).expect("Failed to deserialize category label");
             assert_eq!(c, c2);
         }
     }

--- a/rustuna_core/src/sampler.rs
+++ b/rustuna_core/src/sampler.rs
@@ -147,44 +147,44 @@ mod tests {
     }
 
     #[test]
-    fn test_joint_sampling_empty() {
+    fn test_joint_sampling_empty() -> Result<()> {
         let joint_params = HashMap::new();
         let sampler = Arc::new(Mutex::new(DummyJointSampler { joint_params }));
-        let mut study =
-            create_study("dummy", InMemoryStorage::new(), vec![Direction::Minimize]).unwrap();
-        study.optimize(objective, sampler, 2).unwrap();
+        let mut study = create_study("dummy", InMemoryStorage::new(), vec![Direction::Minimize])?;
+        study.optimize(objective, sampler, 2)?;
+        Ok(())
     }
 
     #[test]
-    fn test_joint_sampling_partially() {
+    fn test_joint_sampling_partially() -> Result<()> {
         let mut joint_params = HashMap::new();
         joint_params.insert(String::from("x"), 0.5);
 
         let sampler = Arc::new(Mutex::new(DummyJointSampler { joint_params }));
-        let mut study =
-            create_study("dummy", InMemoryStorage::new(), vec![Direction::Minimize]).unwrap();
-        study.optimize(objective, sampler, 2).unwrap();
+        let mut study = create_study("dummy", InMemoryStorage::new(), vec![Direction::Minimize])?;
+        study.optimize(objective, sampler, 2)?;
 
-        let trials = study.get_trials().unwrap();
+        let trials = study.get_trials()?;
         assert_eq!(trials.len(), 2);
         assert_eq!(trials[1].internal_params["x"], 0.5);
         assert!(trials[1].internal_params.contains_key("y"));
+        Ok(())
     }
 
     #[test]
-    fn test_joint_sampling_all() {
+    fn test_joint_sampling_all() -> Result<()> {
         let mut joint_params = HashMap::new();
         joint_params.insert(String::from("x"), 1.0);
         joint_params.insert(String::from("y"), 1.0);
 
         let sampler = Arc::new(Mutex::new(DummyJointSampler { joint_params }));
-        let mut study =
-            create_study("dummy", InMemoryStorage::new(), vec![Direction::Minimize]).unwrap();
-        study.optimize(objective, sampler, 2).unwrap();
+        let mut study = create_study("dummy", InMemoryStorage::new(), vec![Direction::Minimize])?;
+        study.optimize(objective, sampler, 2)?;
 
-        let trials = study.get_trials().unwrap();
+        let trials = study.get_trials()?;
         assert_eq!(trials.len(), 2);
         assert_eq!(trials[1].internal_params["x"], 1.0);
         assert_eq!(trials[1].internal_params["y"], 1.0);
+        Ok(())
     }
 }

--- a/rustuna_core/src/storage.rs
+++ b/rustuna_core/src/storage.rs
@@ -113,7 +113,9 @@ impl Storage for InMemoryStorage {
             directions,
         ));
         self.trials.insert(study_id, vec![]);
-        Ok(self.studies.last().unwrap())
+        self.studies
+            .last()
+            .ok_or_else(|| Error::new(ErrorKind::StorageError))
     }
 
     fn delete_study(&mut self, study_id: u32) -> Result<()> {
@@ -272,7 +274,10 @@ mod tests {
         storage.create_new_study("study2", vec![Direction::Minimize])?;
         storage.delete_study(study1_id)?;
 
-        let err = storage.get_study(study1_id).err().unwrap();
+        let err = storage
+            .get_study(study1_id)
+            .err()
+            .expect("Expected StudyNotFound error");
         assert!(matches!(err.kind, ErrorKind::StudyNotFound));
 
         let study3 = storage.create_new_study("study3", vec![Direction::Minimize])?;

--- a/rustuna_core/src/study.rs
+++ b/rustuna_core/src/study.rs
@@ -181,7 +181,10 @@ impl Study {
     }
 
     pub fn get_trials(&self) -> Result<Vec<PersistedTrial>> {
-        let mut guard = self.storage.write().unwrap();
+        let mut guard = self
+            .storage
+            .write()
+            .map_err(|_| Error::new(ErrorKind::StorageError))?;
         let trials = guard.get_trials(self.id)?;
         Ok(trials.clone())
     }
@@ -254,7 +257,10 @@ impl PersistedStudy {
 }
 
 pub fn get_best_trial(study: &Study) -> Result<u32> {
-    let mut guard = study.storage.write().unwrap();
+    let mut guard = study
+        .storage
+        .write()
+        .map_err(|_| Error::new(ErrorKind::StorageError))?;
     let trials = guard.get_trials(study.id)?;
 
     let best_trial = trials
@@ -275,7 +281,9 @@ pub fn get_best_trial(study: &Study) -> Result<u32> {
                 }
                 _ => unreachable!("Unexpected state"),
             };
-            a_value.partial_cmp(&b_value).unwrap()
+            a_value
+                .partial_cmp(&b_value)
+                .unwrap_or(std::cmp::Ordering::Equal)
         })
         .ok_or(Error::new(ErrorKind::NoCompletedTrial))?;
     Ok(best_trial.number)
@@ -283,7 +291,10 @@ pub fn get_best_trial(study: &Study) -> Result<u32> {
 
 // TODO(HideakiImamura): Support the faster algorithm for `len(directions) == 2`.
 pub fn get_pareto_front(study: &Study) -> Result<Vec<u32>> {
-    let mut guard = study.storage.write().unwrap();
+    let mut guard = study
+        .storage
+        .write()
+        .map_err(|_| Error::new(ErrorKind::StorageError))?;
     let trials = guard
         .get_trials(study.id)?
         .iter()
@@ -348,34 +359,33 @@ mod tests {
     use crate::study::get_best_trial;
 
     #[test]
-    fn test_optimize() {
+    fn test_optimize() -> Result<()> {
         let storage = InMemoryStorage::new();
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let mut study = create_study("dummy", storage, directions).unwrap();
+        let mut study = create_study("dummy", storage, directions)?;
 
-        study
-            .optimize(
-                |mut t| {
-                    let x = t.suggest_float("x", 0.0, 10.0)?;
-                    let y = t.suggest_float("y", 0.0, 10.0)?;
-                    let z = t.suggest_int("z", 0, 10)?;
+        study.optimize(
+            |mut t| {
+                let x = t.suggest_float("x", 0.0, 10.0)?;
+                let y = t.suggest_float("y", 0.0, 10.0)?;
+                let z = t.suggest_int("z", 0, 10)?;
 
-                    let value = (x - 3.0).powi(2) + (y - 5.0).powi(2) + (z as f64);
-                    Ok(vec![value])
-                },
-                sampler,
-                100,
-            )
-            .unwrap();
+                let value = (x - 3.0).powi(2) + (y - 5.0).powi(2) + (z as f64);
+                Ok(vec![value])
+            },
+            sampler,
+            100,
+        )?;
         assert!(get_best_trial(&study).is_ok());
+        Ok(())
     }
 
     #[test]
-    fn test_optimize_parallel() {
+    fn test_optimize_parallel() -> Result<()> {
         let storage = InMemoryStorage::new();
         let directions = vec![Direction::Minimize];
-        let study = create_study("dummy-study", storage, directions).unwrap();
+        let study = create_study("dummy-study", storage, directions)?;
 
         thread::scope(|s| {
             for i in 0..4 {
@@ -396,81 +406,81 @@ mod tests {
                             sampler,
                             100,
                         )
-                        .unwrap();
+                        .expect("Optimization failed");
                 });
             }
         });
         assert!(get_best_trial(&study).is_ok());
-        assert!(study.get_trials().unwrap().len() == 400);
+        assert_eq!(study.get_trials()?.len(), 400);
+        Ok(())
     }
 
     #[test]
-    fn test_user_attr() {
+    fn test_user_attr() -> Result<()> {
         let storage = InMemoryStorage::new();
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let mut study = create_study("dummy", storage, directions).unwrap();
+        let mut study = create_study("dummy", storage, directions)?;
 
-        let mut trial = study.ask(sampler).unwrap();
-        trial.set_user_attr("key", String::from("bar")).unwrap();
-        let user_attr = trial.get_user_attr("key").unwrap();
+        let mut trial = study.ask(sampler)?;
+        trial.set_user_attr("key", String::from("bar"))?;
+        let user_attr = trial
+            .get_user_attr("key")
+            .ok_or_else(|| Error::new(ErrorKind::StorageError))?;
         assert_eq!(user_attr, "bar");
+        Ok(())
     }
 
     #[test]
-    fn test_get_best_trial() {
+    fn test_get_best_trial() -> Result<()> {
         let storage = InMemoryStorage::new();
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let mut study = create_study("dummy", storage, directions).unwrap();
+        let mut study = create_study("dummy", storage, directions)?;
 
-        study
-            .optimize(
-                |mut t| {
-                    let x = t.suggest_float("x", 0.0, 10.0)?;
-                    let y = t.suggest_float("y", 0.0, 10.0)?;
-                    let z = t.suggest_int("z", 0, 10)?;
+        study.optimize(
+            |mut t| {
+                let x = t.suggest_float("x", 0.0, 10.0)?;
+                let y = t.suggest_float("y", 0.0, 10.0)?;
+                let z = t.suggest_int("z", 0, 10)?;
 
-                    let value = (x - 3.0).powi(2) + (y - 5.0).powi(2) + (z as f64);
-                    Ok(vec![value])
-                },
-                sampler,
-                100,
-            )
-            .unwrap();
+                let value = (x - 3.0).powi(2) + (y - 5.0).powi(2) + (z as f64);
+                Ok(vec![value])
+            },
+            sampler,
+            100,
+        )?;
 
-        let best_trial_number = get_best_trial(&study);
-        assert!(best_trial_number.is_ok());
-        let best_trial_number = best_trial_number.unwrap();
+        let best_trial_number = get_best_trial(&study)?;
         assert!(best_trial_number < 100);
+        Ok(())
     }
 
     #[test]
-    fn test_get_pareto_front_trials() {
+    fn test_get_pareto_front_trials() -> Result<()> {
         let storage = InMemoryStorage::new();
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize, Direction::Maximize];
-        let mut study = create_study("dummy", storage, directions).unwrap();
+        let mut study = create_study("dummy", storage, directions)?;
 
-        study
-            .optimize(
-                |mut t| {
-                    let x = t.suggest_float("x", 0.0, 10.0)?;
-                    let y = t.suggest_float("y", 0.0, 10.0)?;
-                    let z = t.suggest_int("z", 0, 10)?;
+        study.optimize(
+            |mut t| {
+                let x = t.suggest_float("x", 0.0, 10.0)?;
+                let y = t.suggest_float("y", 0.0, 10.0)?;
+                let z = t.suggest_int("z", 0, 10)?;
 
-                    let value0 = (x - 3.0).powi(2) + (y - 5.0).powi(2) + (z as f64);
-                    let value1 = (x - 3.0).powi(2) + (y - 5.0).powi(2) + (z as f64) * 2.0;
-                    Ok(vec![value0, value1])
-                },
-                sampler,
-                100,
-            )
-            .unwrap();
+                let value0 = (x - 3.0).powi(2) + (y - 5.0).powi(2) + (z as f64);
+                let value1 = (x - 3.0).powi(2) + (y - 5.0).powi(2) + (z as f64) * 2.0;
+                Ok(vec![value0, value1])
+            },
+            sampler,
+            100,
+        )?;
 
-        let pareto_front_numbers = get_pareto_front(&study).unwrap();
+        let pareto_front_numbers = get_pareto_front(&study)?;
         assert!(!pareto_front_numbers.is_empty());
         assert!(pareto_front_numbers.len() <= 100);
+        Ok(())
     }
 
     #[test]
@@ -483,51 +493,46 @@ mod tests {
     }
 
     #[test]
-    fn test_dynamic_search_space() {
+    fn test_dynamic_search_space() -> Result<()> {
         let storage = InMemoryStorage::new();
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let mut study = create_study("dummy", storage, directions).unwrap();
+        let mut study = create_study("dummy", storage, directions)?;
 
-        study
-            .optimize(
-                |mut t| {
-                    t.suggest_float("x", 0.0, 10.0)?;
-                    Ok(vec![0.0])
-                },
-                sampler.clone(),
-                5,
-            )
-            .unwrap();
-        study
-            .optimize(
-                |mut t| {
-                    t.suggest_float("x", 1.0, 10.0)?;
-                    Ok(vec![0.0])
-                },
-                sampler.clone(),
-                5,
-            )
-            .unwrap();
+        study.optimize(
+            |mut t| {
+                t.suggest_float("x", 0.0, 10.0)?;
+                Ok(vec![0.0])
+            },
+            sampler.clone(),
+            5,
+        )?;
+        study.optimize(
+            |mut t| {
+                t.suggest_float("x", 1.0, 10.0)?;
+                Ok(vec![0.0])
+            },
+            sampler.clone(),
+            5,
+        )?;
+        Ok(())
     }
 
     #[test]
-    fn test_invalid_dynamic_search_space() {
+    fn test_invalid_dynamic_search_space() -> Result<()> {
         let storage = InMemoryStorage::new();
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let mut study = create_study("dummy", storage, directions).unwrap();
+        let mut study = create_study("dummy", storage, directions)?;
 
-        study
-            .optimize(
-                |mut t| {
-                    t.suggest_float("x", 0.0, 10.0)?;
-                    Ok(vec![0.0])
-                },
-                sampler.clone(),
-                5,
-            )
-            .unwrap();
+        study.optimize(
+            |mut t| {
+                t.suggest_float("x", 0.0, 10.0)?;
+                Ok(vec![0.0])
+            },
+            sampler.clone(),
+            5,
+        )?;
         let error = study
             .optimize(
                 |mut t| {
@@ -539,5 +544,6 @@ mod tests {
             )
             .unwrap_err();
         assert!(matches!(error.kind, ErrorKind::IncompatibleDistribution));
+        Ok(())
     }
 }

--- a/rustuna_core/src/trial.rs
+++ b/rustuna_core/src/trial.rs
@@ -43,7 +43,10 @@ impl Trial {
         if let Some((d, val)) = self.joint_params.get(name) {
             if *d == *distribution {
                 let param_value = *val;
-                let mut storage_guard = self.storage.write().unwrap();
+                let mut storage_guard = self
+                    .storage
+                    .write()
+                    .map_err(|_| Error::new(ErrorKind::StorageError))?;
                 storage_guard.set_trial_param(
                     self.study_id,
                     self.number,
@@ -61,12 +64,18 @@ impl Trial {
             trial_number: self.number,
             directions: self.directions.clone(),
         };
-        let mut sampler_guard = self.sampler.lock().unwrap();
+        let mut sampler_guard = self
+            .sampler
+            .lock()
+            .map_err(|_| Error::new(ErrorKind::SamplerError))?;
         let param_value =
             sampler_guard.sample_independent(&context, self.storage.clone(), name, distribution)?;
         drop(sampler_guard);
 
-        let mut storage_guard = self.storage.write().unwrap();
+        let mut storage_guard = self
+            .storage
+            .write()
+            .map_err(|_| Error::new(ErrorKind::StorageError))?;
         storage_guard.set_trial_param(
             self.study_id,
             self.number,
@@ -152,7 +161,10 @@ impl Trial {
     }
 
     pub fn set_user_attr(&mut self, key: &str, value: String) -> Result<()> {
-        let mut guard = self.storage.write().unwrap();
+        let mut guard = self
+            .storage
+            .write()
+            .map_err(|_| Error::new(ErrorKind::StorageError))?;
         let mut attrs = Attrs::new();
 
         let key = AttrKey::User(key.to_string());
@@ -212,31 +224,34 @@ mod tests {
     use crate::study::create_study_with_arc;
 
     #[test]
-    fn test_trial_user_attr() {
+    fn test_trial_user_attr() -> Result<()> {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let mut study = create_study_with_arc("dummy", storage.clone(), directions).unwrap();
+        let mut study = create_study_with_arc("dummy", storage.clone(), directions)?;
 
         // Set user attributes
-        let mut trial = study.ask(sampler.clone()).unwrap();
-        trial.set_user_attr("key", "user".to_string()).unwrap();
+        let mut trial = study.ask(sampler.clone())?;
+        trial.set_user_attr("key", "user".to_string())?;
 
         // Set system attributes
-        let mut guard = storage.write().unwrap();
+        let mut guard = storage
+            .write()
+            .map_err(|_| Error::new(ErrorKind::StorageError))?;
         let mut attrs = Attrs::new();
         attrs.insert(AttrKey::System("key".to_string()), "system".to_string());
-        guard.set_trial_attrs(study.id, 0, attrs, false).unwrap();
+        guard.set_trial_attrs(study.id, 0, attrs, false)?;
 
         // Check the attributes
-        let trial = guard.get_trial(study.id, 0).unwrap();
-        assert!(trial.attrs.get(&AttrKey::User("key".to_string())).unwrap() == "user");
-        assert!(
-            trial
-                .attrs
-                .get(&AttrKey::System("key".to_string()))
-                .unwrap()
-                == "system"
+        let trial = guard.get_trial(study.id, 0)?;
+        assert_eq!(
+            trial.attrs.get(&AttrKey::User("key".to_string())),
+            Some(&"user".to_string())
         );
+        assert_eq!(
+            trial.attrs.get(&AttrKey::System("key".to_string())),
+            Some(&"system".to_string())
+        );
+        Ok(())
     }
 }


### PR DESCRIPTION
Follow-up #10 

This PR adds improvements on error handling by removing the use of `unwrap()` under the `rustuna_core` crate.