### PR TITLE
Expose Python APIs for `JournalStorage`

### DIFF
--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -257,6 +257,11 @@ class Storage:
     def sqlite3(
         cls, file_path: str, *, create_database: bool = False
     ) -> OptunaStorageProtocol: ...
+    @classmethod
+    def journal_file(
+        cls,
+        file_path: str,
+    ) -> OptunaStorageProtocol: ...
 
 # Sampler
 class SamplerContext:

--- a/rustuna_pyo3/src/storage.rs
+++ b/rustuna_pyo3/src/storage.rs
@@ -11,6 +11,8 @@ use rustuna_core::storage::{InMemoryStorage, Storage};
 use rustuna_core::study::Direction;
 use rustuna_core::trial::TrialStateValues;
 use rustuna_storages::cache::CachedStorage;
+use rustuna_storages::journal::file::{JournalFileBackend, JournalFileSymlinkLock};
+use rustuna_storages::journal::storage::JournalStorage;
 use rustuna_storages::optuna::OptunaCompatibleStorage;
 use rustuna_storages::sqlite3::SQLite3Storage;
 
@@ -57,6 +59,25 @@ impl PyStorage {
             storage: arc_storage.clone(),
             optuna_compatible: Some(arc_storage),
             kind: "sqlite3",
+        })
+    }
+
+    #[classmethod]
+    #[pyo3(name = "journal_file", signature = (file_path,))]
+    fn journal_file(_cls: &Bound<'_, PyType>, file_path: &str) -> PyResult<Self> {
+        // TODO(c-bata): Add lock_obj argument to use JournalFileOpenLock.
+        let lock_obj = Box::new(JournalFileSymlinkLock::new(file_path));
+        let backend = JournalFileBackend::new(file_path, Some(lock_obj)).map_err(|e| {
+            PyRuntimeError::new_err(format!("Failed to create journal file: {e:?}"))
+        })?;
+        let storage = JournalStorage::new(Box::new(backend)).map_err(|e| {
+            PyRuntimeError::new_err(format!("Failed to create journal storage: {e:?}"))
+        })?;
+        let arc_storage = Arc::new(RwLock::new(storage));
+        Ok(PyStorage {
+            storage: arc_storage.clone(),
+            optuna_compatible: Some(arc_storage),
+            kind: "journal",
         })
     }
 

--- a/rustuna_pyo3/tests/test_to_optuna_storage.py
+++ b/rustuna_pyo3/tests/test_to_optuna_storage.py
@@ -10,6 +10,7 @@ from optuna.study import StudyDirection
 from optuna.testing.pytest_storages import StorageTestCase
 from optuna.trial._frozen import FrozenTrial
 from optuna.trial._state import TrialState
+from pytest import FixtureRequest
 
 import rustuna
 from rustuna.converter import ToOptunaStorage
@@ -20,14 +21,21 @@ if TYPE_CHECKING:
     from optuna.storages import BaseStorage
 
 
-@pytest.fixture
-def storage() -> Generator[BaseStorage, None, None]:
+@pytest.fixture(params=["sqlite3", "journal-file"])
+def storage(request: FixtureRequest) -> Generator[BaseStorage, None, None]:
     with tempfile.TemporaryDirectory() as workdir:
-        file_path = f"{workdir}/test.db"
-        rustuna_storage = rustuna.Storage.sqlite3(file_path, create_database=True)
-        storage = ToOptunaStorage(rustuna_storage)
+        if request.param == "sqlite3":
+            file_path = f"{workdir}/test.db"
+            rustuna_storage = rustuna.Storage.sqlite3(file_path, create_database=True)
+            storage = ToOptunaStorage(rustuna_storage)
 
-        yield storage
+            yield storage
+        else:
+            file_path = f"{workdir}/test.journal"
+            rustuna_storage = rustuna.Storage.journal_file(file_path)
+            storage = ToOptunaStorage(rustuna_storage)
+
+            yield storage
 
 
 class TestSQLite3Storage(StorageTestCase):
@@ -114,6 +122,18 @@ class TestSQLite3Storage(StorageTestCase):
         trials = storage.get_all_trials(study_id) + storage.get_all_trials(study_id2)
         # Check trial_ids are unique across studies.
         assert len({t._trial_id for t in trials}) == 2 * n_trial_in_study
+
+    def test_get_all_trials_uses_cache_diff(self, storage: BaseStorage) -> None:
+        study_id = storage.create_new_study(directions=[StudyDirection.MINIMIZE])
+        trial_id0 = storage.create_new_trial(study_id)
+        trials1 = storage.get_all_trials(study_id)
+        assert len(trials1) == 1
+        assert {t._trial_id for t in trials1} == {trial_id0}
+
+        trial_id1 = storage.create_new_trial(study_id)
+        trials2 = storage.get_all_trials(study_id)
+        assert len(trials2) == 2
+        assert {t._trial_id for t in trials2} == {trial_id0, trial_id1}
 
     @pytest.mark.skip("Fix me!")
     def test_set_trial_state_values_for_values(self, storage: BaseStorage) -> None:

--- a/rustuna_storages/src/journal/storage.rs
+++ b/rustuna_storages/src/journal/storage.rs
@@ -192,12 +192,7 @@ impl Storage for JournalStorage {
         fields.insert("param_name".to_string(), Value::String(name.to_string()));
         fields.insert(
             "param_value_internal".to_string(),
-            Value::Number(Number::from_f64(value).ok_or_else(|| {
-                Error::with_reason(
-                    ErrorKind::StorageError,
-                    format!("Failed to convert f64 to JSON number: value={value}"),
-                )
-            })?),
+            Value::String(format!("{value:.17e}")),
         );
         fields.insert("distribution".to_string(), Value::String(dist_json));
         self.write_log(JournalOperation::SetTrialParam, fields)?;


### PR DESCRIPTION
This PR adds support for the Python API of `JournalStorage` with `JournalFileBackend`. In addition, `JournalStorage` can now be tested using Optuna’s `StorageTestCase` scenarios. The Python API is look like below:

```python
import rustuna
from rustuna.converter import ToOptunaStorage

rustuna_storage = rustuna.Storage.journal_file("rustuna.journal")
optuna_storage = ToOptunaStorage(rustuna_storage)
```