### PR TITLE
Simplifying Storage implementation by introducing `trial_id`.

### DIFF
--- a/rustuna_core/src/storage.rs
+++ b/rustuna_core/src/storage.rs
@@ -83,6 +83,39 @@ impl InMemoryStorage {
             next_trial_id: 0,
         }
     }
+
+    pub fn insert_trial_with_id(
+        &mut self,
+        study_id: u32,
+        trial_id: u32,
+        number: u32,
+    ) -> Result<&PersistedTrial> {
+        let trials = get_mut_trials_by_study_id(&mut self.trials, study_id)?;
+        let trials_len = trials.len() as u32;
+        if number > trials_len {
+            return Err(Error::new(ErrorKind::StorageError));
+        }
+        if number < trials_len {
+            let trial = trials
+                .get(number as usize)
+                .ok_or(Error::new(ErrorKind::TrialNotFound))?;
+            if trial.id != trial_id {
+                return Err(Error::new(ErrorKind::StorageError));
+            }
+            return Ok(trial);
+        }
+        if self.trial_id_to_study_number.contains_key(&trial_id) {
+            return Err(Error::new(ErrorKind::StorageError));
+        }
+        let trial = PersistedTrial::new(trial_id, study_id, number);
+        trials.push(trial);
+        self.trial_id_to_study_number
+            .insert(trial_id, (study_id, number));
+        if trial_id >= self.next_trial_id {
+            self.next_trial_id = trial_id + 1;
+        }
+        Ok(&trials[number as usize])
+    }
 }
 fn get_trials_by_study_id(
     all_trials: &HashMap<u32, Vec<PersistedTrial>>,
@@ -359,6 +392,20 @@ mod tests {
             .err()
             .unwrap();
         assert!(matches!(err.kind, ErrorKind::IncompatibleDistribution));
+        Ok(())
+    }
+
+    #[test]
+    fn insert_trial_with_id_updates_next_trial_id() -> Result<()> {
+        let mut storage = InMemoryStorage::new();
+        let study_id = storage
+            .create_new_study("study", vec![Direction::Minimize])?
+            .id;
+
+        let trial = storage.insert_trial_with_id(study_id, 10, 0)?;
+        assert_eq!(trial.id, 10);
+        let trial = storage.create_new_trial(study_id)?;
+        assert_eq!(trial.id, 11);
         Ok(())
     }
 }

