### PR TITLE
Use optuna's master branch to test storages

### DIFF
--- a/rustuna_pyo3/pyproject.toml
+++ b/rustuna_pyo3/pyproject.toml
@@ -22,8 +22,7 @@ ignore = ["E501"]
 
 [dependency-groups]
 dev = [
-    # TODO(c-bata): Change to optuna/optuna@master after merging Optuna PR #6391.
-    "optuna @ git+https://github.com/c-bata/optuna.git@follow-up-storage-test-case",
+    "optuna @ git+https://github.com/optuna/optuna.git@master",
     "ruff",
     "pytest",
     "mypy",


### PR DESCRIPTION
Since https://github.com/optuna/optuna/pull/6391 was merged, it's ready to use Optuna's master branch to use `StorageTestCase` class.