### PR TITLE
Enforce clippy warnings as errors in CI

### DIFF
--- a/.github/workflows/checks_rust.yml
+++ b/.github/workflows/checks_rust.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt, clippy
-      - run: cargo clippy
+      - run: cargo clippy --all-targets -- -D warnings
       - name: Rustfmt Check
         uses: actions-rust-lang/rustfmt@v1
   rust_test:

--- a/.github/workflows/checks_rust.yml
+++ b/.github/workflows/checks_rust.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt, clippy
-      - run: cargo clippy --all-targets -- -D warnings
+      - run: cargo clippy --lib --tests -- -D warnings
       - name: Rustfmt Check
         uses: actions-rust-lang/rustfmt@v1
   rust_test:

--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -207,9 +207,7 @@ impl ParzenEstimator {
             let col = v as usize;
             assert!(
                 col < cardinality,
-                "Observed index {} out of range (cardinality = {})",
-                col,
-                cardinality
+                "Observed index {col} out of range (cardinality = {cardinality})"
             );
             weights[i][col] += 1.0;
         }
@@ -290,7 +288,7 @@ mod tests {
         );
 
         let parzen_estimator =
-            ParzenEstimator::new(&observations, &search_space, &vec![0.2, 0.5, 0.3], 1.0);
+            ParzenEstimator::new(&observations, &search_space, &[0.2, 0.5, 0.3], 1.0);
         let mut rng = StdRng::seed_from_u64(42);
         let samples = parzen_estimator.sample(&mut rng, 10);
         assert_eq!(samples.len(), 10);

--- a/rustuna_core/src/parzen_estimator/probability_distributions.rs
+++ b/rustuna_core/src/parzen_estimator/probability_distributions.rs
@@ -210,7 +210,7 @@ impl MixtureOfProductDistribution {
                     Distributions::Categorical(d) => {
                         let probs = &d.weights[k];
                         let sum: f64 = probs.iter().sum();
-                        assert!(sum > 0.0, "Categorical distribution has non-positive total probability for param {}", param);
+                        assert!(sum > 0.0, "Categorical distribution has non-positive total probability for param {param}");
 
                         let u = rng.gen::<f64>() * sum;
                         let mut cum = 0.0;

--- a/rustuna_samplers/examples/quadratic.rs
+++ b/rustuna_samplers/examples/quadratic.rs
@@ -29,6 +29,6 @@ fn main() -> Result<()> {
 
     let best_trial_number = get_best_trial(&study)?;
     let trial = study.get_trials()?[best_trial_number as usize].clone();
-    println!("Best trial: {:?}", trial);
+    println!("Best trial: {trial:?}");
     Ok(())
 }

--- a/rustuna_storages/src/cache.rs
+++ b/rustuna_storages/src/cache.rs
@@ -919,8 +919,7 @@ mod tests {
         let trial1 = storage.create_new_trial(study_id)?.clone();
         let err = storage
             .set_trial_param(study_id, trial1.number, "x", &int_dist, 1.0)
-            .err()
-            .expect("Expected IncompatibleDistribution error");
+            .expect_err("Expected IncompatibleDistribution error");
         assert!(matches!(err.kind, ErrorKind::IncompatibleDistribution));
         Ok(())
     }

--- a/rustuna_storages/src/sqlite3.rs
+++ b/rustuna_storages/src/sqlite3.rs
@@ -1977,8 +1977,7 @@ mod tests {
         );
         let err = storage
             .set_study_attrs(study_id, overwrite, true)
-            .err()
-            .expect("Expected AttrOverwriteNotAllowed error");
+            .expect_err("Expected AttrOverwriteNotAllowed error");
         assert!(matches!(err.kind, ErrorKind::AttrOverwriteNotAllowed));
 
         let study = storage.get_study(study_id)?;
@@ -2055,8 +2054,7 @@ mod tests {
         );
         let err = storage
             .set_trial_attrs(study_id, trial.number, overwrite, true)
-            .err()
-            .expect("Expected AttrOverwriteNotAllowed error");
+            .expect_err("Expected AttrOverwriteNotAllowed error");
         assert!(matches!(err.kind, ErrorKind::AttrOverwriteNotAllowed));
 
         let trial = storage.get_trial(study_id, trial.number)?;
@@ -2345,8 +2343,7 @@ mod tests {
         invalid_values.insert(0, 0.5);
         let err = storage
             .set_trial_intermediate_values(non_existent_trial_id, invalid_values)
-            .err()
-            .expect("Expected TrialNotFound error");
+            .expect_err("Expected TrialNotFound error");
         assert!(matches!(err.kind, ErrorKind::TrialNotFound));
 
         Ok(())


### PR DESCRIPTION
This PR enforces clippy warnings as errors in CI to prevent unchecked code style issues across the codebase.