--- a/rustuna_core/src/storage.rs
+++ b/rustuna_core/src/storage.rs
@@ -17,16 +17,14 @@ pub trait Storage: Send + Sync {
     fn create_new_trial(&mut self, study_id: u32) -> Result<&PersistedTrial>;
     fn set_trial_param(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         name: &str,
         distribution: &Distribution,
         value: f64,
     ) -> Result<()>;
     fn set_trial_state_values(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         state_values: TrialStateValues,
     ) -> Result<()>;
     // Design Note:
@@ -36,7 +34,12 @@ pub trait Storage: Send + Sync {
     fn get_studies(&mut self) -> Result<&Vec<PersistedStudy>>;
     fn get_study(&mut self, study_id: u32) -> Result<&PersistedStudy>;
     fn get_trials(&mut self, study_id: u32) -> Result<&Vec<PersistedTrial>>;
-    fn get_trial(&mut self, study_id: u32, trial_number: u32) -> Result<&PersistedTrial>;
+    fn get_trial(&mut self, trial_id: u32) -> Result<&PersistedTrial>;
+    fn get_trial_id_from_study_id_trial_number(
+        &mut self,
+        study_id: u32,
+        trial_number: u32,
+    ) -> Result<u32>;
     // Design Note:
     // Unlike the storage APIs in Optuna, the `set_study_attrs` and `set_trial_attrs` methods
     // are designed to receive multiple attributes for bulk insert operations.
@@ -64,16 +67,20 @@ pub trait Storage: Send + Sync {
 pub struct InMemoryStorage {
     studies: Vec<PersistedStudy>,
     trials: HashMap<u32, Vec<PersistedTrial>>,
+    trial_id_to_study_number: HashMap<u32, (u32, u32)>,
     study_caches: HashMap<u32, StudyCache>,
     next_study_id: u32,
+    next_trial_id: u32,
 }
 impl InMemoryStorage {
     pub fn new() -> InMemoryStorage {
         InMemoryStorage {
             studies: vec![],
             trials: HashMap::new(),
+            trial_id_to_study_number: HashMap::new(),
             study_caches: HashMap::new(),
             next_study_id: 0,
+            next_trial_id: 0,
         }
     }
 }
@@ -94,6 +101,15 @@ fn get_mut_trials_by_study_id(
         .get_mut(&study_id)
         .ok_or(Error::new(ErrorKind::StudyNotFound))?;
     Ok(trials)
+}
+fn get_study_id_trial_number_by_trial_id(
+    trial_id_to_study_number: &HashMap<u32, (u32, u32)>,
+    trial_id: u32,
+) -> Result<(u32, u32)> {
+    trial_id_to_study_number
+        .get(&trial_id)
+        .copied()
+        .ok_or(Error::new(ErrorKind::TrialNotFound))
 }
 impl Storage for InMemoryStorage {
     fn create_new_study(
@@ -124,7 +140,11 @@ impl Storage for InMemoryStorage {
         }
 
         self.studies.retain(|s| s.id != study_id);
-        self.trials.remove(&study_id);
+        if let Some(trials) = self.trials.remove(&study_id) {
+            for trial in trials {
+                self.trial_id_to_study_number.remove(&trial.id);
+            }
+        }
         self.study_caches.remove(&study_id);
 
         Ok(())
@@ -132,19 +152,25 @@ impl Storage for InMemoryStorage {
 
     fn create_new_trial(&mut self, study_id: u32) -> Result<&PersistedTrial> {
         let trials = get_mut_trials_by_study_id(&mut self.trials, study_id)?;
+        let trial_id = self.next_trial_id;
+        self.next_trial_id += 1;
         let number = trials.len() as u32;
-        trials.push(PersistedTrial::new(study_id, number));
+        let trial = PersistedTrial::new(trial_id, study_id, number);
+        trials.push(trial);
+        self.trial_id_to_study_number
+            .insert(trial_id, (study_id, number));
         Ok(&trials[number as usize])
     }
 
     fn set_trial_param(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         name: &str,
         distribution: &Distribution,
         value: f64,
     ) -> Result<()> {
+        let (study_id, trial_number) =
+            get_study_id_trial_number_by_trial_id(&self.trial_id_to_study_number, trial_id)?;
         let trial = get_mut_trials_by_study_id(&mut self.trials, study_id)?
             .get_mut(trial_number as usize)
             .ok_or(Error::new(ErrorKind::TrialNotFound))?;
@@ -170,10 +196,11 @@ impl Storage for InMemoryStorage {
 
     fn set_trial_state_values(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         state_values: TrialStateValues,
     ) -> Result<()> {
+        let (study_id, trial_number) =
+            get_study_id_trial_number_by_trial_id(&self.trial_id_to_study_number, trial_id)?;
         let trial = get_mut_trials_by_study_id(&mut self.trials, study_id)?
             .get_mut(trial_number as usize)
             .ok_or(Error::new(ErrorKind::TrialNotFound))?;
@@ -199,11 +226,25 @@ impl Storage for InMemoryStorage {
         get_trials_by_study_id(&self.trials, study_id)
     }
 
-    fn get_trial(&mut self, study_id: u32, trial_number: u32) -> Result<&PersistedTrial> {
+    fn get_trial(&mut self, trial_id: u32) -> Result<&PersistedTrial> {
+        let (study_id, trial_number) =
+            get_study_id_trial_number_by_trial_id(&self.trial_id_to_study_number, trial_id)?;
         let trial = get_trials_by_study_id(&self.trials, study_id)?
             .get(trial_number as usize)
             .ok_or(Error::new(ErrorKind::TrialNotFound))?;
         Ok(trial)
+    }
+
+    fn get_trial_id_from_study_id_trial_number(
+        &mut self,
+        study_id: u32,
+        trial_number: u32,
+    ) -> Result<u32> {
+        self.trial_id_to_study_number
+            .iter()
+            .find(|(_, &(s_id, t_num))| s_id == study_id && t_num == trial_number)
+            .map(|(&trial_id, _)| trial_id)
+            .ok_or(Error::new(ErrorKind::TrialNotFound))
     }
 
     fn set_study_attrs(
@@ -309,12 +350,12 @@ mod tests {
             log: false,
         };
 
-        let trial0_number = storage.create_new_trial(study_id)?.number;
-        storage.set_trial_param(study_id, trial0_number, "x", &float_dist, 0.5)?;
+        let trial0_id = storage.create_new_trial(study_id)?.id;
+        storage.set_trial_param(trial0_id, "x", &float_dist, 0.5)?;
 
-        let trial1_number = storage.create_new_trial(study_id)?.number;
+        let trial1_id = storage.create_new_trial(study_id)?.id;
         let err = storage
-            .set_trial_param(study_id, trial1_number, "x", &int_dist, 1.0)
+            .set_trial_param(trial1_id, "x", &int_dist, 1.0)
             .err()
             .unwrap();
         assert!(matches!(err.kind, ErrorKind::IncompatibleDistribution));

--- a/rustuna_core/src/study.rs
+++ b/rustuna_core/src/study.rs
@@ -64,9 +64,12 @@ impl Study {
     }
 
     pub fn from_id(id: u32, storage: Arc<RwLock<dyn Storage>>) -> Result<Self> {
-        let mut guard = storage
-            .write()
-            .map_err(|_| Error::new(ErrorKind::Unexpected))?;
+        let mut guard = storage.write().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::Unexpected,
+                format!("Failed to acquire a storage guard: {e}"),
+            )
+        })?;
         let study = guard.get_study(id)?;
         let name = study.name.clone();
         let directions = study.directions.clone();
@@ -75,9 +78,12 @@ impl Study {
     }
 
     pub fn from_name(name: String, storage: Arc<RwLock<dyn Storage>>) -> Result<Self> {
-        let mut guard = storage
-            .write()
-            .map_err(|_| Error::new(ErrorKind::Unexpected))?;
+        let mut guard = storage.write().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::Unexpected,
+                format!("Failed to acquire a storage guard: {e}"),
+            )
+        })?;
         let studies = guard.get_studies()?;
         let study = studies
             .iter()
@@ -90,11 +96,15 @@ impl Study {
     }
 
     pub fn ask(&mut self, sampler: Arc<Mutex<dyn Sampler>>) -> Result<Trial> {
-        let mut guard = self
-            .storage
-            .write()
-            .map_err(|_| Error::new(ErrorKind::Unexpected))?;
-        let trial_number = guard.create_new_trial(self.id)?.number;
+        let mut guard = self.storage.write().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::Unexpected,
+                format!("Failed to acquire a storage guard: {e}"),
+            )
+        })?;
+        let trial = guard.create_new_trial(self.id)?;
+        let trial_id = trial.id;
+        let trial_number = trial.number;
         drop(guard);
 
         // Joint sampling
@@ -128,6 +138,7 @@ impl Study {
         };
 
         let trial = Trial::new(
+            trial_id,
             self.id,
             trial_number,
             self.directions.clone(),
@@ -143,7 +154,8 @@ impl Study {
             .storage
             .write()
             .map_err(|_| Error::new(ErrorKind::Unexpected))?;
-        guard.set_trial_state_values(self.id, trial_number, state_values)?;
+        let trial_id = guard.get_trial_id_from_study_id_trial_number(self.id, trial_number)?;
+        guard.set_trial_state_values(trial_id, state_values)?;
         Ok(())
     }
 

--- a/rustuna_core/src/study_cache.rs
+++ b/rustuna_core/src/study_cache.rs
@@ -86,6 +86,7 @@ mod tests {
         let mut cache = StudyCache::new();
         let trials = vec![
             PersistedTrial {
+                id: 0,
                 study_id: 0,
                 number: 0,
                 state_values: TrialStateValues::Complete(vec![0.0]),
@@ -119,6 +120,7 @@ mod tests {
                 attrs: Attrs::new(),
             },
             PersistedTrial {
+                id: 1,
                 study_id: 0,
                 number: 1,
                 state_values: TrialStateValues::Fail,
@@ -127,6 +129,7 @@ mod tests {
                 attrs: Attrs::new(),
             },
             PersistedTrial {
+                id: 2,
                 study_id: 0,
                 number: 2,
                 state_values: TrialStateValues::Running,
@@ -135,6 +138,7 @@ mod tests {
                 attrs: Attrs::new(),
             },
             PersistedTrial {
+                id: 3,
                 study_id: 0,
                 number: 3,
                 state_values: TrialStateValues::Complete(vec![0.0]),
@@ -180,6 +184,7 @@ mod tests {
         let mut cache = StudyCache::new();
         let trials = vec![
             PersistedTrial {
+                id: 0,
                 study_id: 0,
                 number: 0,
                 state_values: TrialStateValues::Complete(vec![0.0]),
@@ -188,6 +193,7 @@ mod tests {
                 attrs: Attrs::new(),
             },
             PersistedTrial {
+                id: 1,
                 study_id: 0,
                 number: 1,
                 state_values: TrialStateValues::Pruned,
@@ -196,6 +202,7 @@ mod tests {
                 attrs: Attrs::new(),
             },
             PersistedTrial {
+                id: 2,
                 study_id: 0,
                 number: 2,
                 state_values: TrialStateValues::Fail,
@@ -204,6 +211,7 @@ mod tests {
                 attrs: Attrs::new(),
             },
             PersistedTrial {
+                id: 3,
                 study_id: 0,
                 number: 3,
                 state_values: TrialStateValues::Running,
@@ -212,6 +220,7 @@ mod tests {
                 attrs: Attrs::new(),
             },
             PersistedTrial {
+                id: 4,
                 study_id: 0,
                 number: 4,
                 state_values: TrialStateValues::Complete(vec![0.0]),

--- a/rustuna_core/src/trial.rs
+++ b/rustuna_core/src/trial.rs
@@ -10,6 +10,7 @@ use crate::{Error, ErrorKind, Result};
 
 /// Trial is a struct that is equivalent to `optuna.trial.Trial`.
 pub struct Trial {
+    pub id: u32,
     pub study_id: u32,
     pub number: u32,
     directions: Vec<Direction>,
@@ -20,6 +21,7 @@ pub struct Trial {
 }
 impl Trial {
     pub fn new(
+        trial_id: u32,
         study_id: u32,
         number: u32,
         directions: Vec<Direction>,
@@ -27,8 +29,9 @@ impl Trial {
         sampler: Arc<Mutex<dyn Sampler>>,
         joint_params: HashMap<String, (Distribution, f64)>,
     ) -> Self {
-        let cached_trial = PersistedTrial::new(study_id, number);
+        let cached_trial = PersistedTrial::new(trial_id, study_id, number);
         Trial {
+            id: trial_id,
             study_id,
             number,
             directions,
@@ -47,13 +50,7 @@ impl Trial {
                     .storage
                     .write()
                     .map_err(|_| Error::new(ErrorKind::StorageError))?;
-                storage_guard.set_trial_param(
-                    self.study_id,
-                    self.number,
-                    name,
-                    distribution,
-                    param_value,
-                )?;
+                storage_guard.set_trial_param(self.id, name, distribution, param_value)?;
                 drop(storage_guard);
                 return Ok(param_value);
             }
@@ -76,13 +73,7 @@ impl Trial {
             .storage
             .write()
             .map_err(|_| Error::new(ErrorKind::StorageError))?;
-        storage_guard.set_trial_param(
-            self.study_id,
-            self.number,
-            name,
-            distribution,
-            param_value,
-        )?;
+        storage_guard.set_trial_param(self.id, name, distribution, param_value)?;
         drop(storage_guard);
 
         self.cached_trial
@@ -179,6 +170,7 @@ impl Trial {
 /// This is equivalent to `optuna.trial.FrozenTrial`.
 #[derive(Clone, Debug)]
 pub struct PersistedTrial {
+    pub id: u32,
     pub study_id: u32,
     pub number: u32,
     pub state_values: TrialStateValues,
@@ -187,8 +179,9 @@ pub struct PersistedTrial {
     pub attrs: Attrs,
 }
 impl PersistedTrial {
-    pub fn new(study_id: u32, number: u32) -> PersistedTrial {
+    pub fn new(id: u32, study_id: u32, number: u32) -> PersistedTrial {
         PersistedTrial {
+            id,
             study_id,
             number,
             state_values: TrialStateValues::Running,
@@ -243,7 +236,7 @@ mod tests {
         guard.set_trial_attrs(study.id, 0, attrs, false)?;
 
         // Check the attributes
-        let trial = guard.get_trial(study.id, 0)?;
+        let trial = guard.get_trial(trial.id)?;
         assert_eq!(
             trial.attrs.get(&AttrKey::User("key".to_string())),
             Some(&"user".to_string())

--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -82,6 +82,7 @@ class TrialState(enum.IntEnum):
 class PersistedTrial:
     def __init__(
         self,
+        trial_id: int,
         study_id: int,
         number: int,
         state: TrialState,
@@ -90,7 +91,10 @@ class PersistedTrial:
         distributions: dict[str, Distribution] | None = None,
         user_attrs: dict[str, str] | None = None,
         system_attrs: dict[str, str] | None = None,
+        id: int | None = None,
     ) -> None: ...
+    @property
+    def id(self) -> int: ...
     @property
     def study_id(self) -> int: ...
     @property
@@ -192,31 +196,28 @@ class StorageProtocol(Protocol):
     def create_new_trial(self, study_id: int) -> PersistedTrial: ...
     def set_trial_param(
         self,
-        study_id: int,
-        trial_number: int,
+        trial_id: int,
         name: str,
         distribution: Distribution,
         value: float,
     ) -> None: ...
     def set_trial_state_values(
         self,
-        study_id: int,
-        trial_number: int,
+        trial_id: int,
         state: TrialState,
         values: None | list[float] = None,
     ) -> None: ...
     def get_studies(self) -> list[PersistedStudy]: ...
     def get_study(self, study_id: int) -> PersistedStudy: ...
     def get_trials(self, study_id: int) -> list[PersistedTrial]: ...
-    def get_trial(self, study_id: int, trial_number: int) -> PersistedTrial: ...
+    def get_trial(self, trial_id: int) -> PersistedTrial: ...
+    def get_trial_id_from_study_id_trial_number(
+        self, study_id: int, trial_number: int
+    ) -> int: ...
     def set_study_system_attrs(self, study_id: int, attrs: dict[str, str]) -> None: ...
     def set_study_user_attrs(self, study_id: int, attrs: dict[str, str]) -> None: ...
-    def set_trial_system_attrs(
-        self, study_id: int, trial_number: int, attrs: dict[str, str]
-    ) -> None: ...
-    def set_trial_user_attrs(
-        self, study_id: int, trial_number: int, attrs: dict[str, str]
-    ) -> None: ...
+    def set_trial_system_attrs(self, trial_id: int, attrs: dict[str, str]) -> None: ...
+    def set_trial_user_attrs(self, trial_id: int, attrs: dict[str, str]) -> None: ...
     def set_category_labels(
         self,
         study_id: int,
@@ -231,12 +232,6 @@ class StorageProtocol(Protocol):
     ) -> list[CategoricalChoiceType]: ...
 
 class OptunaStorageProtocol(StorageProtocol, Protocol):
-    def get_study_id_trial_number_from_trial_id(
-        self, trial_id: int
-    ) -> tuple[int, int]: ...
-    def get_trial_id_from_study_id_trial_number(
-        self, study_id: int, trial_number: int
-    ) -> int: ...
     def set_trial_datetime(
         self,
         trial_id: int,

--- a/rustuna_pyo3/rustuna/converter/_storage.py
+++ b/rustuna_pyo3/rustuna/converter/_storage.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import datetime
 import json
+import threading
 import typing
 import uuid
 from collections.abc import Container, Sequence
@@ -31,10 +32,15 @@ if typing.TYPE_CHECKING:
     from optuna._typing import JSONSerializable
 
 
+logger = optuna.logging.get_logger(__name__)
+
+
 class ToRustunaStorage:
     def __init__(self, storage: BaseStorage, is_distributed: bool = False) -> None:
         self._storage = storage
         self._is_distributed = is_distributed
+        self._trial_id_to_study_id: dict[int, int] = {}
+        self._lock = threading.Lock()
 
     @property
     def is_distributed(self) -> bool:
@@ -56,33 +62,27 @@ class ToRustunaStorage:
     def create_new_trial(self, study_id: int) -> rustuna.PersistedTrial:
         trial_id = self._storage.create_new_trial(study_id)
         trial = self._storage.get_trial(trial_id)
+        with self._lock:
+            self._trial_id_to_study_id[trial_id] = study_id
         return to_persisted_trial(trial, study_id)
 
     def set_trial_param(
         self,
-        study_id: int,
-        trial_number: int,
+        trial_id: int,
         name: str,
         distribution: rustuna.Distribution,
         value: float,
     ) -> None:
-        trial_id = self._storage.get_trial_id_from_study_id_trial_number(
-            study_id, trial_number
-        )
         self._storage.set_trial_param(
             trial_id, name, value, to_optuna_distribution(distribution)
         )
 
     def set_trial_state_values(
         self,
-        study_id: int,
-        trial_number: int,
+        trial_id: int,
         state: rustuna.TrialState,
         values: None | list[float] = None,
     ) -> None:
-        trial_id = self._storage.get_trial_id_from_study_id_trial_number(
-            study_id, trial_number
-        )
         self._storage.set_trial_state_values(
             trial_id,
             to_optuna_state(state),
@@ -102,14 +102,24 @@ class ToRustunaStorage:
 
     def get_trials(self, study_id: int) -> list[rustuna.PersistedTrial]:
         frozen_trials = self._storage.get_all_trials(study_id)
-        return [to_persisted_trial(t, study_id) for t in frozen_trials]
 
-    def get_trial(self, study_id: int, trial_number: int) -> rustuna.PersistedTrial:
-        trial_id = self._storage.get_trial_id_from_study_id_trial_number(
-            study_id, trial_number
-        )
+        persisted_trials: list[rustuna.PersistedTrial] = []
+        with self._lock:
+            for t in frozen_trials:
+                persisted_trials.append(to_persisted_trial(t, study_id))
+                self._trial_id_to_study_id[t._trial_id] = study_id
+        return persisted_trials
+
+    def get_trial(self, trial_id: int) -> rustuna.PersistedTrial:
+        with self._lock:
+            study_id = self._trial_id_to_study_id.get(trial_id, -1)
+        if study_id == -1:
+            logger.warning(
+                f"Failed to get study_id while converting to PersistedTrial({trial_id=})"
+                "due to the implementation restriction"
+            )
         frozen_trial = self._storage.get_trial(trial_id)
-        return to_persisted_trial(frozen_trial, study_id)
+        return to_persisted_trial(frozen_trial, study_id=study_id)
 
     def set_study_system_attrs(self, study_id: int, attrs: dict[str, str]) -> None:
         for key, value in attrs.items():
@@ -119,21 +129,11 @@ class ToRustunaStorage:
         for key, value in attrs.items():
             self._storage.set_study_user_attr(study_id, key, value)
 
-    def set_trial_system_attrs(
-        self, study_id: int, trial_number: int, attrs: dict[str, str]
-    ) -> None:
-        trial_id = self._storage.get_trial_id_from_study_id_trial_number(
-            study_id, trial_number
-        )
+    def set_trial_system_attrs(self, trial_id: int, attrs: dict[str, str]) -> None:
         for key, value in attrs.items():
             self._storage.set_trial_system_attr(trial_id, key, value)
 
-    def set_trial_user_attrs(
-        self, study_id: int, trial_number: int, attrs: dict[str, str]
-    ) -> None:
-        trial_id = self._storage.get_trial_id_from_study_id_trial_number(
-            study_id, trial_number
-        )
+    def set_trial_user_attrs(self, trial_id: int, attrs: dict[str, str]) -> None:
         for key, value in attrs.items():
             self._storage.set_trial_user_attr(trial_id, key, value)
 
@@ -234,9 +234,7 @@ class ToOptunaStorage(BaseStorage):
         self, study_id: int, template_trial: FrozenTrial | None = None
     ) -> int:
         trial = self._storage.create_new_trial(study_id)
-        trial_id = self._storage.get_trial_id_from_study_id_trial_number(
-            study_id, trial.number
-        )
+        trial_id = trial.id
 
         if template_trial is None:
             self._storage.set_trial_datetime(trial_id, datetime.datetime.now(), None)
@@ -245,12 +243,12 @@ class ToOptunaStorage(BaseStorage):
             user_attrs = {
                 k: json.dumps(v) for k, v in template_trial.user_attrs.items()
             }
-            self._storage.set_trial_user_attrs(study_id, trial.number, user_attrs)
+            self._storage.set_trial_user_attrs(trial_id, user_attrs)
         if template_trial.system_attrs:
             system_attrs = {
                 k: json.dumps(v) for k, v in template_trial.system_attrs.items()
             }
-            self._storage.set_trial_system_attrs(study_id, trial.number, system_attrs)
+            self._storage.set_trial_system_attrs(trial_id, system_attrs)
         if template_trial.distributions and template_trial.params:
             for param_name in template_trial.distributions:
                 optuna_distribution = template_trial.distributions[param_name]
@@ -258,9 +256,7 @@ class ToOptunaStorage(BaseStorage):
                 value = optuna_distribution.to_internal_repr(
                     template_trial.params[param_name]
                 )
-                self._storage.set_trial_param(
-                    study_id, trial.number, param_name, distribution, value
-                )
+                self._storage.set_trial_param(trial_id, param_name, distribution, value)
         if template_trial.intermediate_values:
             for step in template_trial.intermediate_values:
                 self._storage.set_trial_intermediate_value(
@@ -268,7 +264,7 @@ class ToOptunaStorage(BaseStorage):
                 )
         rustuna_state = to_rustuna_state(template_trial.state)
         self._storage.set_trial_state_values(
-            study_id, trial.number, rustuna_state, template_trial.values
+            trial_id, rustuna_state, template_trial.values
         )
         self._storage.set_trial_datetime(
             trial_id, template_trial.datetime_start, template_trial.datetime_complete
@@ -282,14 +278,10 @@ class ToOptunaStorage(BaseStorage):
         param_value_internal: float,
         distribution: BaseDistribution,
     ) -> None:
-        study_id, trial_number = self._storage.get_study_id_trial_number_from_trial_id(
-            trial_id
-        )
         rustuna_distribution = to_rustuna_distribution(distribution)
         try:
             self._storage.set_trial_param(
-                study_id,
-                trial_number,
+                trial_id,
                 param_name,
                 rustuna_distribution,
                 param_value_internal,
@@ -300,16 +292,13 @@ class ToOptunaStorage(BaseStorage):
     def set_trial_state_values(
         self, trial_id: int, state: TrialState, values: Sequence[float] | None = None
     ) -> bool:
-        study_id, trial_number = self._storage.get_study_id_trial_number_from_trial_id(
-            trial_id
-        )
         rustuna_state = to_rustuna_state(state)
+        if values is None and state == TrialState.COMPLETE:
+            values = [0.0]
         values = list(values) if values is not None else None
 
         try:
-            self._storage.set_trial_state_values(
-                study_id, trial_number, rustuna_state, values
-            )
+            self._storage.set_trial_state_values(trial_id, rustuna_state, values)
         except rustuna.exceptions.UpdateFinishedTrialError as e:
             raise optuna.exceptions.UpdateFinishedTrialError(str(e)) from e
         # TODO(c-bata): Add support for pop waiting trial
@@ -326,34 +315,21 @@ class ToOptunaStorage(BaseStorage):
             raise optuna.exceptions.UpdateFinishedTrialError(str(e)) from e
 
     def set_trial_user_attr(self, trial_id: int, key: str, value: Any) -> None:
-        study_id, trial_number = self._storage.get_study_id_trial_number_from_trial_id(
-            trial_id
-        )
         try:
-            self._storage.set_trial_user_attrs(
-                study_id, trial_number, {key: json.dumps(value)}
-            )
+            self._storage.set_trial_user_attrs(trial_id, {key: json.dumps(value)})
         except rustuna.exceptions.UpdateFinishedTrialError as e:
             raise optuna.exceptions.UpdateFinishedTrialError(str(e)) from e
 
     def set_trial_system_attr(
         self, trial_id: int, key: str, value: JSONSerializable
     ) -> None:
-        study_id, trial_number = self._storage.get_study_id_trial_number_from_trial_id(
-            trial_id
-        )
         try:
-            self._storage.set_trial_system_attrs(
-                study_id, trial_number, {key: json.dumps(value)}
-            )
+            self._storage.set_trial_system_attrs(trial_id, {key: json.dumps(value)})
         except rustuna.exceptions.UpdateFinishedTrialError as e:
             raise optuna.exceptions.UpdateFinishedTrialError(str(e)) from e
 
     def get_trial(self, trial_id: int) -> FrozenTrial:
-        study_id, trial_number = self._storage.get_study_id_trial_number_from_trial_id(
-            trial_id
-        )
-        persisted_trial = self._storage.get_trial(study_id, trial_number)
+        persisted_trial = self._storage.get_trial(trial_id)
         return to_frozen_trial(persisted_trial)
 
     def get_all_trials(

--- a/rustuna_pyo3/rustuna/converter/_trial.py
+++ b/rustuna_pyo3/rustuna/converter/_trial.py
@@ -89,6 +89,7 @@ def to_persisted_trial(
         )
 
     return rustuna.PersistedTrial(
+        trial_id=trial._trial_id,
         study_id=study_id,
         number=trial.number,
         state=to_rustuna_state(trial.state),

--- a/rustuna_pyo3/src/pyobject_storage.rs
+++ b/rustuna_pyo3/src/pyobject_storage.rs
@@ -90,8 +90,7 @@ impl PyObjectStorage {
 
     fn obj_set_trial_param(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         name: &str,
         distribution: &Distribution,
         value: f64,
@@ -103,7 +102,7 @@ impl PyObjectStorage {
             self.obj.call_method1(
                 py,
                 "set_trial_param",
-                (study_id, trial_number, name, py_distribution, value),
+                (trial_id, name, py_distribution, value),
             )?;
             Ok(())
         })
@@ -111,8 +110,7 @@ impl PyObjectStorage {
 
     fn obj_set_trial_state_values(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         state: &TrialStateValues,
     ) -> PyResult<()> {
         Python::with_gil(|py| {
@@ -121,11 +119,8 @@ impl PyObjectStorage {
                 _ => None,
             };
             let py_state = PyTrialState::from(state.clone());
-            self.obj.call_method1(
-                py,
-                "set_trial_state_values",
-                (study_id, trial_number, py_state, values),
-            )?;
+            self.obj
+                .call_method1(py, "set_trial_state_values", (trial_id, py_state, values))?;
             Ok(())
         })
     }
@@ -152,12 +147,7 @@ impl PyObjectStorage {
         })
     }
 
-    fn obj_set_trial_attrs(
-        &mut self,
-        study_id: u32,
-        trial_number: u32,
-        attrs: Attrs,
-    ) -> PyResult<()> {
+    fn obj_set_trial_attrs(&mut self, trial_id: u32, attrs: Attrs) -> PyResult<()> {
         Python::with_gil(|py| {
             let py_system_attrs = pyo3::types::PyDict::new(py);
             let py_user_attrs = pyo3::types::PyDict::new(py);
@@ -171,16 +161,10 @@ impl PyObjectStorage {
                     }
                 }
             }
-            self.obj.call_method1(
-                py,
-                "set_trial_system_attrs",
-                (study_id, trial_number, py_system_attrs),
-            )?;
-            self.obj.call_method1(
-                py,
-                "set_trial_user_attrs",
-                (study_id, trial_number, py_user_attrs),
-            )?;
+            self.obj
+                .call_method1(py, "set_trial_system_attrs", (trial_id, py_system_attrs))?;
+            self.obj
+                .call_method1(py, "set_trial_user_attrs", (trial_id, py_user_attrs))?;
             Ok(())
         })
     }
@@ -258,52 +242,39 @@ impl PyObjectStorage {
     fn sync_trial(
         &mut self,
         cache_study_id: u32,
-        number: u32,
-        src_trial: Option<PersistedTrial>,
+        src_trial: PersistedTrial,
         cache_n_trials: Option<u32>,
     ) -> rustuna_core::Result<()> {
         let cache_n_trials = match cache_n_trials {
             Some(n) => n,
             None => self.cache.get_trials(cache_study_id)?.len() as u32,
         };
-        let cache_trial = match cache_n_trials.cmp(&number) {
-            std::cmp::Ordering::Equal => self.cache.create_new_trial(cache_study_id),
-            std::cmp::Ordering::Greater => self.cache.get_trial(cache_study_id, number),
-            std::cmp::Ordering::Less => {
-                for n in cache_n_trials..number {
-                    let cache_trial = self.cache.create_new_trial(cache_study_id)?;
-                    assert!(cache_trial.number == n);
-                }
-                self.cache.create_new_trial(cache_study_id)
+        match src_trial.number.cmp(&cache_n_trials) {
+            std::cmp::Ordering::Equal => {
+                self.cache
+                    .insert_trial_with_id(cache_study_id, src_trial.id, src_trial.number)?;
             }
-        }?;
-        assert!(
-            number == cache_trial.number,
-            "{:?} != {:?} (src_trial={:?})",
-            number,
-            cache_trial.number,
-            src_trial
-        );
+            std::cmp::Ordering::Greater => {
+                return Err(rustuna_core::Error::new(
+                    rustuna_core::ErrorKind::StorageError,
+                ));
+            }
+            std::cmp::Ordering::Less => {
+                let cache_trial_id = self
+                    .cache
+                    .get_trial_id_from_study_id_trial_number(cache_study_id, src_trial.number)?;
+                if cache_trial_id != src_trial.id {
+                    return Err(rustuna_core::Error::new(
+                        rustuna_core::ErrorKind::StorageError,
+                    ));
+                }
+            }
+        }
+
+        let cache_trial = self.cache.get_trial(src_trial.id)?.clone();
         if cache_trial.is_finished() {
             return Ok(());
         }
-        let src_trial = match src_trial {
-            Some(src_trial) => src_trial,
-            None => {
-                let src_study_id = self.cache_study_to_src_study.get(&cache_study_id).ok_or(
-                    rustuna_core::Error::new(rustuna_core::ErrorKind::StudyNotFound),
-                )?;
-                Python::with_gil(|py| {
-                    let trial = self
-                        .obj
-                        .call_method1(py, "get_trial", (*src_study_id, number))?;
-                    let trial = trial.bind(py);
-                    pyobject_to_persisted_trial(trial, *src_study_id)
-                })
-                .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::StorageError))?
-            }
-        };
-        let cache_trial = cache_trial.clone();
         self.cache
             .set_trial_attrs(cache_study_id, cache_trial.number, src_trial.attrs, false)?;
 
@@ -318,21 +289,13 @@ impl PyObjectStorage {
             if cache_trial.distributions.contains_key(&name) {
                 continue;
             }
-            self.cache.set_trial_param(
-                cache_study_id,
-                src_trial.number,
-                &name,
-                &distribution,
-                *internal_repr,
-            )?;
+            self.cache
+                .set_trial_param(src_trial.id, &name, &distribution, *internal_repr)?;
         }
 
-        if !cache_trial.is_finished() && cache_trial.state_values != src_trial.state_values {
-            self.cache.set_trial_state_values(
-                cache_study_id,
-                src_trial.number,
-                src_trial.state_values.clone(),
-            )?;
+        if cache_trial.state_values != src_trial.state_values {
+            self.cache
+                .set_trial_state_values(src_trial.id, src_trial.state_values.clone())?;
         }
         Ok(())
     }
@@ -345,17 +308,24 @@ impl PyObjectStorage {
                     rustuna_core::ErrorKind::StudyNotFound,
                 ))?;
 
-        let src_trials = self
+        let mut src_trials = self
             .obj_get_trials(*src_study_id)
             .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::StorageError))?;
+        src_trials.sort_by_key(|trial| trial.number);
+
+        let mut cache_n_trials = self.cache.get_trials(cache_study_id)?.len() as u32;
         for src_trial in src_trials {
-            let cache_n_trials = self.cache.get_trials(cache_study_id)?.len() as u32;
-            self.sync_trial(
-                cache_study_id,
-                src_trial.number,
-                Some(src_trial),
-                Some(cache_n_trials),
-            )?;
+            self.sync_trial(cache_study_id, src_trial, Some(cache_n_trials))?;
+            cache_n_trials = self.cache.get_trials(cache_study_id)?.len() as u32;
+        }
+        Ok(())
+    }
+
+    fn sync_all_trials(&mut self) -> rustuna_core::Result<()> {
+        self.sync_studies(false)?;
+        let study_ids: Vec<u32> = self.cache.get_studies()?.iter().map(|s| s.id).collect();
+        for cache_study_id in study_ids {
+            self.sync_trials(cache_study_id)?;
         }
         Ok(())
     }
@@ -378,9 +348,19 @@ impl Storage for PyObjectStorage {
     }
 
     fn delete_study(&mut self, study_id: u32) -> rustuna_core::Result<()> {
-        self.obj_delete_study(study_id)
+        self.sync_study_from_id(study_id, false)?;
+        let src_study_id =
+            *self
+                .cache_study_to_src_study
+                .get(&study_id)
+                .ok_or(rustuna_core::Error::new(
+                    rustuna_core::ErrorKind::StudyNotFound,
+                ))?;
+        self.obj_delete_study(src_study_id)
             .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::StorageError))?;
         self.cache.delete_study(study_id)?;
+        self.cache_study_to_src_study.remove(&study_id);
+        self.src_study_to_cache_study.remove(&src_study_id);
         Ok(())
     }
 
@@ -398,47 +378,39 @@ impl Storage for PyObjectStorage {
         let src_trial = self
             .obj_create_new_trial(*src_study_id)
             .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::StorageError))?;
+        let src_trial_id = src_trial.id;
         if self.is_distributed {
             self.sync_trials(study_id)?;
-            return self.cache.get_trial(study_id, src_trial.number);
+            return self.cache.get_trial(src_trial_id);
         }
-        let number = src_trial.number;
         let cached_n_trials = self.cache.get_trials(study_id)?.len() as u32;
-        if number == cached_n_trials {
-            self.cache.create_new_trial(study_id)
-        } else {
-            self.sync_trial(study_id, number, Some(src_trial), Some(cached_n_trials))?;
-            self.cache.get_trial(study_id, number)
+        if src_trial.number != cached_n_trials {
+            self.sync_trials(study_id)?;
+            return self.cache.get_trial(src_trial_id);
         }
+        self.sync_trial(study_id, src_trial, Some(cached_n_trials))?;
+        self.cache.get_trial(src_trial_id)
     }
 
     fn set_trial_param(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         name: &str,
         distribution: &Distribution,
         value: f64,
     ) -> rustuna_core::Result<()> {
-        self.sync_study_from_id(study_id, false)?;
-
-        let src_study_id =
-            self.cache_study_to_src_study
-                .get(&study_id)
-                .ok_or(rustuna_core::Error::new(
-                    rustuna_core::ErrorKind::StudyNotFound,
-                ))?;
-
-        self.obj_set_trial_param(*src_study_id, trial_number, name, distribution, value)
+        self.obj_set_trial_param(trial_id, name, distribution, value)
             .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::StorageError))?;
         match self
             .cache
-            .set_trial_param(study_id, trial_number, name, distribution, value)
+            .set_trial_param(trial_id, name, distribution, value)
         {
             Ok(_) => Ok(()),
             Err(e) => match e.kind {
                 rustuna_core::ErrorKind::StudyNotFound | rustuna_core::ErrorKind::TrialNotFound => {
-                    self.sync_trial(study_id, trial_number, None, None)?;
+                    self.sync_all_trials()?;
+                    self.cache
+                        .set_trial_param(trial_id, name, distribution, value)?;
                     Ok(())
                 }
                 _ => Err(e),
@@ -448,30 +420,20 @@ impl Storage for PyObjectStorage {
 
     fn set_trial_state_values(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         state_values: TrialStateValues,
     ) -> rustuna_core::Result<()> {
-        self.sync_study_from_id(study_id, false)?;
-
-        let src_study_id =
-            self.cache_study_to_src_study
-                .get(&study_id)
-                .ok_or(rustuna_core::Error::new(
-                    rustuna_core::ErrorKind::StudyNotFound,
-                ))?;
-
-        self.obj_set_trial_state_values(*src_study_id, trial_number, &state_values)
+        let state_values_clone = state_values.clone();
+        self.obj_set_trial_state_values(trial_id, &state_values_clone)
             .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::StorageError))?;
 
-        match self
-            .cache
-            .set_trial_state_values(study_id, trial_number, state_values)
-        {
+        match self.cache.set_trial_state_values(trial_id, state_values) {
             Ok(_) => Ok(()),
             Err(e) => match e.kind {
                 rustuna_core::ErrorKind::StudyNotFound | rustuna_core::ErrorKind::TrialNotFound => {
-                    self.sync_trial(study_id, trial_number, None, None)?;
+                    self.sync_all_trials()?;
+                    self.cache
+                        .set_trial_state_values(trial_id, state_values_clone)?;
                     Ok(())
                 }
                 _ => Err(e),
@@ -499,10 +461,31 @@ impl Storage for PyObjectStorage {
 
     fn get_trial(
         &mut self,
+        trial_id: u32,
+    ) -> rustuna_core::Result<&rustuna_core::trial::PersistedTrial> {
+        self.cache.get_trial(trial_id)
+    }
+
+    fn get_trial_id_from_study_id_trial_number(
+        &mut self,
         study_id: u32,
         trial_number: u32,
-    ) -> rustuna_core::Result<&rustuna_core::trial::PersistedTrial> {
-        self.cache.get_trial(study_id, trial_number)
+    ) -> rustuna_core::Result<u32> {
+        self.sync_study_from_id(study_id, false)?;
+        match self
+            .cache
+            .get_trial_id_from_study_id_trial_number(study_id, trial_number)
+        {
+            Ok(trial_id) => Ok(trial_id),
+            Err(e) => match e.kind {
+                rustuna_core::ErrorKind::StudyNotFound | rustuna_core::ErrorKind::TrialNotFound => {
+                    self.sync_trials(study_id)?;
+                    self.cache
+                        .get_trial_id_from_study_id_trial_number(study_id, trial_number)
+                }
+                _ => Err(e),
+            },
+        }
     }
 
     fn set_study_attrs(
@@ -512,7 +495,14 @@ impl Storage for PyObjectStorage {
         _error_on_overwrite: bool,
     ) -> rustuna_core::Result<()> {
         // TODO(c-bata): Emit warnings if error_on_overwrite is true, since Optuna storage cannot support it.
-        self.obj_set_study_attrs(study_id, attrs.clone())
+        self.sync_study_from_id(study_id, false)?;
+        let src_study_id =
+            self.cache_study_to_src_study
+                .get(&study_id)
+                .ok_or(rustuna_core::Error::new(
+                    rustuna_core::ErrorKind::StudyNotFound,
+                ))?;
+        self.obj_set_study_attrs(*src_study_id, attrs.clone())
             .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::StorageError))?;
         match self.cache.set_study_attrs(study_id, attrs, false) {
             Ok(_) => Ok(()),
@@ -534,7 +524,20 @@ impl Storage for PyObjectStorage {
         _error_on_overwrite: bool,
     ) -> rustuna_core::Result<()> {
         // TODO(c-bata): Emit warnings if error_on_overwrite is true, since Optuna storage cannot support it.
-        self.obj_set_trial_attrs(study_id, trial_number, attrs.clone())
+        let attrs_for_obj = attrs.clone();
+        let attrs_for_retry = attrs.clone();
+        let trial_id = match self
+            .cache
+            .get_trial_id_from_study_id_trial_number(study_id, trial_number)
+        {
+            Ok(trial_id) => trial_id,
+            Err(_) => {
+                self.sync_all_trials()?;
+                self.cache
+                    .get_trial_id_from_study_id_trial_number(study_id, trial_number)?
+            }
+        };
+        self.obj_set_trial_attrs(trial_id, attrs_for_obj)
             .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::StorageError))?;
         match self
             .cache
@@ -543,7 +546,9 @@ impl Storage for PyObjectStorage {
             Ok(_) => Ok(()),
             Err(e) => match e.kind {
                 rustuna_core::ErrorKind::StudyNotFound | rustuna_core::ErrorKind::TrialNotFound => {
-                    self.sync_trial(study_id, trial_number, None, None)?;
+                    self.sync_all_trials()?;
+                    self.cache
+                        .set_trial_attrs(study_id, trial_number, attrs_for_retry, false)?;
                     Ok(())
                 }
                 _ => Err(e),

--- a/rustuna_pyo3/src/storage.rs
+++ b/rustuna_pyo3/src/storage.rs
@@ -119,8 +119,7 @@ impl PyStorage {
 
     fn set_trial_param(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         name: String,
         distribution: PyDistribution,
         value: f64,
@@ -129,6 +128,16 @@ impl PyStorage {
         let distribution: Distribution = distribution.into();
 
         if let Some(labels) = category_labels {
+            let study_id = {
+                let mut guard = self
+                    .storage
+                    .write()
+                    .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
+                guard
+                    .get_trial(trial_id)
+                    .map_err(err_to_exceptions)?
+                    .study_id
+            };
             self.set_category_labels_internal(study_id, name.clone(), labels)?;
         }
 
@@ -137,7 +146,7 @@ impl PyStorage {
             .write()
             .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
         guard
-            .set_trial_param(study_id, trial_number, &name, &distribution, value)
+            .set_trial_param(trial_id, &name, &distribution, value)
             .map_err(err_to_exceptions)?;
         Ok(())
     }
@@ -189,11 +198,10 @@ impl PyStorage {
         )
     }
 
-    #[pyo3(signature = (study_id, trial_number, state, values=None))]
+    #[pyo3(signature = (trial_id, state, values=None))]
     fn set_trial_state_values(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         state: PyTrialState,
         values: Option<Vec<f64>>,
     ) -> PyResult<()> {
@@ -215,7 +223,7 @@ impl PyStorage {
             PyTrialState::FAIL => TrialStateValues::Fail,
         };
         guard
-            .set_trial_state_values(study_id, trial_number, state_values)
+            .set_trial_state_values(trial_id, state_values)
             .map_err(err_to_exceptions)?;
         Ok(())
     }
@@ -258,23 +266,38 @@ impl PyStorage {
         Ok(py_trials)
     }
 
-    fn get_trial(&mut self, study_id: u32, trial_number: u32) -> PyResult<PyPersistedTrial> {
+    fn get_trial(&mut self, trial_id: u32) -> PyResult<PyPersistedTrial> {
         let mut guard = self
             .storage
             .write()
             .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
         let trial = guard
-            .get_trial(study_id, trial_number)
+            .get_trial(trial_id)
             .map_err(err_to_exceptions)?
             .clone();
         let study_attrs = Arc::new(
             guard
-                .get_study(study_id)
+                .get_study(trial.study_id)
                 .map_err(err_to_exceptions)?
                 .attrs
                 .clone(),
         );
         Ok(PyPersistedTrial::new_with_arc(trial, study_attrs))
+    }
+
+    fn get_trial_id_from_study_id_trial_number(
+        &mut self,
+        study_id: u32,
+        trial_number: u32,
+    ) -> PyResult<u32> {
+        let mut guard = self
+            .storage
+            .write()
+            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
+        let trial_id = guard
+            .get_trial_id_from_study_id_trial_number(study_id, trial_number)
+            .map_err(err_to_exceptions)?;
+        Ok(trial_id)
     }
 
     fn set_study_system_attrs(&mut self, study_id: u32, attrs: PyObject) -> PyResult<()> {
@@ -307,12 +330,7 @@ impl PyStorage {
         Ok(())
     }
 
-    fn set_trial_system_attrs(
-        &mut self,
-        study_id: u32,
-        trial_number: u32,
-        attrs: PyObject,
-    ) -> PyResult<()> {
+    fn set_trial_system_attrs(&mut self, trial_id: u32, attrs: PyObject) -> PyResult<()> {
         let system_attrs = Python::with_gil(|py| {
             let attrs = attrs.bind(py);
             pyobj_to_system_attrs(attrs)
@@ -321,18 +339,17 @@ impl PyStorage {
             .storage
             .write()
             .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
+        let (study_id, trial_number) = {
+            let trial = guard.get_trial(trial_id).map_err(err_to_exceptions)?;
+            (trial.study_id, trial.number)
+        };
         guard
             .set_trial_attrs(study_id, trial_number, system_attrs, false)
             .map_err(err_to_exceptions)?;
         Ok(())
     }
 
-    fn set_trial_user_attrs(
-        &mut self,
-        study_id: u32,
-        trial_number: u32,
-        attrs: PyObject,
-    ) -> PyResult<()> {
+    fn set_trial_user_attrs(&mut self, trial_id: u32, attrs: PyObject) -> PyResult<()> {
         let user_attrs = Python::with_gil(|py| {
             let attrs = attrs.bind(py);
             pyobj_to_user_attrs(attrs)
@@ -341,40 +358,14 @@ impl PyStorage {
             .storage
             .write()
             .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
+        let (study_id, trial_number) = {
+            let trial = guard.get_trial(trial_id).map_err(err_to_exceptions)?;
+            (trial.study_id, trial.number)
+        };
         guard
             .set_trial_attrs(study_id, trial_number, user_attrs, false)
             .map_err(err_to_exceptions)?;
         Ok(())
-    }
-
-    fn get_trial_id_from_study_id_trial_number(
-        &mut self,
-        study_id: u32,
-        trial_number: u32,
-    ) -> PyResult<u32> {
-        let optuna_storage = self.optuna_compatible.as_ref().ok_or_else(|| {
-            PyRuntimeError::new_err("This storage does not support Optuna-compatible operations")
-        })?;
-        let mut guard = optuna_storage
-            .write()
-            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
-        let trial_id = guard
-            .get_trial_id_from_study_id_trial_number(study_id, trial_number)
-            .map_err(err_to_exceptions)?;
-        Ok(trial_id)
-    }
-
-    fn get_study_id_trial_number_from_trial_id(&mut self, trial_id: u32) -> PyResult<(u32, u32)> {
-        let optuna_storage = self.optuna_compatible.as_ref().ok_or_else(|| {
-            PyRuntimeError::new_err("This storage does not support Optuna-compatible operations")
-        })?;
-        let mut guard = optuna_storage
-            .write()
-            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
-        let (study_id, trial_number) = guard
-            .get_study_id_trial_number_from_trial_id(trial_id)
-            .map_err(err_to_exceptions)?;
-        Ok((study_id, trial_number))
     }
 
     fn get_trials_diff(

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -303,10 +303,12 @@ impl PyStudy {
         let mut guard = self.study.storage.write().map_err(|e| {
             PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
         })?;
+        let trial_id = guard
+            .get_trial_id_from_study_id_trial_number(study_id, trial_number)
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind)))?;
         let trial = guard
-            .get_trial(self.study.id, trial_number)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind)))?
-            .clone();
+            .get_trial(trial_id)
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind)))?;
         let study_attrs = Arc::new(
             guard
                 .get_study(self.study.id)

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -300,24 +300,32 @@ impl PyStudy {
             PyRuntimeError::new_err(format!("Failed to get the best trial: {:?}", e.kind))
         })?;
 
-        let mut guard = self.study.storage.write().map_err(|e| {
-            PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
-        })?;
-        let trial_id = guard
-            .get_trial_id_from_study_id_trial_number(study_id, trial_number)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind)))?;
-        let trial = guard
-            .get_trial(trial_id)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind)))?;
-        let study_attrs = Arc::new(
-            guard
-                .get_study(self.study.id)
+        let (trial, study_attrs) = {
+            let mut guard = self.study.storage.write().map_err(|e| {
+                PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
+            })?;
+            let trial_id = guard
+                .get_trial_id_from_study_id_trial_number(self.study.id, trial_number)
                 .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to get the study: {:?}", e.kind))
+                    PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind))
+                })?;
+            let trial = guard
+                .get_trial(trial_id)
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind))
                 })?
-                .attrs
-                .clone(),
-        );
+                .clone();
+            let study_attrs = Arc::new(
+                guard
+                    .get_study(self.study.id)
+                    .map_err(|e| {
+                        PyRuntimeError::new_err(format!("Failed to get the study: {:?}", e.kind))
+                    })?
+                    .attrs
+                    .clone(),
+            );
+            (trial, study_attrs)
+        };
         let trial = PyPersistedTrial::new_with_arc(trial, study_attrs);
         Ok(trial)
     }

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -165,9 +165,10 @@ impl PyPersistedTrial {
 #[pymethods]
 impl PyPersistedTrial {
     #[new]
-    #[pyo3(signature = (study_id, number, state, values=None, internal_params=None, distributions=None, user_attrs=None, system_attrs=None))]
+    #[pyo3(signature = (trial_id, study_id, number, state, values=None, internal_params=None, distributions=None, user_attrs=None, system_attrs=None))]
     #[allow(clippy::too_many_arguments)]
     pub fn py_new(
+        trial_id: u32,
         study_id: u32,
         number: u32,
         state: PyTrialState,
@@ -182,7 +183,7 @@ impl PyPersistedTrial {
                 "values must be specified when state is COMPLETE",
             ))?;
         }
-        let mut trial = PersistedTrial::new(study_id, number);
+        let mut trial = PersistedTrial::new(trial_id, study_id, number);
         trial.state_values = match state {
             PyTrialState::RUNNING => TrialStateValues::Running,
             PyTrialState::COMPLETE => TrialStateValues::Complete(values.ok_or(
@@ -217,6 +218,11 @@ impl PyPersistedTrial {
 
         let study_attrs = Attrs::new();
         Ok(PyPersistedTrial(trial, Arc::new(study_attrs)))
+    }
+
+    #[getter]
+    fn id(&self) -> PyResult<u32> {
+        Ok(self.0.id)
     }
 
     #[getter]
@@ -331,8 +337,12 @@ pub fn pyobject_to_persisted_trial(
     trial: &Bound<'_, PyAny>,
     study_id: u32,
 ) -> PyResult<PersistedTrial> {
+    let trial_id = match trial.getattr("id") {
+        Ok(attr) => attr.extract::<u32>()?,
+        Err(_) => trial.getattr("_trial_id")?.extract::<u32>()?,
+    };
     let number = trial.getattr("number")?.extract::<u32>()?;
-    let mut persisted_trial = PersistedTrial::new(study_id, number);
+    let mut persisted_trial = PersistedTrial::new(trial_id, study_id, number);
 
     let state = trial.getattr("state")?.extract::<PyTrialState>()?;
     let values = trial.getattr("values")?.extract::<Option<Vec<f64>>>()?;

--- a/rustuna_pyo3/tests/test_rustuna.py
+++ b/rustuna_pyo3/tests/test_rustuna.py
@@ -104,7 +104,11 @@ def test_trial_state():
 
 def test_persisted_trial():
     trial = rustuna.PersistedTrial(
-        study_id=1, number=2, state=rustuna.TrialState.COMPLETE, values=[0.5]
+        trial_id=2,
+        study_id=1,
+        number=2,
+        state=rustuna.TrialState.COMPLETE,
+        values=[0.5],
     )
     assert trial.study_id == 1
     assert trial.number == 2
@@ -113,7 +117,7 @@ def test_persisted_trial():
 
     pytest.raises(
         ValueError,
-        lambda: rustuna.PersistedTrial(1, 2, state=rustuna.TrialState.COMPLETE),
+        lambda: rustuna.PersistedTrial(2, 1, 2, state=rustuna.TrialState.COMPLETE),
     )
 
 

--- a/rustuna_storages/src/cache.rs
+++ b/rustuna_storages/src/cache.rs
@@ -24,21 +24,19 @@ pub trait CachedStorageBackend: Send + Sync {
     fn create_new_trial(&mut self, study_id: u32) -> Result<PersistedTrial>;
     fn set_trial_param(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         name: &str,
         distribution: &Distribution,
         value: f64,
     ) -> Result<()>;
     fn set_trial_state_values(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         state_values: TrialStateValues,
     ) -> Result<()>;
     fn get_studies(&mut self) -> Result<Vec<PersistedStudy>>;
     fn get_study(&mut self, study_id: u32) -> Result<PersistedStudy>;
-    fn get_trial(&mut self, study_id: u32, trial_number: u32) -> Result<PersistedTrial>;
+    fn get_trial(&mut self, trial_id: u32) -> Result<PersistedTrial>;
     fn set_study_attrs(
         &mut self,
         study_id: u32,
@@ -68,6 +66,7 @@ pub trait OptunaCachedStorageBackend: CachedStorageBackend + OptunaCompatibleSto
 pub struct CachedStorage {
     studies: Vec<PersistedStudy>,
     trials: HashMap<u32, HashMap<u32, PersistedTrial>>,
+    trial_id_to_study_number: HashMap<u32, (u32, u32)>,
     study_caches: HashMap<u32, StudyCache>,
     unfinished_trials: HashMap<u32, Vec<u32>>,
     last_finished_trial_number: HashMap<u32, i32>,
@@ -81,6 +80,7 @@ impl CachedStorage {
         CachedStorage {
             studies: Vec::new(),
             trials: HashMap::new(),
+            trial_id_to_study_number: HashMap::new(),
             study_caches: HashMap::new(),
             unfinished_trials: HashMap::new(),
             last_finished_trial_number: HashMap::new(),
@@ -110,6 +110,8 @@ impl CachedStorage {
 
         let trials = self.trials.entry(study_id).or_default();
         for trial in loaded {
+            self.trial_id_to_study_number
+                .insert(trial.id, (study_id, trial.number));
             trials.insert(trial.number, trial);
         }
 
@@ -131,6 +133,23 @@ impl CachedStorage {
         self.last_finished_trial_number
             .insert(study_id, last_finished_next);
         Ok(())
+    }
+
+    fn resolve_trial_location(&mut self, trial_id: u32) -> Result<(u32, u32)> {
+        if let Some((study_id, trial_number)) = self.trial_id_to_study_number.get(&trial_id) {
+            return Ok((*study_id, *trial_number));
+        }
+
+        let trial = self.backend.get_trial(trial_id)?;
+        let study_id = trial.study_id;
+        let trial_number = trial.number;
+        self.trials
+            .entry(study_id)
+            .or_default()
+            .insert(trial_number, trial);
+        self.trial_id_to_study_number
+            .insert(trial_id, (study_id, trial_number));
+        Ok((study_id, trial_number))
     }
 }
 
@@ -156,7 +175,11 @@ impl rustuna_core::storage::Storage for CachedStorage {
         self.backend.delete_study(study_id)?;
 
         self.studies.retain(|s| s.id != study_id);
-        self.trials.remove(&study_id);
+        if let Some(trials) = self.trials.remove(&study_id) {
+            for trial in trials.values() {
+                self.trial_id_to_study_number.remove(&trial.id);
+            }
+        }
         self.study_caches.remove(&study_id);
         self.unfinished_trials.remove(&study_id);
         self.last_finished_trial_number.remove(&study_id);
@@ -168,6 +191,8 @@ impl rustuna_core::storage::Storage for CachedStorage {
         let trial = self.backend.create_new_trial(study_id)?;
         let trials = self.trials.entry(study_id).or_default();
         let number = trial.number;
+        self.trial_id_to_study_number
+            .insert(trial.id, (study_id, number));
         trials.insert(number, trial);
         let trial_ref = trials
             .get(&number)
@@ -186,12 +211,12 @@ impl rustuna_core::storage::Storage for CachedStorage {
 
     fn set_trial_param(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         name: &str,
         distribution: &Distribution,
         value: f64,
     ) -> Result<()> {
+        let (study_id, trial_number) = self.resolve_trial_location(trial_id)?;
         self.refresh_trials(study_id)?;
         if let Some(trials) = self.trials.get(&study_id) {
             if let Some(trial) = trials.get(&trial_number) {
@@ -212,7 +237,7 @@ impl rustuna_core::storage::Storage for CachedStorage {
         }
 
         self.backend
-            .set_trial_param(study_id, trial_number, name, distribution, value)?;
+            .set_trial_param(trial_id, name, distribution, value)?;
         self.unfinished_trials
             .entry(study_id)
             .or_default()
@@ -243,12 +268,12 @@ impl rustuna_core::storage::Storage for CachedStorage {
 
     fn set_trial_state_values(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         state_values: TrialStateValues,
     ) -> Result<()> {
         self.backend
-            .set_trial_state_values(study_id, trial_number, state_values.clone())?;
+            .set_trial_state_values(trial_id, state_values.clone())?;
+        let (study_id, trial_number) = self.resolve_trial_location(trial_id)?;
 
         self.unfinished_trials
             .entry(study_id)
@@ -308,7 +333,8 @@ impl rustuna_core::storage::Storage for CachedStorage {
         Ok(&self.trials_sorted_buffer)
     }
 
-    fn get_trial(&mut self, study_id: u32, trial_number: u32) -> Result<&PersistedTrial> {
+    fn get_trial(&mut self, trial_id: u32) -> Result<&PersistedTrial> {
+        let (study_id, trial_number) = self.resolve_trial_location(trial_id)?;
         self.refresh_trials(study_id)?;
         let trials = self
             .trials
@@ -318,6 +344,22 @@ impl rustuna_core::storage::Storage for CachedStorage {
             .get(&trial_number)
             .ok_or_else(|| Error::new(ErrorKind::TrialNotFound))?;
         Ok(trial)
+    }
+
+    fn get_trial_id_from_study_id_trial_number(
+        &mut self,
+        study_id: u32,
+        trial_number: u32,
+    ) -> Result<u32> {
+        self.refresh_trials(study_id)?;
+        let trials = self
+            .trials
+            .get(&study_id)
+            .ok_or_else(|| Error::new(ErrorKind::StudyNotFound))?;
+        let trial = trials
+            .get(&trial_number)
+            .ok_or_else(|| Error::new(ErrorKind::TrialNotFound))?;
+        Ok(trial.id)
     }
 
     fn set_study_attrs(
@@ -390,29 +432,13 @@ impl rustuna_core::storage::Storage for CachedStorage {
 }
 
 impl OptunaCompatibleStorage for CachedStorage {
-    fn get_study_id_trial_number_from_trial_id(&mut self, trial_id: u32) -> Result<(u32, u32)> {
-        self.backend
-            .get_study_id_trial_number_from_trial_id(trial_id)
-    }
-
-    fn get_trial_id_from_study_id_trial_number(
-        &mut self,
-        study_id: u32,
-        trial_number: u32,
-    ) -> Result<u32> {
-        self.backend
-            .get_trial_id_from_study_id_trial_number(study_id, trial_number)
-    }
-
     fn set_trial_datetime(
         &mut self,
         trial_id: u32,
         datetime_start: Option<chrono::NaiveDateTime>,
         datetime_complete: Option<chrono::NaiveDateTime>,
     ) -> Result<()> {
-        let (study_id, trial_number) = self
-            .backend
-            .get_study_id_trial_number_from_trial_id(trial_id)?;
+        let (study_id, trial_number) = self.resolve_trial_location(trial_id)?;
         self.backend
             .set_trial_datetime(trial_id, datetime_start, datetime_complete)?;
         self.unfinished_trials
@@ -488,24 +514,21 @@ mod tests {
 
         fn set_trial_param(
             &mut self,
-            study_id: u32,
-            trial_number: u32,
+            trial_id: u32,
             name: &str,
             distribution: &Distribution,
             value: f64,
         ) -> Result<()> {
             self.inner
-                .set_trial_param(study_id, trial_number, name, distribution, value)
+                .set_trial_param(trial_id, name, distribution, value)
         }
 
         fn set_trial_state_values(
             &mut self,
-            study_id: u32,
-            trial_number: u32,
+            trial_id: u32,
             state_values: TrialStateValues,
         ) -> Result<()> {
-            self.inner
-                .set_trial_state_values(study_id, trial_number, state_values)
+            self.inner.set_trial_state_values(trial_id, state_values)
         }
 
         fn get_studies(&mut self) -> Result<Vec<PersistedStudy>> {
@@ -534,8 +557,8 @@ mod tests {
             Ok(trials)
         }
 
-        fn get_trial(&mut self, study_id: u32, trial_number: u32) -> Result<PersistedTrial> {
-            Ok(self.inner.get_trial(study_id, trial_number)?.clone())
+        fn get_trial(&mut self, trial_id: u32) -> Result<PersistedTrial> {
+            Ok(self.inner.get_trial(trial_id)?.clone())
         }
 
         fn set_study_attrs(
@@ -560,21 +583,6 @@ mod tests {
         }
     }
     impl OptunaCompatibleStorage for DummyBackend {
-        fn get_study_id_trial_number_from_trial_id(
-            &mut self,
-            _trial_id: u32,
-        ) -> Result<(u32, u32)> {
-            todo!()
-        }
-
-        fn get_trial_id_from_study_id_trial_number(
-            &mut self,
-            _study_id: u32,
-            _trial_number: u32,
-        ) -> Result<u32> {
-            todo!()
-        }
-
         fn set_trial_datetime(
             &mut self,
             _trial_id: u32,
@@ -693,14 +701,14 @@ mod tests {
     fn get_trials_and_get_trial_return_cached_refs() -> Result<()> {
         let mut storage = CachedStorage::new(Box::new(DummyBackend::new()));
         let study_id = storage.create_new_study("s", vec![Direction::Minimize])?.id;
-        storage.create_new_trial(study_id)?;
-        storage.create_new_trial(study_id)?;
+        let t0_id = storage.create_new_trial(study_id)?.id;
+        let t1_id = storage.create_new_trial(study_id)?.id;
 
         let trials = storage.get_trials(study_id)?;
         assert_eq!(trials.len(), 2);
-        let t0 = storage.get_trial(study_id, 0)?;
+        let t0 = storage.get_trial(t0_id)?;
         assert_eq!(t0.number, 0);
-        let t1 = storage.get_trial(study_id, 1)?;
+        let t1 = storage.get_trial(t1_id)?;
         assert_eq!(t1.number, 1);
         Ok(())
     }
@@ -756,11 +764,11 @@ mod tests {
     fn set_trial_state_values_updates_cache() -> Result<()> {
         let mut backend = DummyBackend::new();
         let study_id = backend.create_new_study("s", vec![Direction::Minimize])?.id;
-        backend.create_new_trial(study_id)?;
+        let trial_id = backend.create_new_trial(study_id)?.id;
 
         let mut storage = CachedStorage::new(Box::new(backend));
-        storage.set_trial_state_values(study_id, 0, TrialStateValues::Complete(vec![1.0]))?;
-        let trial = storage.get_trial(study_id, 0)?;
+        storage.set_trial_state_values(trial_id, TrialStateValues::Complete(vec![1.0]))?;
+        let trial = storage.get_trial(trial_id)?;
         assert!(matches!(trial.state_values, TrialStateValues::Complete(_)));
         Ok(())
     }
@@ -776,9 +784,9 @@ mod tests {
             step: None,
             log: false,
         };
-        storage.create_new_trial(study_id)?;
-        storage.set_trial_param(study_id, 0, "x", &dist, 0.5)?;
-        storage.set_trial_state_values(study_id, 0, TrialStateValues::Complete(vec![0.0]))?;
+        let trial_id = storage.create_new_trial(study_id)?.id;
+        storage.set_trial_param(trial_id, "x", &dist, 0.5)?;
+        storage.set_trial_state_values(trial_id, TrialStateValues::Complete(vec![0.0]))?;
 
         let search_space = storage.get_joint_search_space(study_id)?;
         assert!(search_space.contains_key("x"));
@@ -806,7 +814,8 @@ mod tests {
         let mut t_attrs = Attrs::new();
         t_attrs.insert(AttrKey::System("key".to_string()), "val".to_string());
         storage.set_trial_attrs(study_id, 0, t_attrs, false)?;
-        let trial = storage.get_trial(study_id, 0)?;
+        let trial_id = storage.get_trials(study_id)?[0].id;
+        let trial = storage.get_trial(trial_id)?;
         assert_eq!(
             trial
                 .attrs
@@ -830,9 +839,10 @@ mod tests {
             step: None,
             log: false,
         };
-        storage.set_trial_param(study_id, 0, "x", &dist, 0.5)?;
+        let trial_id = storage.get_trials(study_id)?[0].id;
+        storage.set_trial_param(trial_id, "x", &dist, 0.5)?;
 
-        let trial = storage.get_trial(study_id, 0)?;
+        let trial = storage.get_trial(trial_id)?;
         assert_eq!(trial.internal_params.get("x"), Some(&0.5));
         assert_eq!(
             trial.distributions.get("x"),
@@ -856,9 +866,9 @@ mod tests {
             .id;
         storage.create_new_study("test2", vec![Direction::Minimize])?;
         let trial_1 = storage.create_new_trial(study_id)?;
-        let trial_1_number = trial_1.number;
+        let trial_1_id = trial_1.id;
         let trial_2 = storage.create_new_trial(study_id)?;
-        let trial_2_number = trial_2.number;
+        let trial_2_id = trial_2.id;
 
         // Setup distributions
         let distribution_x = Distribution::Float {
@@ -877,16 +887,16 @@ mod tests {
         };
 
         // Set new params.
-        storage.set_trial_param(study_id, trial_1_number, "x", &distribution_x, 0.5)?;
-        storage.set_trial_param(study_id, trial_1_number, "y", &distribution_y_1, 2.0)?;
-        let trial = storage.get_trial(study_id, trial_1_number)?;
+        storage.set_trial_param(trial_1_id, "x", &distribution_x, 0.5)?;
+        storage.set_trial_param(trial_1_id, "y", &distribution_y_1, 2.0)?;
+        let trial = storage.get_trial(trial_1_id)?;
         assert_eq!(trial.internal_params["x"], 0.5);
         assert_eq!(trial.internal_params["y"], 2.0);
 
         // Set params to another trial
-        storage.set_trial_param(study_id, trial_2_number, "x", &distribution_x, 0.3)?;
-        storage.set_trial_param(study_id, trial_2_number, "z", &distribution_z, 0.1)?;
-        let trial = storage.get_trial(study_id, trial_2_number)?;
+        storage.set_trial_param(trial_2_id, "x", &distribution_x, 0.3)?;
+        storage.set_trial_param(trial_2_id, "z", &distribution_z, 0.1)?;
+        let trial = storage.get_trial(trial_2_id)?;
         assert_eq!(trial.internal_params["x"], 0.3);
         assert_eq!(trial.internal_params["z"], 0.1);
 
@@ -913,12 +923,12 @@ mod tests {
             log: false,
         };
 
-        let trial0 = storage.create_new_trial(study_id)?.clone();
-        storage.set_trial_param(study_id, trial0.number, "x", &float_dist, 0.5)?;
+        let trial0_id = storage.create_new_trial(study_id)?.id;
+        storage.set_trial_param(trial0_id, "x", &float_dist, 0.5)?;
 
-        let trial1 = storage.create_new_trial(study_id)?.clone();
+        let trial1_id = storage.create_new_trial(study_id)?.id;
         let err = storage
-            .set_trial_param(study_id, trial1.number, "x", &int_dist, 1.0)
+            .set_trial_param(trial1_id, "x", &int_dist, 1.0)
             .expect_err("Expected IncompatibleDistribution error");
         assert!(matches!(err.kind, ErrorKind::IncompatibleDistribution));
         Ok(())

--- a/rustuna_storages/src/journal/storage.rs
+++ b/rustuna_storages/src/journal/storage.rs
@@ -168,17 +168,24 @@ impl Storage for JournalStorage {
 
     fn set_trial_param(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         name: &str,
         distribution: &Distribution,
         value: f64,
     ) -> Result<()> {
         self.sync_with_backend()?;
-        let trial_id = self
-            .replay
-            .trial_id_from_study_number(study_id, trial_number)?;
         self.replay.ensure_trial_updatable(trial_id)?;
+        let (study_id, _trial_number) = self
+            .replay
+            .trial_id_to_study_number
+            .get(&trial_id)
+            .copied()
+            .ok_or_else(|| {
+                Error::with_reason(
+                    ErrorKind::TrialNotFound,
+                    format!("Trial not found in storage: trial_id={trial_id}"),
+                )
+            })?;
         self.replay
             .check_param_compatibility(study_id, name, distribution)?;
         let labels = self.replay.labels_for_param(study_id, name);
@@ -202,15 +209,22 @@ impl Storage for JournalStorage {
 
     fn set_trial_state_values(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         state_values: TrialStateValues,
     ) -> Result<()> {
         self.sync_with_backend()?;
-        let trial_id = self
-            .replay
-            .trial_id_from_study_number(study_id, trial_number)?;
         self.replay.ensure_trial_updatable(trial_id)?;
+        let (study_id, trial_number) = self
+            .replay
+            .trial_id_to_study_number
+            .get(&trial_id)
+            .copied()
+            .ok_or_else(|| {
+                Error::with_reason(
+                    ErrorKind::TrialNotFound,
+                    format!("Trial not found in storage: trial_id={trial_id}"),
+                )
+            })?;
         let existing_trial = self
             .replay
             .trial_from_study_number(study_id, trial_number)?;
@@ -289,8 +303,19 @@ impl Storage for JournalStorage {
         Ok(trials)
     }
 
-    fn get_trial(&mut self, study_id: u32, trial_number: u32) -> Result<&PersistedTrial> {
+    fn get_trial(&mut self, trial_id: u32) -> Result<&PersistedTrial> {
         self.sync_with_backend()?;
+        let (study_id, trial_number) = self
+            .replay
+            .trial_id_to_study_number
+            .get(&trial_id)
+            .copied()
+            .ok_or_else(|| {
+                Error::with_reason(
+                    ErrorKind::TrialNotFound,
+                    format!("Trial not found in storage: trial_id={trial_id}"),
+                )
+            })?;
         let trials = self.replay.trials_by_study.get(&study_id).ok_or_else(|| {
             Error::with_reason(
                 ErrorKind::StudyNotFound,
@@ -307,6 +332,16 @@ impl Storage for JournalStorage {
                 ),
             )
         })
+    }
+
+    fn get_trial_id_from_study_id_trial_number(
+        &mut self,
+        study_id: u32,
+        trial_number: u32,
+    ) -> Result<u32> {
+        self.sync_with_backend()?;
+        self.replay
+            .trial_id_from_study_number(study_id, trial_number)
     }
 
     fn set_study_attrs(
@@ -422,30 +457,6 @@ impl Storage for JournalStorage {
 }
 
 impl OptunaCompatibleStorage for JournalStorage {
-    fn get_study_id_trial_number_from_trial_id(&mut self, trial_id: u32) -> Result<(u32, u32)> {
-        self.sync_with_backend()?;
-        self.replay
-            .trial_id_to_study_number
-            .get(&trial_id)
-            .copied()
-            .ok_or_else(|| {
-                Error::with_reason(
-                    ErrorKind::TrialNotFound,
-                    format!("Trial not found in storage: trial_id={trial_id}"),
-                )
-            })
-    }
-
-    fn get_trial_id_from_study_id_trial_number(
-        &mut self,
-        study_id: u32,
-        trial_number: u32,
-    ) -> Result<u32> {
-        self.sync_with_backend()?;
-        self.replay
-            .trial_id_from_study_number(study_id, trial_number)
-    }
-
     fn set_trial_datetime(
         &mut self,
         trial_id: u32,
@@ -812,7 +823,7 @@ impl JournalReplayState {
             .map(|ids| ids.len())
             .unwrap_or(0) as u32;
 
-        let mut trial = PersistedTrial::new(study_id, trial_number);
+        let mut trial = PersistedTrial::new(trial_id, study_id, trial_number);
         let state_code = log
             .fields
             .get("state")
@@ -2029,14 +2040,14 @@ mod tests {
     fn get_trials_and_get_trial_return_cached_refs() -> Result<()> {
         let (mut storage, _logs) = new_storage()?;
         let study_id = storage.create_new_study("s", vec![Direction::Minimize])?.id;
-        storage.create_new_trial(study_id)?;
-        storage.create_new_trial(study_id)?;
+        let t0_id = storage.create_new_trial(study_id)?.id;
+        let t1_id = storage.create_new_trial(study_id)?.id;
 
         let trials = storage.get_trials(study_id)?;
         assert_eq!(trials.len(), 2);
-        let t0 = storage.get_trial(study_id, 0)?;
+        let t0 = storage.get_trial(t0_id)?;
         assert_eq!(t0.number, 0);
-        let t1 = storage.get_trial(study_id, 1)?;
+        let t1 = storage.get_trial(t1_id)?;
         assert_eq!(t1.number, 1);
         Ok(())
     }
@@ -2084,10 +2095,10 @@ mod tests {
     fn set_trial_state_values_updates_cache() -> Result<()> {
         let (mut storage, _logs) = new_storage()?;
         let study_id = storage.create_new_study("s", vec![Direction::Minimize])?.id;
-        storage.create_new_trial(study_id)?;
+        let trial_id = storage.create_new_trial(study_id)?.id;
 
-        storage.set_trial_state_values(study_id, 0, TrialStateValues::Complete(vec![1.0]))?;
-        let trial = storage.get_trial(study_id, 0)?;
+        storage.set_trial_state_values(trial_id, TrialStateValues::Complete(vec![1.0]))?;
+        let trial = storage.get_trial(trial_id)?;
         assert!(matches!(trial.state_values, TrialStateValues::Complete(_)));
         Ok(())
     }
@@ -2103,9 +2114,9 @@ mod tests {
             step: None,
             log: false,
         };
-        storage.create_new_trial(study_id)?;
-        storage.set_trial_param(study_id, 0, "x", &dist, 0.5)?;
-        storage.set_trial_state_values(study_id, 0, TrialStateValues::Complete(vec![0.0]))?;
+        let trial_id = storage.create_new_trial(study_id)?.id;
+        storage.set_trial_param(trial_id, "x", &dist, 0.5)?;
+        storage.set_trial_state_values(trial_id, TrialStateValues::Complete(vec![0.0]))?;
 
         let search_space = storage.get_joint_search_space(study_id)?;
         assert!(search_space.contains_key("x"));
@@ -2133,7 +2144,8 @@ mod tests {
         let mut t_attrs = Attrs::new();
         t_attrs.insert(AttrKey::System("key".to_string()), "val".to_string());
         storage.set_trial_attrs(study_id, 0, t_attrs, false)?;
-        let trial = storage.get_trial(study_id, 0)?;
+        let trial_id = storage.get_trials(study_id)?[0].id;
+        let trial = storage.get_trial(trial_id)?;
         assert_eq!(
             trial
                 .attrs
@@ -2156,9 +2168,10 @@ mod tests {
             step: None,
             log: false,
         };
-        storage.set_trial_param(study_id, 0, "x", &dist, 0.5)?;
+        let trial_id = storage.get_trials(study_id)?[0].id;
+        storage.set_trial_param(trial_id, "x", &dist, 0.5)?;
 
-        let trial = storage.get_trial(study_id, 0)?;
+        let trial = storage.get_trial(trial_id)?;
         assert_eq!(trial.internal_params.get("x"), Some(&0.5));
         assert_eq!(
             trial.distributions.get("x"),
@@ -2179,8 +2192,8 @@ mod tests {
             .create_new_study("test1", vec![Direction::Minimize])?
             .id;
         storage.create_new_study("test2", vec![Direction::Minimize])?;
-        let trial_1_number = storage.create_new_trial(study_id)?.number;
-        let trial_2_number = storage.create_new_trial(study_id)?.number;
+        let trial_1_id = storage.create_new_trial(study_id)?.id;
+        let trial_2_id = storage.create_new_trial(study_id)?.id;
 
         let distribution_x = Distribution::Float {
             low: 1.0,
@@ -2196,15 +2209,15 @@ mod tests {
             log: true,
         };
 
-        storage.set_trial_param(study_id, trial_1_number, "x", &distribution_x, 0.5)?;
-        storage.set_trial_param(study_id, trial_1_number, "y", &distribution_y_1, 2.0)?;
-        let trial = storage.get_trial(study_id, trial_1_number)?;
+        storage.set_trial_param(trial_1_id, "x", &distribution_x, 0.5)?;
+        storage.set_trial_param(trial_1_id, "y", &distribution_y_1, 2.0)?;
+        let trial = storage.get_trial(trial_1_id)?;
         assert_eq!(trial.internal_params["x"], 0.5);
         assert_eq!(trial.internal_params["y"], 2.0);
 
-        storage.set_trial_param(study_id, trial_2_number, "x", &distribution_x, 0.3)?;
-        storage.set_trial_param(study_id, trial_2_number, "z", &distribution_z, 0.1)?;
-        let trial = storage.get_trial(study_id, trial_2_number)?;
+        storage.set_trial_param(trial_2_id, "x", &distribution_x, 0.3)?;
+        storage.set_trial_param(trial_2_id, "z", &distribution_z, 0.1)?;
+        let trial = storage.get_trial(trial_2_id)?;
         assert_eq!(trial.internal_params["x"], 0.3);
         assert_eq!(trial.internal_params["z"], 0.1);
 
@@ -2231,12 +2244,12 @@ mod tests {
             log: false,
         };
 
-        let trial0 = storage.create_new_trial(study_id)?.clone();
-        storage.set_trial_param(study_id, trial0.number, "x", &float_dist, 0.5)?;
+        let trial0_id = storage.create_new_trial(study_id)?.id;
+        storage.set_trial_param(trial0_id, "x", &float_dist, 0.5)?;
 
-        let trial1 = storage.create_new_trial(study_id)?.clone();
+        let trial1_id = storage.create_new_trial(study_id)?.id;
         let err = storage
-            .set_trial_param(study_id, trial1.number, "x", &int_dist, 1.0)
+            .set_trial_param(trial1_id, "x", &int_dist, 1.0)
             .expect_err("Expected IncompatibleDistribution error");
         assert!(matches!(err.kind, ErrorKind::IncompatibleDistribution));
         Ok(())

--- a/rustuna_storages/src/optuna.rs
+++ b/rustuna_storages/src/optuna.rs
@@ -6,12 +6,6 @@ use rustuna_core::Result;
 use serde::{Deserialize, Serialize};
 
 pub trait OptunaCompatibleStorage: Send + Sync {
-    fn get_study_id_trial_number_from_trial_id(&mut self, trial_id: u32) -> Result<(u32, u32)>;
-    fn get_trial_id_from_study_id_trial_number(
-        &mut self,
-        study_id: u32,
-        trial_number: u32,
-    ) -> Result<u32>;
     fn set_trial_datetime(
         &mut self,
         trial_id: u32,

--- a/rustuna_storages/src/sqlite3.rs
+++ b/rustuna_storages/src/sqlite3.rs
@@ -17,6 +17,7 @@ pub struct SQLite3Storage {
 }
 
 const SCHEMA_SQL: &str = include_str!("sqlite3_schema.sql");
+type TrialRow = (u32, u32, String, Option<String>, Option<String>);
 
 impl SQLite3Storage {
     pub fn new(file_path: &str) -> Result<SQLite3Storage> {
@@ -194,7 +195,7 @@ impl CachedStorageBackend for SQLite3Storage {
                 )
             })?;
 
-        let mut trial = PersistedTrial::new(study_id, number);
+        let mut trial = PersistedTrial::new(trial_id, study_id, number);
         if let Some(dt) = datetime_start {
             let v = serde_json::to_string(&dt).map_err(|e| {
                 Error::with_reason(
@@ -211,8 +212,7 @@ impl CachedStorageBackend for SQLite3Storage {
 
     fn set_trial_param(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         name: &str,
         distribution: &rustuna_core::distribution::Distribution,
         value: f64,
@@ -222,10 +222,10 @@ impl CachedStorageBackend for SQLite3Storage {
             .conn
             .lock()
             .map_err(|_| Error::new(ErrorKind::StorageError))?;
-        let trial_id: Option<u32> = guard
+        let exists: Option<u32> = guard
             .query_row(
-                "SELECT trial_id FROM trials WHERE study_id = ? AND number = ?",
-                params![study_id, trial_number],
+                "SELECT trial_id FROM trials WHERE trial_id = ?",
+                params![trial_id],
                 |row| row.get(0),
             )
             .optional()
@@ -235,7 +235,9 @@ impl CachedStorageBackend for SQLite3Storage {
                     format!("Database query failed: {e}"),
                 )
             })?;
-        let trial_id = trial_id.ok_or(Error::new(ErrorKind::TrialNotFound))?;
+        if exists.is_none() {
+            return Err(Error::new(ErrorKind::TrialNotFound));
+        }
 
         let distribution_json = distribution_to_json(distribution, None);
         guard
@@ -257,19 +259,18 @@ impl CachedStorageBackend for SQLite3Storage {
 
     fn set_trial_state_values(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         state_values: rustuna_core::trial::TrialStateValues,
     ) -> rustuna_core::Result<()> {
         let guard = self
             .conn
             .lock()
             .map_err(|_| Error::new(ErrorKind::StorageError))?;
-        let result: Option<(u32, String)> = guard
+        let result: Option<String> = guard
             .query_row(
-                "SELECT trial_id, state FROM trials WHERE study_id = ? AND number = ?",
-                params![study_id, trial_number],
-                |row| Ok((row.get(0)?, row.get(1)?)),
+                "SELECT state FROM trials WHERE trial_id = ?",
+                params![trial_id],
+                |row| row.get(0),
             )
             .optional()
             .map_err(|e| {
@@ -278,7 +279,7 @@ impl CachedStorageBackend for SQLite3Storage {
                     format!("Database query failed: {e}"),
                 )
             })?;
-        let (trial_id, current_state) = result.ok_or(Error::new(ErrorKind::TrialNotFound))?;
+        let current_state = result.ok_or(Error::new(ErrorKind::TrialNotFound))?;
 
         if matches!(current_state.as_str(), "COMPLETE" | "FAIL" | "PRUNED") {
             return Err(Error::new(ErrorKind::TrialAlreadyFinished));
@@ -507,8 +508,7 @@ impl CachedStorageBackend for SQLite3Storage {
 
     fn get_trial(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
     ) -> rustuna_core::Result<rustuna_core::trial::PersistedTrial> {
         let guard = self
             .conn
@@ -516,15 +516,15 @@ impl CachedStorageBackend for SQLite3Storage {
             .map_err(|_| Error::new(ErrorKind::StorageError))?;
 
         // Query to trials table .
-        let trial_row: Option<(u32, String, Option<String>, Option<String>)> = guard
+        let trial_row: Option<TrialRow> = guard
             .query_row(
-                "SELECT trial_id, state, datetime_start, datetime_complete FROM trials WHERE study_id = ? AND number = ?",
-                params![study_id, trial_number],
-                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+                "SELECT study_id, number, state, datetime_start, datetime_complete FROM trials WHERE trial_id = ?",
+                params![trial_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
             )
             .optional()
             .map_err(|e| Error::with_reason(ErrorKind::StorageError, format!("Database query failed: {e}")))?;
-        let (trial_id, state_str, datetime_start, datetime_complete) =
+        let (study_id, number, state_str, datetime_start, datetime_complete) =
             trial_row.ok_or(Error::new(ErrorKind::TrialNotFound))?;
         let state_values = match state_str.as_str() {
             "RUNNING" | "WAITING" => TrialStateValues::Running,
@@ -735,7 +735,7 @@ impl CachedStorageBackend for SQLite3Storage {
             );
         }
 
-        let mut trial = PersistedTrial::new(study_id, trial_number);
+        let mut trial = PersistedTrial::new(trial_id, study_id, number);
         trial.state_values = state_values;
         trial.internal_params = internal_params;
         trial.distributions = distributions;
@@ -1270,7 +1270,7 @@ impl CachedStorageBackend for SQLite3Storage {
                 );
             }
 
-            let mut trial = PersistedTrial::new(study_id, number);
+            let mut trial = PersistedTrial::new(trial_id, study_id, number);
             trial.state_values = state_values;
             trial.internal_params = internal_params;
             trial.distributions = distributions;
@@ -1385,52 +1385,6 @@ impl CachedStorageBackend for SQLite3Storage {
 }
 
 impl OptunaCompatibleStorage for SQLite3Storage {
-    fn get_study_id_trial_number_from_trial_id(&mut self, trial_id: u32) -> Result<(u32, u32)> {
-        let guard = self
-            .conn
-            .lock()
-            .map_err(|_| Error::new(ErrorKind::StorageError))?;
-        let result: Option<(u32, u32)> = guard
-            .query_row(
-                "SELECT study_id, number FROM trials WHERE trial_id = ?",
-                params![trial_id],
-                |row| Ok((row.get(0)?, row.get(1)?)),
-            )
-            .optional()
-            .map_err(|e| {
-                Error::with_reason(
-                    ErrorKind::StorageError,
-                    format!("Database query failed: {e}"),
-                )
-            })?;
-        result.ok_or_else(|| Error::new(ErrorKind::TrialNotFound))
-    }
-
-    fn get_trial_id_from_study_id_trial_number(
-        &mut self,
-        study_id: u32,
-        trial_number: u32,
-    ) -> Result<u32> {
-        let guard = self
-            .conn
-            .lock()
-            .map_err(|_| Error::new(ErrorKind::StorageError))?;
-        let trial_id: Option<u32> = guard
-            .query_row(
-                "SELECT trial_id FROM trials WHERE study_id = ? AND number = ?",
-                params![study_id, trial_number],
-                |row| row.get(0),
-            )
-            .optional()
-            .map_err(|e| {
-                Error::with_reason(
-                    ErrorKind::StorageError,
-                    format!("Database query failed: {e}"),
-                )
-            })?;
-        trial_id.ok_or_else(|| Error::new(ErrorKind::TrialNotFound))
-    }
-
     fn get_trials_diff_optuna(
         &mut self,
         study_id: u32,
@@ -1890,7 +1844,7 @@ mod tests {
             step: None,
             log: false,
         };
-        storage.set_trial_param(study_id, trial.number, "float", &float_dist, 0.5)?;
+        storage.set_trial_param(trial.id, "float", &float_dist, 0.5)?;
 
         // IntDistribution
         let int_dist = Distribution::Int {
@@ -1899,14 +1853,14 @@ mod tests {
             step: 1,
             log: false,
         };
-        storage.set_trial_param(study_id, trial.number, "int", &int_dist, 5.0)?;
+        storage.set_trial_param(trial.id, "int", &int_dist, 5.0)?;
 
         // CategoricalDistribution
         let categorical_dist = Distribution::Categorical { cardinality: 3 };
-        storage.set_trial_param(study_id, trial.number, "cat", &categorical_dist, 1.0)?;
+        storage.set_trial_param(trial.id, "cat", &categorical_dist, 1.0)?;
 
         // Check distributions
-        let trial = storage.get_trial(study_id, trial.number)?;
+        let trial = storage.get_trial(trial.id)?;
         assert_eq!(trial.distributions.len(), 3);
         assert_eq!(trial.distributions["float"], float_dist);
         assert_eq!(trial.distributions["int"], int_dist);
@@ -2012,7 +1966,7 @@ mod tests {
 
         storage.set_trial_attrs(study_id, trial.number, attrs, false)?;
 
-        let trial = storage.get_trial(study_id, trial.number)?;
+        let trial = storage.get_trial(trial.id)?;
         assert_eq!(
             trial
                 .attrs
@@ -2057,7 +2011,7 @@ mod tests {
             .expect_err("Expected AttrOverwriteNotAllowed error");
         assert!(matches!(err.kind, ErrorKind::AttrOverwriteNotAllowed));
 
-        let trial = storage.get_trial(study_id, trial.number)?;
+        let trial = storage.get_trial(trial.id)?;
         assert_eq!(
             trial
                 .attrs
@@ -2081,13 +2035,9 @@ mod tests {
 
         assert_eq!(trial.state_values, TrialStateValues::Running);
 
-        storage.set_trial_state_values(
-            study_id,
-            trial.number,
-            TrialStateValues::Complete(vec![1.5, 2.5]),
-        )?;
+        storage.set_trial_state_values(trial.id, TrialStateValues::Complete(vec![1.5, 2.5]))?;
 
-        let trial = storage.get_trial(study_id, trial.number)?;
+        let trial = storage.get_trial(trial.id)?;
         assert_eq!(
             trial.state_values,
             TrialStateValues::Complete(vec![1.5, 2.5])
@@ -2103,9 +2053,9 @@ mod tests {
             .id;
         let trial = storage.create_new_trial(study_id)?;
 
-        storage.set_trial_state_values(study_id, trial.number, TrialStateValues::Fail)?;
+        storage.set_trial_state_values(trial.id, TrialStateValues::Fail)?;
 
-        let trial = storage.get_trial(study_id, trial.number)?;
+        let trial = storage.get_trial(trial.id)?;
         assert_eq!(trial.state_values, TrialStateValues::Fail);
         Ok(())
     }
@@ -2120,11 +2070,7 @@ mod tests {
         // Create 5 trials
         for i in 0..5 {
             let trial = storage.create_new_trial(study_id)?;
-            storage.set_trial_state_values(
-                study_id,
-                trial.number,
-                TrialStateValues::Complete(vec![i as f64]),
-            )?;
+            storage.set_trial_state_values(trial.id, TrialStateValues::Complete(vec![i as f64]))?;
         }
 
         // Get all trials with number > 2
@@ -2235,33 +2181,25 @@ mod tests {
         let trial3 = storage.create_new_trial(study_id2)?;
         let trial4 = storage.create_new_trial(study_id)?;
 
-        // Get trial_ids via OptunaCompatibleStorage
-        let trial_id_1 =
-            storage.get_trial_id_from_study_id_trial_number(study_id, trial1.number)?;
-        let trial_id_3 =
-            storage.get_trial_id_from_study_id_trial_number(study_id2, trial3.number)?;
-        let trial_id_4 =
-            storage.get_trial_id_from_study_id_trial_number(study_id, trial4.number)?;
-
         // Test setting new values
         let mut values1 = HashMap::new();
         values1.insert(0, 0.3);
         values1.insert(2, 0.4);
-        storage.set_trial_intermediate_values(trial_id_1, values1)?;
+        storage.set_trial_intermediate_values(trial1.id, values1)?;
 
         let mut values3 = HashMap::new();
         values3.insert(0, 0.1);
         values3.insert(1, 0.4);
         values3.insert(2, 0.5);
         values3.insert(3, f64::INFINITY);
-        storage.set_trial_intermediate_values(trial_id_3, values3)?;
+        storage.set_trial_intermediate_values(trial3.id, values3)?;
 
         let mut values4 = HashMap::new();
         values4.insert(0, f64::NAN);
-        storage.set_trial_intermediate_values(trial_id_4, values4)?;
+        storage.set_trial_intermediate_values(trial4.id, values4)?;
 
         // Verify trial 1
-        let trial1_result = storage.get_trial(study_id, trial1.number)?;
+        let trial1_result = storage.get_trial(trial1.id)?;
         let intermediate_json = trial1_result
             .attrs
             .get(&AttrKey::System("intermediate_values".to_string()))
@@ -2277,13 +2215,13 @@ mod tests {
         assert_eq!(intermediate_entries[1].value_type, "FINITE");
 
         // Verify trial 2 (no intermediate values)
-        let trial2_result = storage.get_trial(study_id, trial2.number)?;
+        let trial2_result = storage.get_trial(trial2.id)?;
         assert!(!trial2_result
             .attrs
             .contains_key(&AttrKey::System("intermediate_values".to_string())));
 
         // Verify trial 3
-        let trial3_result = storage.get_trial(study_id2, trial3.number)?;
+        let trial3_result = storage.get_trial(trial3.id)?;
         let intermediate_json = trial3_result
             .attrs
             .get(&AttrKey::System("intermediate_values".to_string()))
@@ -2305,7 +2243,7 @@ mod tests {
         assert_eq!(intermediate_entries[3].value_type, "INF_POS");
 
         // Verify trial 4 (NaN value)
-        let trial4_result = storage.get_trial(study_id, trial4.number)?;
+        let trial4_result = storage.get_trial(trial4.id)?;
         let intermediate_json = trial4_result
             .attrs
             .get(&AttrKey::System("intermediate_values".to_string()))
@@ -2320,9 +2258,9 @@ mod tests {
         // Test overwriting existing step
         let mut values1_update = HashMap::new();
         values1_update.insert(0, 0.2);
-        storage.set_trial_intermediate_values(trial_id_1, values1_update)?;
+        storage.set_trial_intermediate_values(trial1.id, values1_update)?;
 
-        let trial1_updated = storage.get_trial(study_id, trial1.number)?;
+        let trial1_updated = storage.get_trial(trial1.id)?;
         let intermediate_json = trial1_updated
             .attrs
             .get(&AttrKey::System("intermediate_values".to_string()))
@@ -2338,7 +2276,7 @@ mod tests {
         assert_eq!(intermediate_entries[1].value_type, "FINITE");
 
         // Test non-existent trial
-        let non_existent_trial_id = trial_id_4 + 1000;
+        let non_existent_trial_id = trial4.id + 1000;
         let mut invalid_values = HashMap::new();
         invalid_values.insert(0, 0.5);
         let err = storage

--- a/rustuna_storages/tests/journal.rs
+++ b/rustuna_storages/tests/journal.rs
@@ -120,7 +120,8 @@ study.optimize(objective, n_trials=10)
         studies[0].id
     };
 
-    let trial0 = storage.get_trial(study_id, 0)?;
+    let trial_id = storage.get_trials(study_id)?[0].id;
+    let trial0 = storage.get_trial(trial_id)?;
     assert_eq!(trial0.number, 0);
 
     // Distributions

--- a/rustuna_storages/tests/sqlite3.rs
+++ b/rustuna_storages/tests/sqlite3.rs
@@ -90,7 +90,11 @@ study.optimize(objective, n_trials=10)
     let studies = storage.get_studies()?;
     assert_eq!(studies.len(), 1);
 
-    let trial0 = storage.get_trial(studies[0].id, 0)?;
+    let trials = storage.get_trials_diff(studies[0].id, &[], -1)?;
+    let trial0 = trials
+        .into_iter()
+        .find(|trial| trial.number == 0)
+        .expect("trial number 0 should exist");
     assert_eq!(trial0.number, 0);
 
     // Distributions


### PR DESCRIPTION
This PR introduces `trial_id` in `rustuna_core` to simplify Optuna compatible storage implementations.