### PR TITLE
Remove trials cache on `ToOptunaStorage` converter class.

### DIFF
--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -241,9 +241,6 @@ class OptunaStorageProtocol(StorageProtocol, Protocol):
     def set_trial_intermediate_value(
         self, trial_id: int, step: int, intermediate_value: float
     ) -> None: ...
-    def get_trials_diff(
-        self, study_id: int, included_numbers: list[int], trial_number_greater_than: int
-    ) -> list[PersistedTrial]: ...
 
 class Storage:
     @classmethod

--- a/rustuna_pyo3/rustuna/converter/_storage.py
+++ b/rustuna_pyo3/rustuna/converter/_storage.py
@@ -141,33 +141,6 @@ class ToRustunaStorage:
 class ToOptunaStorage(BaseStorage):
     def __init__(self, storage: rustuna.OptunaStorageProtocol) -> None:
         self._storage = storage
-        self._trials_cache: dict[int, dict[int, FrozenTrial]] = {}
-        self._unfinished_trial_numbers: dict[int, list[int]] = {}
-        self._last_finished_trial_number: dict[int, int] = {}
-
-    def _refresh_trials_cache(self, study_id: int) -> None:
-        included_numbers = self._unfinished_trial_numbers.get(study_id, [])
-        trial_number_greater_than = self._last_finished_trial_number.get(study_id, -1)
-        try:
-            rustuna_trials = self._storage.get_trials_diff(
-                study_id, included_numbers, trial_number_greater_than
-            )
-        except AttributeError:
-            rustuna_trials = self._storage.get_trials(study_id)
-
-        cache = self._trials_cache.setdefault(study_id, {})
-        for trial in rustuna_trials:
-            cache[trial.number] = to_frozen_trial(trial)
-
-        unfinished_numbers: list[int] = []
-        last_finished = -1
-        for frozen_trial in cache.values():
-            if frozen_trial.state.is_finished():
-                last_finished = max(last_finished, frozen_trial.number)
-            else:
-                unfinished_numbers.append(frozen_trial.number)
-        self._unfinished_trial_numbers[study_id] = unfinished_numbers
-        self._last_finished_trial_number[study_id] = last_finished
 
     def create_new_study(
         self, directions: Sequence[StudyDirection], study_name: str | None = None
@@ -190,9 +163,6 @@ class ToOptunaStorage(BaseStorage):
 
     def delete_study(self, study_id: int) -> None:
         self._storage.delete_study(study_id=study_id)
-        self._trials_cache.pop(study_id, None)
-        self._unfinished_trial_numbers.pop(study_id, None)
-        self._last_finished_trial_number.pop(study_id, None)
 
     def set_study_user_attr(self, study_id: int, key: str, value: Any) -> None:
         self._storage.set_study_user_attrs(study_id, {key: json.dumps(value)})
@@ -338,9 +308,8 @@ class ToOptunaStorage(BaseStorage):
         deepcopy: bool = True,
         states: Container[TrialState] | None = None,
     ) -> list[FrozenTrial]:
-        self._refresh_trials_cache(study_id)
-        trials = list(self._trials_cache.get(study_id, {}).values())
-        trials.sort(key=lambda t: t.number)
+        rustuna_trials = self._storage.get_trials(study_id)
+        trials = [to_frozen_trial(t) for t in rustuna_trials]
         if states is not None:
             trials = [t for t in trials if t.state in states]
         if deepcopy:

--- a/rustuna_pyo3/src/storage.rs
+++ b/rustuna_pyo3/src/storage.rs
@@ -368,41 +368,6 @@ impl PyStorage {
         Ok(())
     }
 
