### PR TITLE
Change the default value of IntDistribution's step value

### DIFF
--- a/rustuna_core/src/distribution.rs
+++ b/rustuna_core/src/distribution.rs
@@ -11,7 +11,7 @@ pub enum Distribution {
     Int {
         low: i64,
         high: i64,
-        step: Option<i64>,
+        step: i64,
         log: bool,
     },
     Categorical {
@@ -74,7 +74,7 @@ mod tests {
         let i = Distribution::Int {
             low: 0,
             high: 1,
-            step: None,
+            step: 1,
             log: false,
         };
         let c = Distribution::Categorical { cardinality: 3 };
@@ -117,13 +117,13 @@ mod tests {
         let i1 = Distribution::Int {
             low: 0,
             high: 1,
-            step: None,
+            step: 1,
             log: false,
         };
         let i2 = Distribution::Int {
             low: 0,
             high: 2,
-            step: None,
+            step: 1,
             log: false,
         };
         assert!(i1.check_compatibility(&i1).is_ok());
@@ -132,7 +132,7 @@ mod tests {
         let i1_log = Distribution::Int {
             low: 0,
             high: 1,
-            step: None,
+            step: 1,
             log: true,
         };
         assert!(i1.check_compatibility(&i1_log).is_err());

--- a/rustuna_core/src/trial.rs
+++ b/rustuna_core/src/trial.rs
@@ -113,7 +113,7 @@ impl Trial {
         let distribution = Distribution::Int {
             low,
             high,
-            step: None,
+            step: 1,
             log: false,
         };
         let param_value = self.suggest(name, &distribution)?;

--- a/rustuna_js/src/distribution.rs
+++ b/rustuna_js/src/distribution.rs
@@ -72,11 +72,11 @@ pub struct JsIntDistribution {
     pub type_: &'static str,
     pub low: i64,
     pub high: i64,
-    pub step: Option<i64>,
+    pub step: i64,
     pub log: bool,
 }
 impl JsIntDistribution {
-    pub fn new(low: i64, high: i64, step: Option<i64>, log: bool) -> Self {
+    pub fn new(low: i64, high: i64, step: i64, log: bool) -> Self {
         JsIntDistribution {
             type_: "IntDistribution",
             low,

--- a/rustuna_pyo3/src/distribution.rs
+++ b/rustuna_pyo3/src/distribution.rs
@@ -54,8 +54,8 @@ impl PyDistribution {
     }
 
     #[classmethod]
-    #[pyo3(signature = (low, high, log=false, step=None))]
-    pub fn int(_cls: &PyType, low: i64, high: i64, log: bool, step: Option<i64>) -> Self {
+    #[pyo3(signature = (low, high, log=false, step=1))]
+    pub fn int(_cls: &PyType, low: i64, high: i64, log: bool, step: i64) -> Self {
         PyDistribution {
             distribution: Distribution::Int {
                 low,
@@ -118,11 +118,7 @@ impl PyDistribution {
                 dist.set_item("low", low)?;
                 dist.set_item("high", high)?;
                 dist.set_item("log", log)?;
-                if let Some(step) = step {
-                    dist.set_item("step", step)?;
-                } else {
-                    dist.set_item("step", py.None())?;
-                }
+                dist.set_item("step", step)?;
                 Ok(dist.into())
             }
             Distribution::Categorical { cardinality } => {

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -87,13 +87,13 @@ impl PyTrial {
         })?;
         Ok(value)
     }
-    #[pyo3(signature = (name, low, high, step=None, log=false))]
+    #[pyo3(signature = (name, low, high, step=1, log=false))]
     pub fn suggest_int(
         &mut self,
         name: &str,
         low: i64,
         high: i64,
-        step: Option<i64>,
+        step: i64,
         log: bool,
     ) -> PyResult<i64> {
         let dist = Distribution::Int {

--- a/rustuna_storages/src/cache.rs
+++ b/rustuna_storages/src/cache.rs
@@ -885,7 +885,7 @@ mod tests {
         let int_dist = Distribution::Int {
             low: 0,
             high: 5,
-            step: None,
+            step: 1,
             log: false,
         };
 

--- a/rustuna_storages/src/sqlite3.rs
+++ b/rustuna_storages/src/sqlite3.rs
@@ -1277,10 +1277,10 @@ fn json_to_distribution(
                 .and_then(|v| v.as_bool())
                 .ok_or_else(|| Error::new(ErrorKind::StorageError))?;
             let step = match attributes.get("step") {
-                Some(Value::Null) | None => None,
-                Some(Value::Number(n)) => n.as_i64(),
-                Some(Value::String(s)) => s.parse::<i64>().ok(),
-                _ => None,
+                Some(Value::Null) | None => 1,
+                Some(Value::Number(n)) => n.as_i64().unwrap_or(1),
+                Some(Value::String(s)) => s.parse::<i64>().unwrap_or(1),
+                _ => 1,
             };
             Ok((
                 Distribution::Int {
@@ -1433,7 +1433,7 @@ mod tests {
         let int_dist = Distribution::Int {
             low: 0,
             high: 10,
-            step: None,
+            step: 1,
             log: false,
         };
         storage.set_trial_param(study_id, trial.number, "int", &int_dist, 5.0)?;

--- a/rustuna_storages/tests/sqlite3.rs
+++ b/rustuna_storages/tests/sqlite3.rs
@@ -110,7 +110,7 @@ study.optimize(objective, n_trials=10)
             low: -10,
             high: 10,
             log: false,
-            step: Some(1)
+            step: 1
         }
     );
     assert_eq!(
@@ -175,7 +175,7 @@ study.optimize(objective, n_trials=10)
         Distribution::Int {
             low: -10,
             high: 10,
-            step: Some(1),
+            step: 1,
             log: false
         }
     );


### PR DESCRIPTION
This PR updates the type and the default value of IntDistribution's `step` field from `Option<i64>` to `i64`, improving the compatibility with Optuna.
https://github.com/optuna/optuna/blob/1146ac23ab667487018b6a761092afa7361a9b3d/optuna/distributions.py#L340
