### PR TITLE
Bump up the PyO3 version from 0.21 to 0.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da6bc11b07529f16944307272d5bd9b22530bc7d05751717c9d416586cedab49"
 dependencies = [
  "clap",
- "heck",
+ "heck 0.4.1",
  "indexmap",
  "log",
  "proc-macro2",
@@ -271,6 +271,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,15 +386,6 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
-
-[[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -519,29 +516,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,16 +553,16 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.21.2"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
+checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
 dependencies = [
  "cfg-if",
  "chrono",
  "indoc",
  "libc",
  "memoffset",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -598,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.21.2"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
+checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -608,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.21.2"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
+checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -618,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.21.2"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
+checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -630,11 +604,11 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.21.2"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
+checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
@@ -720,15 +694,6 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -839,12 +804,6 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,11 +553,10 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.6"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
 dependencies = [
- "cfg-if",
  "chrono",
  "indoc",
  "libc",
@@ -572,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.6"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -582,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.6"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -592,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.6"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -604,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.6"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -926,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tempfile"

--- a/rustuna_pyo3/Cargo.toml
+++ b/rustuna_pyo3/Cargo.toml
@@ -14,7 +14,7 @@ name = "rustuna"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.22", features = ["extension-module", "chrono"] }
+pyo3 = { version = "0.25", features = ["extension-module", "chrono"] }
 chrono = { workspace = true }
 rustuna_core = { workspace = true }
 rustuna_samplers = { workspace = true }

--- a/rustuna_pyo3/Cargo.toml
+++ b/rustuna_pyo3/Cargo.toml
@@ -14,7 +14,7 @@ name = "rustuna"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.21", features = ["extension-module", "chrono"] }
+pyo3 = { version = "0.22", features = ["extension-module", "chrono"] }
 chrono = { workspace = true }
 rustuna_core = { workspace = true }
 rustuna_samplers = { workspace = true }

--- a/rustuna_pyo3/src/distribution.rs
+++ b/rustuna_pyo3/src/distribution.rs
@@ -76,19 +76,15 @@ impl PyDistribution {
     #[classmethod]
     pub fn categorical(_cls: &Bound<'_, PyType>, choices: Vec<PyObject>) -> PyResult<Self> {
         let cardinality = choices.len();
-        let category_labels = Python::with_gil(|py| {
-            let mut labels: Vec<CategoryLabel> = Vec::with_capacity(choices.len());
-            for choice in choices {
-                match pyobject_to_category_label(py, choice) {
-                    Ok(label) => labels.push(label),
-                    Err(e) => return Err(e),
-                }
-            }
-            Ok(labels)
-        })?;
+        let mut labels: Vec<CategoryLabel> = Vec::with_capacity(choices.len());
+        let py = _cls.py();
+        for choice in choices {
+            let label = pyobject_to_category_label(choice.bind(py).as_any())?;
+            labels.push(label);
+        }
         let py_dist = PyDistribution {
             distribution: Distribution::Categorical { cardinality },
-            category_labels: Some(category_labels),
+            category_labels: Some(labels),
         };
         Ok(py_dist)
     }
@@ -146,7 +142,7 @@ impl PyDistribution {
                     let c = labels.get(i).ok_or(PyValueError::new_err(
                         "Internal representation of categorical value is out of range",
                     ))?;
-                    elements.push(category_label_to_pyobject(py, c)?);
+                    elements.push(category_label_to_pyobject(py, c)?.unbind());
                 }
                 let choices = PyList::new(py, &elements)?;
                 dist.set_item("choices", choices)?;
@@ -166,39 +162,41 @@ impl PyDistribution {
     }
 }
 
-pub fn category_label_to_pyobject(py: Python, label: &CategoryLabel) -> PyResult<PyObject> {
+pub fn category_label_to_pyobject<'py>(
+    py: Python<'py>,
+    label: &CategoryLabel,
+) -> PyResult<Bound<'py, PyAny>> {
     match label {
-        CategoryLabel::String(s) => Ok(s.into_pyobject(py)?.into_any().unbind()),
-        CategoryLabel::Int(i) => Ok(i.into_pyobject(py)?.into_any().unbind()),
-        CategoryLabel::Float(f) => Ok(f.into_pyobject(py)?.into_any().unbind()),
-        CategoryLabel::Bool(b) => Ok(PyBool::new(py, *b).to_owned().into()),
-        CategoryLabel::None => Ok(py.None()),
+        CategoryLabel::String(s) => Ok(s.into_pyobject(py)?.into_any()),
+        CategoryLabel::Int(i) => Ok(i.into_pyobject(py)?.into_any()),
+        CategoryLabel::Float(f) => Ok(f.into_pyobject(py)?.into_any()),
+        CategoryLabel::Bool(b) => Ok(PyBool::new(py, *b).to_owned().into_any()),
+        CategoryLabel::None => Ok(py.None().into_bound(py)),
     }
 }
 
-pub fn pyobject_to_category_label(py: Python, obj: PyObject) -> PyResult<CategoryLabel> {
-    let py_any = obj.bind(py);
-    if py_any.is_instance_of::<PyBool>() {
-        let x = py_any
+pub fn pyobject_to_category_label(obj: &Bound<'_, PyAny>) -> PyResult<CategoryLabel> {
+    if obj.is_instance_of::<PyBool>() {
+        let x = obj
             .extract::<bool>()
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to extract bool: {e:?}")))?;
         Ok(CategoryLabel::Bool(x))
-    } else if py_any.is_instance_of::<PyInt>() {
-        let x = py_any
+    } else if obj.is_instance_of::<PyInt>() {
+        let x = obj
             .extract::<i64>()
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to extract i64: {e:?}")))?;
         Ok(CategoryLabel::Int(x))
-    } else if py_any.is_instance_of::<PyFloat>() {
-        let x = py_any
+    } else if obj.is_instance_of::<PyFloat>() {
+        let x = obj
             .extract::<f64>()
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to extract f64: {e:?}")))?;
         Ok(CategoryLabel::Float(x))
-    } else if py_any.is_instance_of::<PyString>() {
-        let x = py_any
+    } else if obj.is_instance_of::<PyString>() {
+        let x = obj
             .extract::<String>()
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to extract String: {e:?}")))?;
         Ok(CategoryLabel::String(x))
-    } else if py_any.is_none() {
+    } else if obj.is_none() {
         Ok(CategoryLabel::None)
     } else {
         Err(PyRuntimeError::new_err(
@@ -207,26 +205,16 @@ pub fn pyobject_to_category_label(py: Python, obj: PyObject) -> PyResult<Categor
     }
 }
 
-pub fn py_to_external_repr(
+pub fn py_to_external_repr<'py>(
+    py: Python<'py>,
     dist: &Distribution,
     internal_repr: f64,
     param_name: &str,
     study_attrs: &Attrs,
-) -> PyResult<PyObject> {
+) -> PyResult<Bound<'py, PyAny>> {
     match dist {
-        Distribution::Float { .. } => {
-            let external_value =
-                Python::with_gil(|py| internal_repr.into_pyobject(py).map(|o| o.unbind().into()))?;
-            Ok(external_value)
-        }
-        Distribution::Int { .. } => {
-            let external_value = Python::with_gil(|py| {
-                (internal_repr as i64)
-                    .into_pyobject(py)
-                    .map(|o| o.unbind().into())
-            })?;
-            Ok(external_value)
-        }
+        Distribution::Float { .. } => Ok(internal_repr.into_pyobject(py)?.into_any()),
+        Distribution::Int { .. } => Ok((internal_repr as i64).into_pyobject(py)?.into_any()),
         Distribution::Categorical { cardinality } => {
             match get_category_labels(study_attrs, param_name, *cardinality) {
                 Some(labels) => {
@@ -235,17 +223,9 @@ pub fn py_to_external_repr(
                         .ok_or(PyValueError::new_err(
                             "Internal representation of categorical value is out of range",
                         ))?;
-                    let external_value = Python::with_gil(|py| category_label_to_pyobject(py, c))?;
-                    Ok(external_value)
+                    category_label_to_pyobject(py, c)
                 }
-                None => {
-                    let external_value = Python::with_gil(|py| {
-                        (internal_repr as i64)
-                            .into_pyobject(py)
-                            .map(|o| o.unbind().into())
-                    })?;
-                    Ok(external_value)
-                }
+                None => Ok((internal_repr as i64).into_pyobject(py)?.into_any()),
             }
         }
     }

--- a/rustuna_pyo3/src/distribution.rs
+++ b/rustuna_pyo3/src/distribution.rs
@@ -89,8 +89,8 @@ impl PyDistribution {
         Ok(py_dist)
     }
 
-    pub fn to_dict(&self) -> PyResult<PyObject> {
-        Python::with_gil(|py| match &self.distribution {
+    pub fn to_dict<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        match &self.distribution {
             Distribution::Float {
                 low,
                 high,
@@ -107,7 +107,7 @@ impl PyDistribution {
                 } else {
                     dist.set_item("step", py.None())?;
                 }
-                Ok(dist.into())
+                Ok(dist)
             }
             Distribution::Int {
                 low,
@@ -121,7 +121,7 @@ impl PyDistribution {
                 dist.set_item("high", high)?;
                 dist.set_item("log", log)?;
                 dist.set_item("step", step)?;
-                Ok(dist.into())
+                Ok(dist)
             }
             Distribution::Categorical { cardinality } => {
                 let dist = PyDict::new(py);
@@ -146,9 +146,9 @@ impl PyDistribution {
                 }
                 let choices = PyList::new(py, &elements)?;
                 dist.set_item("choices", choices)?;
-                Ok(dist.into())
+                Ok(dist)
             }
-        })
+        }
     }
 
     fn __repr__(slf: &Bound<'_, Self>) -> PyResult<String> {
@@ -158,7 +158,7 @@ impl PyDistribution {
     }
 
     fn __str__(&self) -> PyResult<String> {
-        Python::with_gil(|_py| Ok(self.to_dict()?.to_string()))
+        Python::with_gil(|py| Ok(self.to_dict(py)?.to_string()))
     }
 }
 

--- a/rustuna_pyo3/src/distribution.rs
+++ b/rustuna_pyo3/src/distribution.rs
@@ -101,7 +101,7 @@ impl PyDistribution {
                 step,
                 log,
             } => {
-                let dist = PyDict::new_bound(py);
+                let dist = PyDict::new(py);
                 dist.set_item("type", "FloatDistribution")?;
                 dist.set_item("low", low)?;
                 dist.set_item("high", high)?;
@@ -119,7 +119,7 @@ impl PyDistribution {
                 step,
                 log,
             } => {
-                let dist = PyDict::new_bound(py);
+                let dist = PyDict::new(py);
                 dist.set_item("type", "IntDistribution")?;
                 dist.set_item("low", low)?;
                 dist.set_item("high", high)?;
@@ -128,7 +128,7 @@ impl PyDistribution {
                 Ok(dist.into())
             }
             Distribution::Categorical { cardinality } => {
-                let dist = PyDict::new_bound(py);
+                let dist = PyDict::new(py);
                 dist.set_item("type", "CategoricalDistribution")?;
 
                 let mut elements: Vec<PyObject> = Vec::with_capacity(*cardinality);
@@ -146,9 +146,9 @@ impl PyDistribution {
                     let c = labels.get(i).ok_or(PyValueError::new_err(
                         "Internal representation of categorical value is out of range",
                     ))?;
-                    elements.push(category_label_to_pyobject(py, c));
+                    elements.push(category_label_to_pyobject(py, c)?);
                 }
-                let choices = PyList::new_bound(py, &elements);
+                let choices = PyList::new(py, &elements)?;
                 dist.set_item("choices", choices)?;
                 Ok(dist.into())
             }
@@ -166,13 +166,13 @@ impl PyDistribution {
     }
 }
 
-pub fn category_label_to_pyobject(py: Python, label: &CategoryLabel) -> PyObject {
+pub fn category_label_to_pyobject(py: Python, label: &CategoryLabel) -> PyResult<PyObject> {
     match label {
-        CategoryLabel::String(s) => s.into_py(py),
-        CategoryLabel::Int(i) => i.into_py(py),
-        CategoryLabel::Float(f) => f.into_py(py),
-        CategoryLabel::Bool(b) => b.into_py(py),
-        CategoryLabel::None => py.None(),
+        CategoryLabel::String(s) => Ok(s.into_pyobject(py)?.into_any().unbind()),
+        CategoryLabel::Int(i) => Ok(i.into_pyobject(py)?.into_any().unbind()),
+        CategoryLabel::Float(f) => Ok(f.into_pyobject(py)?.into_any().unbind()),
+        CategoryLabel::Bool(b) => Ok(PyBool::new(py, *b).to_owned().into()),
+        CategoryLabel::None => Ok(py.None()),
     }
 }
 
@@ -215,11 +215,16 @@ pub fn py_to_external_repr(
 ) -> PyResult<PyObject> {
     match dist {
         Distribution::Float { .. } => {
-            let external_value = Python::with_gil(|py| internal_repr.into_py(py));
+            let external_value =
+                Python::with_gil(|py| internal_repr.into_pyobject(py).map(|o| o.unbind().into()))?;
             Ok(external_value)
         }
         Distribution::Int { .. } => {
-            let external_value = Python::with_gil(|py| (internal_repr as i64).into_py(py));
+            let external_value = Python::with_gil(|py| {
+                (internal_repr as i64)
+                    .into_pyobject(py)
+                    .map(|o| o.unbind().into())
+            })?;
             Ok(external_value)
         }
         Distribution::Categorical { cardinality } => {
@@ -230,11 +235,15 @@ pub fn py_to_external_repr(
                         .ok_or(PyValueError::new_err(
                             "Internal representation of categorical value is out of range",
                         ))?;
-                    let external_value = Python::with_gil(|py| category_label_to_pyobject(py, c));
+                    let external_value = Python::with_gil(|py| category_label_to_pyobject(py, c))?;
                     Ok(external_value)
                 }
                 None => {
-                    let external_value = Python::with_gil(|py| (internal_repr as i64).into_py(py));
+                    let external_value = Python::with_gil(|py| {
+                        (internal_repr as i64)
+                            .into_pyobject(py)
+                            .map(|o| o.unbind().into())
+                    })?;
                     Ok(external_value)
                 }
             }

--- a/rustuna_pyo3/src/pyobject_storage.rs
+++ b/rustuna_pyo3/src/pyobject_storage.rs
@@ -132,8 +132,8 @@ impl PyObjectStorage {
 
     fn obj_set_study_attrs(&mut self, study_id: u32, attrs: Attrs) -> PyResult<()> {
         Python::with_gil(|py| {
-            let py_system_attrs = pyo3::types::PyDict::new_bound(py);
-            let py_user_attrs = pyo3::types::PyDict::new_bound(py);
+            let py_system_attrs = pyo3::types::PyDict::new(py);
+            let py_user_attrs = pyo3::types::PyDict::new(py);
             for (k, v) in attrs.into_iter() {
                 match k {
                     AttrKey::System(k) => {
@@ -159,8 +159,8 @@ impl PyObjectStorage {
         attrs: Attrs,
     ) -> PyResult<()> {
         Python::with_gil(|py| {
-            let py_system_attrs = pyo3::types::PyDict::new_bound(py);
-            let py_user_attrs = pyo3::types::PyDict::new_bound(py);
+            let py_system_attrs = pyo3::types::PyDict::new(py);
+            let py_user_attrs = pyo3::types::PyDict::new(py);
             for (k, v) in attrs.into_iter() {
                 match k {
                     AttrKey::System(k) => {

--- a/rustuna_pyo3/src/sampler.rs
+++ b/rustuna_pyo3/src/sampler.rs
@@ -252,9 +252,10 @@ impl Sampler for PyObjectSampler {
                 optuna_compatible: None,
                 kind: "unset",
             };
-            let py_search_space = PyDict::new_bound(py);
+            let py_search_space = PyDict::new(py);
             for (k, v) in search_space {
-                let py_distribution = PyDistribution::new(v.clone(), k, &study_attrs).into_py(py);
+                let py_distribution = Py::new(py, PyDistribution::new(v.clone(), k, &study_attrs))
+                    .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::SamplerError))?;
                 py_search_space
                     .set_item(k, py_distribution)
                     .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::SamplerError))?;

--- a/rustuna_pyo3/src/storage.rs
+++ b/rustuna_pyo3/src/storage.rs
@@ -127,13 +127,11 @@ impl PyStorage {
         param_name: String,
         choices: Vec<PyObject>,
     ) -> PyResult<()> {
-        let category_labels = Python::with_gil(|py| {
+        let category_labels = Python::with_gil(|py| -> PyResult<Vec<CategoryLabel>> {
             let mut labels: Vec<CategoryLabel> = Vec::with_capacity(choices.len());
             for choice in choices {
-                match pyobject_to_category_label(py, choice) {
-                    Ok(label) => labels.push(label),
-                    Err(e) => return Err(e),
-                }
+                let label = pyobject_to_category_label(choice.bind(py))?;
+                labels.push(label);
             }
             Ok(labels)
         })?;
@@ -154,15 +152,16 @@ impl PyStorage {
         Python::with_gil(
             |py| match get_category_labels(&study.attrs, &param_name, cardinality) {
                 Some(labels) => {
-                    let mut elements: Vec<PyObject> = Vec::with_capacity(cardinality);
-                    for i in 0..cardinality {
-                        let c = labels.get(i).ok_or(PyValueError::new_err(
-                            "Internal representation of categorical value is out of range",
-                        ))?;
-                        elements.push(category_label_to_pyobject(py, c)?);
-                    }
-                    let choices = PyList::new(py, &elements)?;
-                    Ok(choices.into())
+                    let elements: PyResult<Vec<_>> = (0..cardinality)
+                        .map(|i| {
+                            let c = labels.get(i).ok_or(PyValueError::new_err(
+                                "Internal representation of categorical value is out of range",
+                            ))?;
+                            category_label_to_pyobject(py, c)
+                        })
+                        .collect();
+                    let choices = PyList::new(py, elements?)?;
+                    Ok(choices.unbind().into_any())
                 }
                 None => Ok(py.None()),
             },

--- a/rustuna_pyo3/src/storage.rs
+++ b/rustuna_pyo3/src/storage.rs
@@ -159,9 +159,9 @@ impl PyStorage {
                         let c = labels.get(i).ok_or(PyValueError::new_err(
                             "Internal representation of categorical value is out of range",
                         ))?;
-                        elements.push(category_label_to_pyobject(py, c));
+                        elements.push(category_label_to_pyobject(py, c)?);
                     }
-                    let choices = PyList::new_bound(py, &elements);
+                    let choices = PyList::new(py, &elements)?;
                     Ok(choices.into())
                 }
                 None => Ok(py.None()),

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -417,8 +417,8 @@ impl PyStudy {
     }
 }
 
-#[derive(Clone, Debug)]
-#[pyclass(name = "StudyDirection")]
+#[derive(Clone, Debug, PartialEq)]
+#[pyclass(name = "StudyDirection", eq, eq_int)]
 #[pyo3(module = "rustuna")]
 pub enum PyDirection {
     #[pyo3(name = "MINIMIZE")]

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -119,7 +119,7 @@ impl PyTrial {
         let mut category_labels: Vec<CategoryLabel> = Vec::with_capacity(choices.len());
         let category_labels = Python::with_gil(|py| {
             for choice in choices {
-                match pyobject_to_category_label(py, choice) {
+                match pyobject_to_category_label(choice.bind(py)) {
                     Ok(label) => category_labels.push(label),
                     Err(e) => return Err(e),
                 }
@@ -138,7 +138,7 @@ impl PyTrial {
                 }
             })?;
 
-        Python::with_gil(|py| category_label_to_pyobject(py, label))
+        Python::with_gil(|py| category_label_to_pyobject(py, label).map(|b| b.unbind()))
     }
     #[pyo3(signature = (key, value))]
     pub fn set_user_attr(&mut self, key: &str, value: String) -> PyResult<()> {
@@ -259,17 +259,20 @@ impl PyPersistedTrial {
 
     #[getter]
     fn params(&self) -> PyResult<HashMap<String, PyObject>> {
-        self.0
-            .internal_params
-            .iter()
-            .map(|(name, internal_repr)| {
-                let maybe_pyobj: PyResult<PyObject> = match self.0.distributions.get(name) {
-                    Some(dist) => py_to_external_repr(dist, *internal_repr, name, &self.1),
-                    None => Err(PyValueError::new_err(format!("No distribution for {name}"))),
-                };
-                maybe_pyobj.map(|v| (name.to_string(), v))
-            })
-            .collect()
+        Python::with_gil(|py| {
+            self.0
+                .internal_params
+                .iter()
+                .map(|(name, internal_repr)| {
+                    let maybe_pyobj: PyResult<PyObject> = match self.0.distributions.get(name) {
+                        Some(dist) => py_to_external_repr(py, dist, *internal_repr, name, &self.1)
+                            .map(|b| b.unbind()),
+                        None => Err(PyValueError::new_err(format!("No distribution for {name}"))),
+                    };
+                    maybe_pyobj.map(|v| (name.to_string(), v))
+                })
+                .collect()
+        })
     }
 
     #[getter]

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -14,8 +14,8 @@ use crate::distribution::{
     category_label_to_pyobject, py_to_external_repr, pyobject_to_category_label, PyDistribution,
 };
 
-#[derive(Clone, Debug)]
-#[pyclass(name = "TrialState")]
+#[derive(Clone, Debug, PartialEq)]
+#[pyclass(name = "TrialState", eq, eq_int)]
 #[pyo3(module = "rustuna")]
 #[allow(clippy::upper_case_acronyms)]
 pub enum PyTrialState {

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -138,8 +138,7 @@ impl PyTrial {
                 }
             })?;
 
-        let return_value = Python::with_gil(|py| category_label_to_pyobject(py, label));
-        Ok(return_value)
+        Python::with_gil(|py| category_label_to_pyobject(py, label))
     }
     #[pyo3(signature = (key, value))]
     pub fn set_user_attr(&mut self, key: &str, value: String) -> PyResult<()> {
@@ -303,23 +302,21 @@ impl PyPersistedTrial {
 
     fn __repr__(slf: &Bound<'_, Self>) -> PyResult<String> {
         let type_obj = slf.get_type();
-        let class_name = type_obj.name()?;
-        Ok(format!(
-            "{}({})",
-            class_name.as_ref(),
-            slf.borrow().__str__()?
-        ))
+        let class_name = type_obj.name()?.to_string_lossy().into_owned();
+        Ok(format!("{}({})", class_name, slf.borrow().__str__()?))
     }
 
     fn __str__(&self) -> PyResult<String> {
-        let params: PyResult<String> =
-            Python::with_gil(|py| Ok(self.params()?.to_object(py).to_string()));
+        let params = Python::with_gil(|py| -> PyResult<String> {
+            let py_params = self.params()?.into_pyobject(py)?;
+            Ok(py_params.str()?.to_str()?.to_owned())
+        })?;
         Ok(format!(
             "number={} state={:?} values={:?} params={} distributions={:?} user_attrs={:?} system_attrs={:?}",
             self.number()?,
             self.state()?,
             self.values(),
-            params?,
+            params,
             self.distributions()?,
             self.user_attrs()?,
             self.system_attrs()?,

--- a/rustuna_samplers/src/nsgaii.rs
+++ b/rustuna_samplers/src/nsgaii.rs
@@ -369,12 +369,7 @@ fn calc_crowding_distance(
             .collect::<Vec<_>>();
 
         let min_value = values.iter().cloned().find(|v| v.is_finite()).unwrap();
-        let max_value = values
-            .iter()
-            .cloned()
-            .filter(|v| v.is_finite())
-            .next_back()
-            .unwrap();
+        let max_value = values.iter().cloned().rfind(|v| v.is_finite()).unwrap();
 
         let mut width = max_value - min_value;
         if width <= 0.0 {


### PR DESCRIPTION
Follow-up #15 

This PR updates the PyO3 version from 0.22 to 0.25. Please refer to following page for details.

* https://pyo3.rs/v0.22.0/migration.html
* https://pyo3.rs/v0.23.0/migration.html
* https://pyo3.rs/v0.25.0/migration.html