-    fn get_trials_diff(
-        &mut self,
-        study_id: u32,
-        included_numbers: Vec<u32>,
-        trial_number_greater_than: i32,
-    ) -> PyResult<Vec<PyPersistedTrial>> {
-        let study_attrs = {
-            let mut guard = self
-                .storage
-                .write()
-                .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
-            Arc::new(
-                guard
-                    .get_study(study_id)
-                    .map_err(err_to_exceptions)?
-                    .attrs
-                    .clone(),
-            )
-        };
-        let optuna_storage = self.optuna_compatible.as_ref().ok_or_else(|| {
-            PyRuntimeError::new_err("This storage does not support Optuna-compatible operations")
-        })?;
-        let mut guard = optuna_storage
-            .write()
-            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
-        let trials = guard
-            .get_trials_diff_optuna(study_id, &included_numbers, trial_number_greater_than)
-            .map_err(err_to_exceptions)?;
-        let py_trials = trials
-            .into_iter()
-            .map(|t| PyPersistedTrial::new_with_arc(t, study_attrs.clone()))
-            .collect();
-        Ok(py_trials)
-    }
-
     fn set_trial_intermediate_value(
         &mut self,
         trial_id: u32,

--- a/rustuna_storages/src/cache.rs
+++ b/rustuna_storages/src/cache.rs
@@ -461,16 +461,6 @@ impl OptunaCompatibleStorage for CachedStorage {
             .set_trial_intermediate_values(trial_id, intermediate_values)?;
         Ok(())
     }
-
-    fn get_trials_diff_optuna(
-        &mut self,
-        study_id: u32,
-        included_numbers: &[u32],
-        trial_number_greater_than: i32,
-    ) -> Result<Vec<PersistedTrial>> {
-        self.backend
-            .get_trials_diff_optuna(study_id, included_numbers, trial_number_greater_than)
-    }
 }
 
 #[cfg(test)]
@@ -598,20 +588,6 @@ mod tests {
             _intermediate_values: HashMap<u32, f64>,
         ) -> Result<()> {
             todo!()
-        }
-
-        fn get_trials_diff_optuna(
-            &mut self,
-            study_id: u32,
-            included_numbers: &[u32],
-            trial_number_greater_than: i32,
-        ) -> Result<Vec<PersistedTrial>> {
-            <DummyBackend as CachedStorageBackend>::get_trials_diff(
-                self,
-                study_id,
-                included_numbers,
-                trial_number_greater_than,
-            )
         }
     }
     impl OptunaCachedStorageBackend for DummyBackend {}

--- a/rustuna_storages/src/journal/storage.rs
+++ b/rustuna_storages/src/journal/storage.rs
@@ -533,30 +533,6 @@ impl OptunaCompatibleStorage for JournalStorage {
         self.sync_with_backend()?;
         Ok(())
     }
-
-    fn get_trials_diff_optuna(
-        &mut self,
-        study_id: u32,
-        included_numbers: &[u32],
-        trial_number_greater_than: i32,
-    ) -> Result<Vec<PersistedTrial>> {
-        self.sync_with_backend()?;
-        let trials = self.replay.trials_by_study.get(&study_id).ok_or_else(|| {
-            Error::with_reason(
-                ErrorKind::StudyNotFound,
-                format!("Failed to get trials for study: study_id={study_id}"),
-            )
-        })?;
-        let mut result = Vec::new();
-        for trial in trials {
-            if included_numbers.contains(&trial.number)
-                || (trial.number as i32) > trial_number_greater_than
-            {
-                result.push(trial.clone());
-            }
-        }
-        Ok(result)
-    }
 }
 
 struct JournalReplayState {

--- a/rustuna_storages/src/optuna.rs
+++ b/rustuna_storages/src/optuna.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use chrono::NaiveDateTime;
-use rustuna_core::trial::PersistedTrial;
 use rustuna_core::Result;
 use serde::{Deserialize, Serialize};
 
@@ -17,12 +16,6 @@ pub trait OptunaCompatibleStorage: Send + Sync {
         trial_id: u32,
         intermediate_values: HashMap<u32, f64>,
     ) -> Result<()>;
-    fn get_trials_diff_optuna(
-        &mut self,
-        study_id: u32,
-        included_numbers: &[u32],
-        trial_number_greater_than: i32,
-    ) -> Result<Vec<PersistedTrial>>;
 }
 
 /// Intermediate value entry for JSON serialization.

--- a/rustuna_storages/src/sqlite3.rs
+++ b/rustuna_storages/src/sqlite3.rs
@@ -1385,20 +1385,6 @@ impl CachedStorageBackend for SQLite3Storage {
 }
 
 impl OptunaCompatibleStorage for SQLite3Storage {
-    fn get_trials_diff_optuna(
-        &mut self,
-        study_id: u32,
-        included_numbers: &[u32],
-        trial_number_greater_than: i32,
-    ) -> Result<Vec<PersistedTrial>> {
-        <SQLite3Storage as CachedStorageBackend>::get_trials_diff(
-            self,
-            study_id,
-            included_numbers,
-            trial_number_greater_than,
-        )
-    }
-
     fn set_trial_intermediate_values(
         &mut self,
         trial_id: u32,


### PR DESCRIPTION
Thanks to the huge improvements on `FrozenTrialLike` class, `get_trials_diff` storage is not required anymore. This PR simply removes `get_trials_diff` method and its related apis.