### PR TITLE
Refactor `ParzenEstimator`

### DIFF
--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -231,6 +231,31 @@ impl ParzenEstimator {
     }
 }
 
+pub trait ParzenDistributionBuilder {
+    fn calculate_distribution(&self, observations: &[f64], search_space: &Distribution) -> Distributions {
+        match search_space {
+            Distribution::Float { .. } | Distribution::Int { .. } => {
+                self.calculate_numerical_distribution(observations, search_space)
+            }
+            Distribution::Categorical { .. } => {
+                self.calculate_categorical_distribution(observations, search_space)
+            }
+        }
+    }
+
+    fn calculate_numerical_distribution(
+        &self,
+        observations: &[f64],
+        search_space: &Distribution,
+    ) -> Distributions;
+
+    fn calculate_categorical_distribution(
+        &self,
+        observations: &[f64],
+        search_space: &Distribution,
+    ) -> Distributions;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -93,13 +93,11 @@ impl ParzenEstimator {
             _ => unreachable!("Invalid distribution type for numerical calculation"),
         };
 
-        // Handle step
         let (mut adj_low, mut adj_high) = match step_opt {
             Some(s) => (low - s / 2.0, high + s / 2.0),
             None => (low, high),
         };
 
-        // Handle log scale
         if log {
             adj_low = adj_low.ln();
             adj_high = adj_high.ln();

--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -256,6 +256,8 @@ pub trait ParzenDistributionBuilder {
     ) -> Distributions;
 }
 
+pub struct DefaultParazenDistributionBuilder;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -42,15 +42,16 @@ impl ParzenEstimator {
             distributions.insert((*key).clone(), dist);
         }
 
-        let mut weights_sum = weights.iter().sum::<f64>() + prior_weight;
-        if weights_sum == 0.0 {
-            weights_sum = (weights.len() + 1) as f64;
-        }
-        let mut weights_with_prior_weight: Vec<f64> = Vec::with_capacity(weights.len() + 1);
-        for &w in weights.iter() {
-            weights_with_prior_weight.push(w / weights_sum);
-        }
-        weights_with_prior_weight.push(prior_weight / weights_sum);
+        let weights_sum = {
+            let s = weights.iter().sum::<f64>() + prior_weight;
+            if s == 0.0 { (weights.len() + 1) as f64 } else { s }
+        };
+
+        let weights_with_prior_weight= weights
+            .iter()
+            .chain(std::iter::once(&prior_weight))
+            .map(|w| w / weights_sum)
+            .collect();
 
         ParzenEstimator {
             mixuture_distribution: MixtureOfProductDistribution::new(

--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -97,9 +97,9 @@ pub trait CategoricalDistributionBuilder {
     ) -> Distributions;
 }
 
-pub struct DefaultParazenDistributionBuilder;
+pub struct DefaultNumericalDistributionBuilder;
 
-impl ParzenDistributionBuilder for DefaultParazenDistributionBuilder {
+impl NumericalDistributionBuilder for DefaultNumericalDistributionBuilder {
     fn calculate_numerical_distribution(
         &self,
         observations: &[f64],

--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -1,5 +1,4 @@
 use rand::rngs::StdRng;
-use std::cmp::Ordering;
 use std::{collections::HashMap, vec};
 
 use super::probability_distributions::CategoricalDistributions;

--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -20,6 +20,24 @@ impl ParzenEstimator {
         weights: &[f64],
         prior_weight: f64,
     ) -> Self {
+        Self::new_with_builder(
+            observations,
+            search_space,
+            weights,
+            prior_weight,
+            &DefaultNumericalDistributionBuilder,
+            &DefaultCategoricalDistributionBuilder,
+        )
+    }
+
+    pub fn new_with_builder(
+        observations: &HashMap<String, Vec<f64>>,
+        search_space: &HashMap<String, Distribution>,
+        weights: &[f64],
+        prior_weight: f64,
+        num_builder: &impl NumericalDistributionBuilder,
+        cat_builder: &impl CategoricalDistributionBuilder,
+    ) -> Self {
         let n_observations = observations.values().next().map_or(0, |v| {
             assert!(
                 observations.values().all(|w| w.len() == v.len()),

--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -247,14 +247,12 @@ impl CategoricalDistributionBuilder for DefaultCategoricalDistributionBuilder {
 
         let n_kernels = observations.len() + 1; // +1 for prior
         let prior_mass_per_kernel = 1.0 / (n_kernels as f64);
-        let mut weights: Vec<Vec<f64>> = vec![vec![prior_mass_per_kernel; cardinality]; n_kernels];
+        let mut weights = vec![vec![prior_mass_per_kernel; cardinality]; n_kernels];
         for (i, &v) in observations.iter().enumerate() {
             let col = v as usize;
             assert!(
                 col < cardinality,
-                "Observed index {} out of range (cardinality = {})",
-                col,
-                cardinality
+                "Observed index {col} out of range (cardinality = {cardinality})",
             );
             weights[i][col] += 1.0;
         }

--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -56,7 +56,14 @@ impl ParzenEstimator {
         let mut distributions = HashMap::with_capacity(keys.len());
         for key in keys.iter() {
             let obs_vec = observations.get(*key).map(Vec::as_slice).unwrap_or(&[]);
-            let dist = Self::calculate_distribution(obs_vec, &search_space[*key]);
+            let dist = match &search_space[*key] {
+                Distribution::Float { .. } | Distribution::Int { .. } => {
+                    num_builder.calculate_numerical_distribution(obs_vec, &search_space[*key])
+                }
+                Distribution::Categorical { .. } => {
+                    cat_builder.calculate_categorical_distribution(obs_vec, &search_space[*key])
+                }
+            };
             distributions.insert((*key).clone(), dist);
         }
 

--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -27,17 +27,17 @@ impl ParzenEstimator {
             );
             v.len()
         });
-        assert!(
-            n_observations == weights.len(),
+        assert_eq!(
+            n_observations, weights.len(),
             "Number of observations and length of weights must be equal"
         );
 
-        let mut keys: Vec<&String> = search_space.keys().collect();
+        let mut keys: Vec<_> = search_space.keys().collect();
         keys.sort();
 
-        let mut distributions = HashMap::<String, Distributions>::with_capacity(keys.len());
+        let mut distributions = HashMap::with_capacity(keys.len());
         for key in keys.iter() {
-            let obs_vec = observations.get(*key).map(|v| v.as_slice()).unwrap_or(&[]);
+            let obs_vec = observations.get(*key).map(Vec::as_slice).unwrap_or(&[]);
             let dist = Self::calculate_distribution(obs_vec, &search_space[*key]);
             distributions.insert((*key).clone(), dist);
         }
@@ -53,7 +53,7 @@ impl ParzenEstimator {
             .map(|w| w / weights_sum)
             .collect();
 
-        ParzenEstimator {
+        Self {
             mixuture_distribution: MixtureOfProductDistribution::new(
                 distributions,
                 weights_with_prior_weight,

--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -72,7 +72,45 @@ impl ParzenEstimator {
         }
     }
 
+    pub fn sample(&self, rng: &mut StdRng, size: usize) -> Vec<HashMap<String, f64>> {
+        self.mixuture_distribution.sample(rng, size)
+    }
+
+    pub fn log_pdf(&self, x: &HashMap<String, f64>) -> f64 {
+        self.mixuture_distribution.log_pdf(x)
+    }
+}
+
+pub trait ParzenDistributionBuilder {
+    fn calculate_distribution(&self, observations: &[f64], search_space: &Distribution) -> Distributions {
+        match search_space {
+            Distribution::Float { .. } | Distribution::Int { .. } => {
+                self.calculate_numerical_distribution(observations, search_space)
+            }
+            Distribution::Categorical { .. } => {
+                self.calculate_categorical_distribution(observations, search_space)
+            }
+        }
+    }
+
     fn calculate_numerical_distribution(
+        &self,
+        observations: &[f64],
+        search_space: &Distribution,
+    ) -> Distributions;
+
+    fn calculate_categorical_distribution(
+        &self,
+        observations: &[f64],
+        search_space: &Distribution,
+    ) -> Distributions;
+}
+
+pub struct DefaultParazenDistributionBuilder;
+
+impl ParzenDistributionBuilder for DefaultParazenDistributionBuilder {
+    fn calculate_numerical_distribution(
+        &self,
         observations: &[f64],
         search_space: &Distribution,
     ) -> Distributions {
@@ -182,6 +220,7 @@ impl ParzenEstimator {
     }
 
     fn calculate_categorical_distribution(
+        &self,
         observations: &[f64],
         search_space: &Distribution,
     ) -> Distributions {
@@ -221,42 +260,7 @@ impl ParzenEstimator {
 
         Distributions::Categorical(CategoricalDistributions { weights })
     }
-
-    pub fn sample(&self, rng: &mut StdRng, size: usize) -> Vec<HashMap<String, f64>> {
-        self.mixuture_distribution.sample(rng, size)
-    }
-
-    pub fn log_pdf(&self, x: &HashMap<String, f64>) -> f64 {
-        self.mixuture_distribution.log_pdf(x)
-    }
 }
-
-pub trait ParzenDistributionBuilder {
-    fn calculate_distribution(&self, observations: &[f64], search_space: &Distribution) -> Distributions {
-        match search_space {
-            Distribution::Float { .. } | Distribution::Int { .. } => {
-                self.calculate_numerical_distribution(observations, search_space)
-            }
-            Distribution::Categorical { .. } => {
-                self.calculate_categorical_distribution(observations, search_space)
-            }
-        }
-    }
-
-    fn calculate_numerical_distribution(
-        &self,
-        observations: &[f64],
-        search_space: &Distribution,
-    ) -> Distributions;
-
-    fn calculate_categorical_distribution(
-        &self,
-        observations: &[f64],
-        search_space: &Distribution,
-    ) -> Distributions;
-}
-
-pub struct DefaultParazenDistributionBuilder;
 
 #[cfg(test)]
 mod tests {

--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -45,7 +45,8 @@ impl ParzenEstimator {
             v.len()
         });
         assert_eq!(
-            n_observations, weights.len(),
+            n_observations,
+            weights.len(),
             "Number of observations and length of weights must be equal"
         );
 
@@ -68,10 +69,14 @@ impl ParzenEstimator {
 
         let weights_sum = {
             let s = weights.iter().sum::<f64>() + prior_weight;
-            if s == 0.0 { (weights.len() + 1) as f64 } else { s }
+            if s == 0.0 {
+                (weights.len() + 1) as f64
+            } else {
+                s
+            }
         };
 
-        let weights_with_prior_weight= weights
+        let weights_with_prior_weight = weights
             .iter()
             .chain(std::iter::once(&prior_weight))
             .map(|w| w / weights_sum)
@@ -161,7 +166,7 @@ impl NumericalDistributionBuilder for DefaultNumericalDistributionBuilder {
             let mut idx_vals: Vec<(usize, f64)> = (0..m).map(|i| (i, mus[i])).collect();
             idx_vals.sort_by(|a, b| a.1.total_cmp(&b.1));
             let sorted_mus = idx_vals.iter().map(|&(_, v)| v);
-            
+
             let extended = std::iter::once(adj_low)
                 .chain(sorted_mus)
                 .chain(std::iter::once(adj_high))
@@ -324,7 +329,7 @@ mod tests {
         );
 
         let parzen_estimator =
-            ParzenEstimator::new(&observations, &search_space, &vec![0.2, 0.5, 0.3], 1.0);
+            ParzenEstimator::new(&observations, &search_space, &[0.2, 0.5, 0.3], 1.0);
         let mut rng = StdRng::seed_from_u64(42);
         let samples = parzen_estimator.sample(&mut rng, 10);
         assert_eq!(samples.len(), 10);

--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -98,6 +98,7 @@ pub trait CategoricalDistributionBuilder {
 }
 
 pub struct DefaultNumericalDistributionBuilder;
+pub struct DefaultCategoricalDistributionBuilder;
 
 impl NumericalDistributionBuilder for DefaultNumericalDistributionBuilder {
     fn calculate_numerical_distribution(
@@ -209,7 +210,9 @@ impl NumericalDistributionBuilder for DefaultNumericalDistributionBuilder {
             }
         }
     }
+}
 
+impl CategoricalDistributionBuilder for DefaultCategoricalDistributionBuilder {
     fn calculate_categorical_distribution(
         &self,
         observations: &[f64],

--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -81,24 +81,15 @@ impl ParzenEstimator {
     }
 }
 
-pub trait ParzenDistributionBuilder {
-    fn calculate_distribution(&self, observations: &[f64], search_space: &Distribution) -> Distributions {
-        match search_space {
-            Distribution::Float { .. } | Distribution::Int { .. } => {
-                self.calculate_numerical_distribution(observations, search_space)
-            }
-            Distribution::Categorical { .. } => {
-                self.calculate_categorical_distribution(observations, search_space)
-            }
-        }
-    }
-
+pub trait NumericalDistributionBuilder {
     fn calculate_numerical_distribution(
         &self,
         observations: &[f64],
         search_space: &Distribution,
     ) -> Distributions;
+}
 
+pub trait CategoricalDistributionBuilder {
     fn calculate_categorical_distribution(
         &self,
         observations: &[f64],

--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -133,8 +133,8 @@ impl ParzenEstimator {
                 .collect::<Vec<_>>();
 
             sigmas.resize(m, 0.0);
-            for (i, &(orig_idx, _)) in idx_vals.iter().enumerate() {
-                sigmas[orig_idx] = sorted_sigmas[i];
+            for (&(orig_idx, _), &sigma) in idx_vals.iter().zip(sorted_sigmas.iter()) {
+                sigmas[orig_idx] = sigma;
             }
             // Sigma for prior
             sigmas.push(adj_high - adj_low);
@@ -160,22 +160,22 @@ impl ParzenEstimator {
                 low,
                 high,
             }),
-            (Some(value), false) => {
+            (Some(step), false) => {
                 Distributions::DiscreteTruncNorm(DiscreteTruncNormDistributions {
                     mus,
                     sigmas,
                     low,
                     high,
-                    step: value,
+                    step,
                 })
             }
-            (Some(value), true) => {
+            (Some(step), true) => {
                 Distributions::DiscreteTruncLogNorm(DiscreteTruncLogNormDistributions {
                     mus,
                     sigmas,
                     low,
                     high,
-                    step: value,
+                    step,
                 })
             }
         }

--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -95,7 +95,7 @@ impl ParzenEstimator {
     }
 }
 
-pub trait NumericalDistributionBuilder {
+pub(crate) trait NumericalDistributionBuilder {
     fn calculate_numerical_distribution(
         &self,
         observations: &[f64],
@@ -103,7 +103,7 @@ pub trait NumericalDistributionBuilder {
     ) -> Distributions;
 }
 
-pub trait CategoricalDistributionBuilder {
+pub(crate) trait CategoricalDistributionBuilder {
     fn calculate_categorical_distribution(
         &self,
         observations: &[f64],

--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -103,35 +103,34 @@ impl ParzenEstimator {
             adj_high = adj_high.ln();
         }
 
-        let mut mus: Vec<f64> = Vec::with_capacity(observations.len() + 1);
-        for &m in observations.iter() {
-            mus.push(if log { m.ln() } else { m });
-        }
-        mus.push((adj_low + adj_high) / 2.0); // Add prior
+        let mus = observations
+            .iter()
+            .map(|&m| if log { m.ln() } else { m })
+            .chain(std::iter::once((adj_low + adj_high) / 2.0)) // Add prior
+            .collect::<Vec<_>>();
 
-        let mut sigmas: Vec<f64> = Vec::with_capacity(mus.len());
+        let mut sigmas = Vec::with_capacity(mus.len());
         if mus.len() == 1 {
             // Case: prior only
             sigmas.push(adj_high - adj_low);
         } else {
             let m = mus.len() - 1; // exclude prior
             let mut idx_vals: Vec<(usize, f64)> = (0..m).map(|i| (i, mus[i])).collect();
-            idx_vals.sort_by(|a, b| match a.1.partial_cmp(&b.1) {
-                Some(ord) => ord,
-                None => Ordering::Equal,
-            });
-            let sorted_mus: Vec<f64> = idx_vals.iter().map(|&(_, v)| v).collect();
-            let mut extended = Vec::with_capacity(sorted_mus.len() + 2);
-            extended.push(adj_low);
-            extended.extend_from_slice(&sorted_mus);
-            extended.push(adj_high);
+            idx_vals.sort_by(|a, b| a.1.total_cmp(&b.1));
+            let sorted_mus = idx_vals.iter().map(|&(_, v)| v);
+            
+            let extended = std::iter::once(adj_low)
+                .chain(sorted_mus)
+                .chain(std::iter::once(adj_high))
+                .collect::<Vec<_>>();
 
-            let mut sorted_sigmas: Vec<f64> = Vec::with_capacity(m);
-            for i in 1..(extended.len() - 1) {
-                let left_diff = extended[i] - extended[i - 1];
-                let right_diff = extended[i + 1] - extended[i];
-                sorted_sigmas.push(left_diff.max(right_diff));
-            }
+            let sorted_sigmas = (1..(extended.len() - 1))
+                .map(|i| {
+                    let left_diff = extended[i] - extended[i - 1];
+                    let right_diff = extended[i + 1] - extended[i];
+                    left_diff.max(right_diff)
+                })
+                .collect::<Vec<_>>();
 
             sigmas.resize(m, 0.0);
             for (i, &(orig_idx, _)) in idx_vals.iter().enumerate() {
@@ -142,7 +141,7 @@ impl ParzenEstimator {
 
             // Clamp (minsigma, maxsigma)
             let maxsigma = adj_high - adj_low;
-            let minsigma = (adj_high - adj_low) / (100.0f64.min(1.0 + sigmas.len() as f64));
+            let minsigma = (adj_high - adj_low) / (100.0_f64.min(1.0 + sigmas.len() as f64));
             for s in sigmas.iter_mut() {
                 *s = s.clamp(minsigma, maxsigma);
             }

--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -29,7 +29,7 @@ impl ParzenEstimator {
         )
     }
 
-    pub fn new_with_builder(
+    pub(crate) fn new_with_builder(
         observations: &HashMap<String, Vec<f64>>,
         search_space: &HashMap<String, Distribution>,
         weights: &[f64],

--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -86,17 +86,6 @@ impl ParzenEstimator {
         }
     }
 
-    fn calculate_distribution(observations: &[f64], search_space: &Distribution) -> Distributions {
-        match search_space {
-            Distribution::Float { .. } | Distribution::Int { .. } => {
-                Self::calculate_numerical_distribution(observations, search_space)
-            }
-            Distribution::Categorical { .. } => {
-                Self::calculate_categorical_distribution(observations, search_space)
-            }
-        }
-    }
-
     pub fn sample(&self, rng: &mut StdRng, size: usize) -> Vec<HashMap<String, f64>> {
         self.mixuture_distribution.sample(rng, size)
     }


### PR DESCRIPTION
## Motivation

Currently, the `ParzenEstimator` struct has fixed implementations for `calculate_numerical_distribution` and `calculate_categorical_distribution`. Because Rust does not support method overriding via inheritance, we need to refactor the implementation so that these distribution-building routines can be replaced. This is required to implement the Rust counterpart of Optuna’s `_ScottParzenEstimator`.

## Description of the changes

- Extract `calculate_numerical_distribution` and `calculate_categorical_distribution` from `ParzenEstimator` into the `NumericalDistributionBuilder` and `CategoricalDistributionBuilder` traits, respectively.


## Sanity check

I verified that this branch produces identical output to main for the quadratic example by running the following script:
```bash
#!/bin/bash

git switch main
master=$(git rev-parse HEAD)
cargo run -p rustuna_samplers --example quadratic > ${master}.txt

git switch kAIto47802/refactor-parzen-estimator
refactor=$(git rev-parse HEAD)
cargo run -p rustuna_samplers --example quadratic > ${refactor}.txt

if cmp -s ${master}.txt ${refactor}.txt; then
    echo "Both branches produce the same output."
    exit 0
else
    echo "The outputs differ between the branches."
    exit 1
fi
```