### PR TITLE
Add `from_storage` method in `PyPersistedTrial`

### DIFF
--- a/rustuna_core/src/storage.rs
+++ b/rustuna_core/src/storage.rs
@@ -375,7 +375,6 @@ fn check_trial_is_updatable(trial: &PersistedTrial) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::attr::{category_labels_to_attrs, CategoryLabel};
     use crate::distribution::Distribution;
 
     #[test]

--- a/rustuna_core/src/storage.rs
+++ b/rustuna_core/src/storage.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::attr::Attrs;
+use crate::attr::{category_labels_to_attrs, get_category_labels, Attrs, CategoryLabel};
 use crate::distribution::Distribution;
 use crate::study::{Direction, PersistedStudy};
 use crate::study_cache::StudyCache;
@@ -35,6 +35,23 @@ pub trait Storage: Send + Sync {
     fn get_study(&mut self, study_id: u32) -> Result<&PersistedStudy>;
     fn get_trials(&mut self, study_id: u32) -> Result<&Vec<PersistedTrial>>;
     fn get_trial(&mut self, trial_id: u32) -> Result<&PersistedTrial>;
+    // Design Note:
+    // Category labels are stored in study system attrs internally, but exposed via dedicated
+    // APIs for caching efficiency. Since category labels cannot be overwritten once set for
+    // a given (study_id, param_name), implementations can safely cache them without
+    // invalidation concerns.
+    fn set_category_labels(
+        &mut self,
+        study_id: u32,
+        param_name: &str,
+        labels: Vec<CategoryLabel>,
+    ) -> Result<()>;
+    fn get_category_labels(
+        &mut self,
+        study_id: u32,
+        param_name: &str,
+        cardinality: usize,
+    ) -> Result<Option<Vec<CategoryLabel>>>;
     fn get_trial_id_from_study_id_trial_number(
         &mut self,
         study_id: u32,
@@ -268,6 +285,26 @@ impl Storage for InMemoryStorage {
         Ok(trial)
     }
 
+    fn set_category_labels(
+        &mut self,
+        study_id: u32,
+        param_name: &str,
+        labels: Vec<CategoryLabel>,
+    ) -> Result<()> {
+        let attrs = category_labels_to_attrs(param_name, &labels);
+        self.set_study_attrs(study_id, attrs, true)
+    }
+
+    fn get_category_labels(
+        &mut self,
+        study_id: u32,
+        param_name: &str,
+        cardinality: usize,
+    ) -> Result<Option<Vec<CategoryLabel>>> {
+        let study = self.get_study(study_id)?;
+        Ok(get_category_labels(&study.attrs, param_name, cardinality))
+    }
+
     fn get_trial_id_from_study_id_trial_number(
         &mut self,
         study_id: u32,
@@ -338,6 +375,7 @@ fn check_trial_is_updatable(trial: &PersistedTrial) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::attr::{category_labels_to_attrs, CategoryLabel};
     use crate::distribution::Distribution;
 
     #[test]

--- a/rustuna_pyo3/rustuna/converter/_trial.py
+++ b/rustuna_pyo3/rustuna/converter/_trial.py
@@ -105,10 +105,12 @@ class FrozenTrialLike(FrozenTrial):
     def __init__(self, persisted_trial: rustuna.PersistedTrial) -> None:
         self._persisted_trial = persisted_trial
 
-        # The following field is defined to support property.setter
+        # Pre-cache frequently accessed lightweight fields to avoid repeated conversions
+        self.__number: int = persisted_trial.number
+        self.__state: TrialState = to_optuna_state(persisted_trial.state)
+        
+        # The following fields are defined to support property.setter (lazy evaluation)
         self.__trial_id: int | None = None
-        self.__number: int | None = None
-        self.__state: TrialState | None = None
         self.__values: list[float] | None = None
         self.__intermediate_values: dict[int, float] | None = None
         self.__datetime_start: datetime.datetime | None = None
@@ -149,9 +151,7 @@ class FrozenTrialLike(FrozenTrial):
 
     @property
     def number(self) -> int:
-        if self.__number is not None:
-            return self._number
-        return self._persisted_trial.number
+        return self.__number
 
     @number.setter
     def number(self, value: int) -> None:
@@ -159,7 +159,7 @@ class FrozenTrialLike(FrozenTrial):
 
     @property
     def state(self) -> TrialState:
-        return self.__state or to_optuna_state(self._persisted_trial.state)
+        return self.__state
 
     @state.setter
     def state(self, value: TrialState) -> None:

--- a/rustuna_pyo3/rustuna/converter/_trial.py
+++ b/rustuna_pyo3/rustuna/converter/_trial.py
@@ -26,12 +26,10 @@ if typing.TYPE_CHECKING:
     from optuna.distributions import BaseDistribution
     from optuna.trial import TrialState
 
-
 # This is a dummy datetime since Rustuna does not store the datetime_start and datetime_complete.
 dummy_datetime = datetime.datetime(
     2023, 11, 26, 16, 56, 38
 )  # Date of the initial commit of Rustuna
-
 
 to_rustuna_state_map = {
     optuna.trial.TrialState.RUNNING: rustuna.TrialState.RUNNING,
@@ -108,7 +106,7 @@ class FrozenTrialLike(FrozenTrial):
         # Pre-cache frequently accessed lightweight fields to avoid repeated conversions
         self.__number: int = persisted_trial.number
         self.__state: TrialState = to_optuna_state(persisted_trial.state)
-        
+
         # The following fields are defined to support property.setter (lazy evaluation)
         self.__trial_id: int | None = None
         self.__values: list[float] | None = None

--- a/rustuna_pyo3/src/distribution.rs
+++ b/rustuna_pyo3/src/distribution.rs
@@ -31,6 +31,16 @@ impl PyDistribution {
             },
         }
     }
+
+    pub fn new_with_category_labels(
+        distribution: Distribution,
+        category_labels: Option<Vec<CategoryLabel>>,
+    ) -> PyDistribution {
+        PyDistribution {
+            distribution,
+            category_labels,
+        }
+    }
 }
 impl From<PyDistribution> for Distribution {
     fn from(val: PyDistribution) -> Self {
@@ -209,24 +219,21 @@ pub fn py_to_external_repr<'py>(
     py: Python<'py>,
     dist: &Distribution,
     internal_repr: f64,
-    param_name: &str,
-    study_attrs: &Attrs,
+    category_labels: Option<&[CategoryLabel]>,
 ) -> PyResult<Bound<'py, PyAny>> {
     match dist {
         Distribution::Float { .. } => Ok(internal_repr.into_pyobject(py)?.into_any()),
         Distribution::Int { .. } => Ok((internal_repr as i64).into_pyobject(py)?.into_any()),
-        Distribution::Categorical { cardinality } => {
-            match get_category_labels(study_attrs, param_name, *cardinality) {
-                Some(labels) => {
-                    let c = labels
-                        .get(internal_repr as usize)
-                        .ok_or(PyValueError::new_err(
-                            "Internal representation of categorical value is out of range",
-                        ))?;
-                    category_label_to_pyobject(py, c)
-                }
-                None => Ok((internal_repr as i64).into_pyobject(py)?.into_any()),
+        Distribution::Categorical { .. } => {
+            if let Some(labels) = category_labels {
+                let c = labels
+                    .get(internal_repr as usize)
+                    .ok_or(PyValueError::new_err(
+                        "Internal representation of categorical value is out of range",
+                    ))?;
+                return category_label_to_pyobject(py, c);
             }
+            Ok((internal_repr as i64).into_pyobject(py)?.into_any())
         }
     }
 }

--- a/rustuna_pyo3/src/pyobject_storage.rs
+++ b/rustuna_pyo3/src/pyobject_storage.rs
@@ -4,7 +4,7 @@ use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 
 use pyo3::types::PyList;
-use rustuna_core::attr::{AttrKey, Attrs};
+use rustuna_core::attr::{AttrKey, Attrs, CategoryLabel};
 use rustuna_core::distribution::Distribution;
 use rustuna_core::storage::{InMemoryStorage, Storage};
 use rustuna_core::study::{Direction, PersistedStudy};
@@ -464,6 +464,26 @@ impl Storage for PyObjectStorage {
         trial_id: u32,
     ) -> rustuna_core::Result<&rustuna_core::trial::PersistedTrial> {
         self.cache.get_trial(trial_id)
+    }
+
+    fn get_category_labels(
+        &mut self,
+        study_id: u32,
+        param_name: &str,
+        cardinality: usize,
+    ) -> rustuna_core::Result<Option<Vec<CategoryLabel>>> {
+        self.sync_study_from_id(study_id, true)?;
+        self.cache
+            .get_category_labels(study_id, param_name, cardinality)
+    }
+
+    fn set_category_labels(
+        &mut self,
+        study_id: u32,
+        param_name: &str,
+        labels: Vec<CategoryLabel>,
+    ) -> rustuna_core::Result<()> {
+        self.cache.set_category_labels(study_id, param_name, labels)
     }
 
     fn get_trial_id_from_study_id_trial_number(

--- a/rustuna_pyo3/src/storage.rs
+++ b/rustuna_pyo3/src/storage.rs
@@ -5,7 +5,7 @@ use pyo3::prelude::*;
 
 use chrono::NaiveDateTime;
 use pyo3::types::{PyList, PyType};
-use rustuna_core::attr::{category_labels_to_attrs, get_category_labels, CategoryLabel};
+use rustuna_core::attr::CategoryLabel;
 use rustuna_core::distribution::Distribution;
 use rustuna_core::storage::{InMemoryStorage, Storage};
 use rustuna_core::study::Direction;
@@ -114,7 +114,7 @@ impl PyStorage {
         let trial = guard
             .create_new_trial(study_id)
             .map_err(err_to_exceptions)?;
-        Ok(PyPersistedTrial::new(trial.clone(), Default::default()))
+        Ok(PyPersistedTrial::from_storage(self.storage.clone(), trial))
     }
 
     fn set_trial_param(
@@ -178,9 +178,11 @@ impl PyStorage {
             .storage
             .write()
             .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
-        let study = guard.get_study(study_id).map_err(err_to_exceptions)?;
-        Python::with_gil(
-            |py| match get_category_labels(&study.attrs, &param_name, cardinality) {
+        Python::with_gil(|py| {
+            match guard
+                .get_category_labels(study_id, &param_name, cardinality)
+                .map_err(err_to_exceptions)?
+            {
                 Some(labels) => {
                     let elements: PyResult<Vec<_>> = (0..cardinality)
                         .map(|i| {
@@ -194,8 +196,8 @@ impl PyStorage {
                     Ok(choices.unbind().into_any())
                 }
                 None => Ok(py.None()),
-            },
-        )
+            }
+        })
     }
 
     #[pyo3(signature = (trial_id, state, values=None))]
@@ -253,15 +255,10 @@ impl PyStorage {
             .storage
             .write()
             .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
-        let study_attrs = {
-            let study = guard.get_study(study_id).map_err(err_to_exceptions)?;
-            Arc::new(study.attrs.clone())
-        };
         let trials = guard.get_trials(study_id).map_err(err_to_exceptions)?;
-        // TODO(c-bata): Filter category_labels attrs and clone them only.
         let py_trials: Vec<PyPersistedTrial> = trials
             .iter()
-            .map(|t| PyPersistedTrial::new_with_arc(t.clone(), study_attrs.clone()))
+            .map(|t| PyPersistedTrial::from_storage(self.storage.clone(), t))
             .collect();
         Ok(py_trials)
     }
@@ -275,14 +272,12 @@ impl PyStorage {
             .get_trial(trial_id)
             .map_err(err_to_exceptions)?
             .clone();
-        let study_attrs = Arc::new(
-            guard
-                .get_study(trial.study_id)
-                .map_err(err_to_exceptions)?
-                .attrs
-                .clone(),
-        );
-        Ok(PyPersistedTrial::new_with_arc(trial, study_attrs))
+        let study_attrs = guard
+            .get_study(trial.study_id)
+            .map_err(err_to_exceptions)?
+            .attrs
+            .clone();
+        Ok(PyPersistedTrial::new(trial, study_attrs))
     }
 
     fn get_trial_id_from_study_id_trial_number(
@@ -415,18 +410,17 @@ impl PyStorage {
         param_name: String,
         category_labels: Vec<CategoryLabel>,
     ) -> PyResult<()> {
-        let attrs = category_labels_to_attrs(&param_name, &category_labels);
         let mut guard = self
             .storage
             .write()
             .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
-        match guard.set_study_attrs(study_id, attrs, true) {
+        match guard.set_category_labels(study_id, &param_name, category_labels.clone()) {
             Ok(_) => Ok(()),
             Err(e) => {
                 if matches!(e.kind, rustuna_core::ErrorKind::AttrOverwriteNotAllowed) {
-                    let study = guard.get_study(study_id).map_err(err_to_exceptions)?;
-                    let existing_labels =
-                        get_category_labels(&study.attrs, &param_name, category_labels.len());
+                    let existing_labels = guard
+                        .get_category_labels(study_id, &param_name, category_labels.len())
+                        .map_err(err_to_exceptions)?;
                     if let Some(existing) = existing_labels {
                         if existing == category_labels {
                             return Ok(());

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -300,34 +300,21 @@ impl PyStudy {
             PyRuntimeError::new_err(format!("Failed to get the best trial: {:?}", e.kind))
         })?;
 
-        let (trial, study_attrs) = {
-            let mut guard = self.study.storage.write().map_err(|e| {
-                PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
+        let mut guard = self.study.storage.write().map_err(|e| {
+            PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
+        })?;
+        let trial_id = guard
+            .get_trial_id_from_study_id_trial_number(self.study.id, trial_number)
+            .map_err(|e| {
+                PyRuntimeError::new_err(format!("Failed to get trial id: {:?}", e.kind))
             })?;
-            let trial_id = guard
-                .get_trial_id_from_study_id_trial_number(self.study.id, trial_number)
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind))
-                })?;
-            let trial = guard
-                .get_trial(trial_id)
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind))
-                })?
-                .clone();
-            let study_attrs = Arc::new(
-                guard
-                    .get_study(self.study.id)
-                    .map_err(|e| {
-                        PyRuntimeError::new_err(format!("Failed to get the study: {:?}", e.kind))
-                    })?
-                    .attrs
-                    .clone(),
-            );
-            (trial, study_attrs)
-        };
-        let trial = PyPersistedTrial::new_with_arc(trial, study_attrs);
-        Ok(trial)
+        let trial = guard
+            .get_trial(trial_id)
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get trial: {:?}", e.kind)))?;
+        Ok(PyPersistedTrial::from_storage(
+            self.study.storage.clone(),
+            trial,
+        ))
     }
 
     #[getter]
@@ -339,21 +326,10 @@ impl PyStudy {
             .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
         let trials_vec = guard
             .get_trials(self.study.id)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind)))?
-            .clone();
-        let study_attrs = Arc::new(
-            guard
-                .get_study(self.study.id)
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to get the study: {:?}", e.kind))
-                })?
-                .attrs
-                .clone(),
-        );
-
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind)))?;
         let trials: Vec<PyPersistedTrial> = trials_vec
             .iter()
-            .map(|t| PyPersistedTrial::new_with_arc(t.clone(), study_attrs.clone()))
+            .map(|t| PyPersistedTrial::from_storage(self.study.storage.clone(), t))
             .collect();
         Ok(trials)
     }
@@ -379,33 +355,18 @@ impl PyStudy {
         let pareto_front_numbers = get_pareto_front(&self.study).map_err(|e| {
             PyRuntimeError::new_err(format!("Failed to get the pareto front: {:?}", e.kind))
         })?;
-        let (trials_vec, study_attrs) = {
-            let mut guard = self
-                .study
-                .storage
-                .write()
-                .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
-            let trials_vec = guard
-                .get_trials(self.study.id)
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind))
-                })?
-                .clone();
-            let study_attrs = Arc::new(
-                guard
-                    .get_study(self.study.id)
-                    .map_err(|e| {
-                        PyRuntimeError::new_err(format!("Failed to get the study: {:?}", e.kind))
-                    })?
-                    .attrs
-                    .clone(),
-            );
-            (trials_vec, study_attrs)
-        };
+        let mut guard = self
+            .study
+            .storage
+            .write()
+            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
+        let trials_vec = guard
+            .get_trials(self.study.id)
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind)))?;
         let best_trials = pareto_front_numbers
             .iter()
             .map(|n| {
-                PyPersistedTrial::new_with_arc(trials_vec[*n as usize].clone(), study_attrs.clone())
+                PyPersistedTrial::from_storage(self.study.storage.clone(), &trials_vec[*n as usize])
             })
             .collect();
         Ok(best_trials)

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -165,6 +165,8 @@ enum PyPersistedTrialSource {
     },
 }
 
+type TrialParams = Vec<(String, f64, Distribution)>;
+
 #[pyclass(name = "PersistedTrial")]
 #[pyo3(module = "rustuna")]
 pub struct PyPersistedTrial {
@@ -227,7 +229,7 @@ impl PyPersistedTrial {
         }
     }
 
-    fn collect_params(&self) -> PyResult<(u32, Vec<(String, f64, Distribution)>)> {
+    fn collect_params(&self) -> PyResult<(u32, TrialParams)> {
         match &self.source {
             PyPersistedTrialSource::Owned(trial) => {
                 let mut params: Vec<(String, f64, Distribution)> =

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -1,18 +1,19 @@
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use rustuna_core::attr::{AttrKey, Attrs, CategoryLabel};
+use rustuna_core::attr::{get_category_labels, AttrKey, Attrs, CategoryLabel};
 use rustuna_core::distribution::Distribution;
-
+use rustuna_core::storage::Storage;
 use rustuna_core::trial::{PersistedTrial, Trial, TrialStateValues};
 
 use crate::attrs::pyobj_to_attrs;
 use crate::distribution::{
     category_label_to_pyobject, py_to_external_repr, pyobject_to_category_label, PyDistribution,
 };
+use crate::exception::err_to_exceptions;
 
 #[derive(Clone, Debug, PartialEq)]
 #[pyclass(name = "TrialState", eq, eq_int)]
@@ -149,16 +150,161 @@ impl PyTrial {
     }
 }
 
-#[derive(Debug)]
+enum PyPersistedTrialSource {
+    Owned(PersistedTrial),
+    StorageBacked {
+        storage: Arc<RwLock<dyn Storage>>,
+        trial_id: u32,
+        // Eagerly cached lightweight fields
+        study_id: u32,
+        number: u32,
+        state: PyTrialState,
+        values: Option<Vec<f64>>,
+        internal_params: HashMap<String, f64>,
+        distributions: HashMap<String, Distribution>,
+    },
+}
+
 #[pyclass(name = "PersistedTrial")]
 #[pyo3(module = "rustuna")]
-pub struct PyPersistedTrial(PersistedTrial, Arc<Attrs>);
+pub struct PyPersistedTrial {
+    source: PyPersistedTrialSource,
+    study_attrs: Option<Arc<Attrs>>,
+}
 impl PyPersistedTrial {
+    /// Create a PyPersistedTrial that owns all trial data including study_attrs.
+    ///
+    /// Use this constructor when:
+    /// - Constructing from Python via `__new__`
+    /// - Retrieving a single trial where study_attrs are already available
     pub fn new(trial: PersistedTrial, study_attrs: Attrs) -> Self {
-        PyPersistedTrial(trial, Arc::new(study_attrs))
+        PyPersistedTrial {
+            source: PyPersistedTrialSource::Owned(trial),
+            study_attrs: Some(Arc::new(study_attrs)),
+        }
     }
-    pub fn new_with_arc(trial: PersistedTrial, study_attrs: Arc<Attrs>) -> Self {
-        PyPersistedTrial(trial, study_attrs)
+    /// Create a lightweight PyPersistedTrial that caches frequently accessed fields
+    /// but defers heavy fields (user_attrs, system_attrs) to storage lookup.
+    ///
+    /// Use this constructor when:
+    /// - Retrieving multiple trials (e.g., `get_trials`, `best_trials`)
+    /// - The caller has already fetched study_attrs and can share them via Arc
+    ///
+    /// This avoids cloning study_attrs for each trial and defers expensive
+    /// attribute lookups until actually needed.
+    pub fn from_storage(storage: Arc<RwLock<dyn Storage>>, trial: &PersistedTrial) -> Self {
+        let values = match &trial.state_values {
+            TrialStateValues::Complete(v) => Some(v.clone()),
+            _ => None,
+        };
+        PyPersistedTrial {
+            source: PyPersistedTrialSource::StorageBacked {
+                storage,
+                trial_id: trial.id,
+                study_id: trial.study_id,
+                number: trial.number,
+                state: PyTrialState::from(trial.state_values.clone()),
+                values,
+                internal_params: trial.internal_params.clone(),
+                distributions: trial.distributions.clone(),
+            },
+            study_attrs: None,
+        }
+    }
+
+    fn with_trial<R>(&self, f: impl FnOnce(&PersistedTrial) -> PyResult<R>) -> PyResult<R> {
+        match &self.source {
+            PyPersistedTrialSource::Owned(trial) => f(trial),
+            PyPersistedTrialSource::StorageBacked {
+                storage, trial_id, ..
+            } => {
+                let mut guard = storage
+                    .write()
+                    .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
+                let trial = guard.get_trial(*trial_id).map_err(err_to_exceptions)?;
+                f(trial)
+            }
+        }
+    }
+
+    fn collect_params(&self) -> PyResult<(u32, Vec<(String, f64, Distribution)>)> {
+        match &self.source {
+            PyPersistedTrialSource::Owned(trial) => {
+                let mut params: Vec<(String, f64, Distribution)> =
+                    Vec::with_capacity(trial.internal_params.len());
+                for (name, internal_repr) in &trial.internal_params {
+                    let dist = trial
+                        .distributions
+                        .get(name)
+                        .ok_or(PyValueError::new_err(format!("No distribution for {name}")))?;
+                    params.push((name.clone(), *internal_repr, dist.clone()));
+                }
+                Ok((trial.study_id, params))
+            }
+            PyPersistedTrialSource::StorageBacked {
+                study_id,
+                internal_params,
+                distributions,
+                ..
+            } => {
+                let mut params: Vec<(String, f64, Distribution)> =
+                    Vec::with_capacity(internal_params.len());
+                for (name, internal_repr) in internal_params {
+                    let dist = distributions
+                        .get(name)
+                        .ok_or(PyValueError::new_err(format!("No distribution for {name}")))?;
+                    params.push((name.clone(), *internal_repr, dist.clone()));
+                }
+                Ok((*study_id, params))
+            }
+        }
+    }
+
+    fn collect_distributions(&self) -> PyResult<(u32, Vec<(String, Distribution)>)> {
+        match &self.source {
+            PyPersistedTrialSource::Owned(trial) => {
+                let mut distributions: Vec<(String, Distribution)> =
+                    Vec::with_capacity(trial.distributions.len());
+                for (name, dist) in &trial.distributions {
+                    distributions.push((name.clone(), dist.clone()));
+                }
+                Ok((trial.study_id, distributions))
+            }
+            PyPersistedTrialSource::StorageBacked {
+                study_id,
+                distributions,
+                ..
+            } => {
+                let mut dists: Vec<(String, Distribution)> =
+                    Vec::with_capacity(distributions.len());
+                for (name, dist) in distributions {
+                    dists.push((name.clone(), dist.clone()));
+                }
+                Ok((*study_id, dists))
+            }
+        }
+    }
+
+    fn category_labels_for_param(
+        &self,
+        study_id: u32,
+        param_name: &str,
+        cardinality: usize,
+    ) -> PyResult<Option<Vec<CategoryLabel>>> {
+        if let Some(attrs) = &self.study_attrs {
+            return Ok(get_category_labels(attrs, param_name, cardinality));
+        }
+        match &self.source {
+            PyPersistedTrialSource::StorageBacked { storage, .. } => {
+                let mut guard = storage
+                    .write()
+                    .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
+                guard
+                    .get_category_labels(study_id, param_name, cardinality)
+                    .map_err(err_to_exceptions)
+            }
+            PyPersistedTrialSource::Owned(_) => Ok(None),
+        }
     }
 }
 #[allow(non_local_definitions)]
@@ -217,65 +363,99 @@ impl PyPersistedTrial {
         trial.attrs = trial_attrs;
 
         let study_attrs = Attrs::new();
-        Ok(PyPersistedTrial(trial, Arc::new(study_attrs)))
+        Ok(PyPersistedTrial::new(trial, study_attrs))
     }
 
     #[getter]
     fn id(&self) -> PyResult<u32> {
-        Ok(self.0.id)
+        match &self.source {
+            PyPersistedTrialSource::Owned(trial) => Ok(trial.id),
+            PyPersistedTrialSource::StorageBacked { trial_id, .. } => Ok(*trial_id),
+        }
     }
 
     #[getter]
     fn study_id(&self) -> PyResult<u32> {
-        Ok(self.0.study_id)
+        match &self.source {
+            PyPersistedTrialSource::Owned(trial) => Ok(trial.study_id),
+            PyPersistedTrialSource::StorageBacked { study_id, .. } => Ok(*study_id),
+        }
     }
 
     #[getter]
     fn number(&self) -> PyResult<u32> {
-        Ok(self.0.number)
+        match &self.source {
+            PyPersistedTrialSource::Owned(trial) => Ok(trial.number),
+            PyPersistedTrialSource::StorageBacked { number, .. } => Ok(*number),
+        }
     }
 
     #[getter]
     fn state(&self) -> PyResult<PyTrialState> {
-        Ok(PyTrialState::from(self.0.state_values.clone()))
+        match &self.source {
+            PyPersistedTrialSource::Owned(trial) => {
+                Ok(PyTrialState::from(trial.state_values.clone()))
+            }
+            PyPersistedTrialSource::StorageBacked { state, .. } => Ok(state.clone()),
+        }
     }
 
     #[getter]
-    fn values(&self) -> Option<Vec<f64>> {
-        match self.0.state_values {
-            TrialStateValues::Complete(ref values) => Some(values.clone()),
-            _ => None,
+    fn values(&self) -> PyResult<Option<Vec<f64>>> {
+        match &self.source {
+            PyPersistedTrialSource::Owned(trial) => match &trial.state_values {
+                TrialStateValues::Complete(values) => Ok(Some(values.clone())),
+                _ => Ok(None),
+            },
+            PyPersistedTrialSource::StorageBacked { values, .. } => Ok(values.clone()),
         }
     }
 
     #[getter]
     fn distributions(&self) -> PyResult<HashMap<String, PyDistribution>> {
-        let mut distributions = HashMap::new();
-        for (name, dist) in &self.0.distributions {
-            let distribution = PyDistribution::new(dist.clone(), name, &self.1);
-            distributions.insert(name.clone(), distribution);
+        let (study_id, distributions) = self.collect_distributions()?;
+        let mut result = HashMap::with_capacity(distributions.len());
+        for (name, dist) in distributions {
+            let labels = match dist {
+                Distribution::Categorical { cardinality } => {
+                    self.category_labels_for_param(study_id, &name, cardinality)?
+                }
+                _ => None,
+            };
+            let distribution = PyDistribution::new_with_category_labels(dist, labels);
+            result.insert(name, distribution);
         }
-        Ok(distributions)
+        Ok(result)
     }
 
     #[getter]
     fn internal_params(&self) -> PyResult<HashMap<String, f64>> {
-        Ok(self.0.internal_params.clone())
+        match &self.source {
+            PyPersistedTrialSource::Owned(trial) => Ok(trial.internal_params.clone()),
+            PyPersistedTrialSource::StorageBacked {
+                internal_params, ..
+            } => Ok(internal_params.clone()),
+        }
     }
 
     #[getter]
     fn params(&self) -> PyResult<HashMap<String, PyObject>> {
+        let (study_id, params) = self.collect_params()?;
+        let mut labels_map: HashMap<String, Option<Vec<CategoryLabel>>> = HashMap::new();
+        for (name, _, dist) in &params {
+            if let Distribution::Categorical { cardinality } = dist {
+                let labels = self.category_labels_for_param(study_id, name, *cardinality)?;
+                labels_map.insert(name.clone(), labels);
+            }
+        }
         Python::with_gil(|py| {
-            self.0
-                .internal_params
-                .iter()
-                .map(|(name, internal_repr)| {
-                    let maybe_pyobj: PyResult<PyObject> = match self.0.distributions.get(name) {
-                        Some(dist) => py_to_external_repr(py, dist, *internal_repr, name, &self.1)
-                            .map(|b| b.unbind()),
-                        None => Err(PyValueError::new_err(format!("No distribution for {name}"))),
-                    };
-                    maybe_pyobj.map(|v| (name.to_string(), v))
+            params
+                .into_iter()
+                .map(|(name, internal_repr, dist)| {
+                    let labels = labels_map.get(&name).and_then(|labels| labels.as_deref());
+                    let maybe_pyobj: PyResult<PyObject> =
+                        py_to_external_repr(py, &dist, internal_repr, labels).map(|b| b.unbind());
+                    maybe_pyobj.map(|v| (name, v))
                 })
                 .collect()
         })
@@ -283,30 +463,32 @@ impl PyPersistedTrial {
 
     #[getter]
     fn user_attrs(&self) -> PyResult<HashMap<String, String>> {
-        let user_attrs = self
-            .0
-            .attrs
-            .iter()
-            .filter_map(|(key, value)| match key {
-                AttrKey::User(k) => Some((k.clone(), value.clone())),
-                _ => None,
-            })
-            .collect();
-        Ok(user_attrs)
+        self.with_trial(|trial| {
+            let user_attrs = trial
+                .attrs
+                .iter()
+                .filter_map(|(key, value)| match key {
+                    AttrKey::User(k) => Some((k.clone(), value.clone())),
+                    _ => None,
+                })
+                .collect();
+            Ok(user_attrs)
+        })
     }
 
     #[getter]
     fn system_attrs(&self) -> PyResult<HashMap<String, String>> {
-        let system_attrs = self
-            .0
-            .attrs
-            .iter()
-            .filter_map(|(key, value)| match key {
-                AttrKey::System(k) => Some((k.clone(), value.clone())),
-                _ => None,
-            })
-            .collect();
-        Ok(system_attrs)
+        self.with_trial(|trial| {
+            let system_attrs = trial
+                .attrs
+                .iter()
+                .filter_map(|(key, value)| match key {
+                    AttrKey::System(k) => Some((k.clone(), value.clone())),
+                    _ => None,
+                })
+                .collect();
+            Ok(system_attrs)
+        })
     }
 
     fn __repr__(slf: &Bound<'_, Self>) -> PyResult<String> {
@@ -324,7 +506,7 @@ impl PyPersistedTrial {
             "number={} state={:?} values={:?} params={} distributions={:?} user_attrs={:?} system_attrs={:?}",
             self.number()?,
             self.state()?,
-            self.values(),
+            self.values()?,
             params,
             self.distributions()?,
             self.user_attrs()?,

--- a/rustuna_storages/src/cache.rs
+++ b/rustuna_storages/src/cache.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use rustuna_core::attr::Attrs;
+use rustuna_core::attr::{category_labels_to_attrs, get_category_labels, Attrs, CategoryLabel};
 use rustuna_core::distribution::Distribution;
 use rustuna_core::study::{Direction, PersistedStudy};
 use rustuna_core::study_cache::StudyCache;
@@ -71,6 +71,9 @@ pub struct CachedStorage {
     unfinished_trials: HashMap<u32, Vec<u32>>,
     last_finished_trial_number: HashMap<u32, i32>,
     trials_sorted_buffer: Vec<PersistedTrial>,
+    // Cache for category labels: (study_id, param_name) -> labels
+    // Since category labels cannot be overwritten once set, this cache never needs invalidation.
+    category_labels_cache: HashMap<(u32, String), Vec<CategoryLabel>>,
 
     backend: Box<dyn OptunaCachedStorageBackend>,
 }
@@ -85,6 +88,7 @@ impl CachedStorage {
             unfinished_trials: HashMap::new(),
             last_finished_trial_number: HashMap::new(),
             trials_sorted_buffer: Vec::new(),
+            category_labels_cache: HashMap::new(),
             backend,
         }
     }
@@ -344,6 +348,37 @@ impl rustuna_core::storage::Storage for CachedStorage {
             .get(&trial_number)
             .ok_or_else(|| Error::new(ErrorKind::TrialNotFound))?;
         Ok(trial)
+    }
+
+    fn set_category_labels(
+        &mut self,
+        study_id: u32,
+        param_name: &str,
+        labels: Vec<CategoryLabel>,
+    ) -> Result<()> {
+        let attrs = category_labels_to_attrs(param_name, &labels);
+        self.backend.set_study_attrs(study_id, attrs, true)?;
+        self.category_labels_cache
+            .insert((study_id, param_name.to_string()), labels);
+        Ok(())
+    }
+
+    fn get_category_labels(
+        &mut self,
+        study_id: u32,
+        param_name: &str,
+        cardinality: usize,
+    ) -> Result<Option<Vec<CategoryLabel>>> {
+        let key = (study_id, param_name.to_string());
+        if let Some(labels) = self.category_labels_cache.get(&key) {
+            return Ok(Some(labels.clone()));
+        }
+        let study = self.get_study(study_id)?;
+        if let Some(labels) = get_category_labels(&study.attrs, param_name, cardinality) {
+            self.category_labels_cache.insert(key, labels.clone());
+            return Ok(Some(labels));
+        }
+        Ok(None)
     }
 
     fn get_trial_id_from_study_id_trial_number(

--- a/rustuna_storages/src/journal/storage.rs
+++ b/rustuna_storages/src/journal/storage.rs
@@ -4,7 +4,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::{Map, Number, Value};
 
-use rustuna_core::attr::{category_labels_to_attrs, AttrKey, Attrs, CategoryLabel};
+use rustuna_core::attr::{
+    category_labels_to_attrs, get_category_labels, AttrKey, Attrs, CategoryLabel,
+};
 use rustuna_core::distribution::Distribution;
 use rustuna_core::storage::Storage;
 use rustuna_core::study::{Direction, PersistedStudy};
@@ -332,6 +334,32 @@ impl Storage for JournalStorage {
                 ),
             )
         })
+    }
+
+    fn get_category_labels(
+        &mut self,
+        study_id: u32,
+        param_name: &str,
+        cardinality: usize,
+    ) -> Result<Option<Vec<CategoryLabel>>> {
+        self.sync_with_backend()?;
+        let study = self
+            .replay
+            .studies
+            .values()
+            .find(|s| s.id == study_id)
+            .ok_or_else(|| Error::new(ErrorKind::StudyNotFound))?;
+        Ok(get_category_labels(&study.attrs, param_name, cardinality))
+    }
+
+    fn set_category_labels(
+        &mut self,
+        study_id: u32,
+        param_name: &str,
+        labels: Vec<CategoryLabel>,
+    ) -> Result<()> {
+        let attrs = category_labels_to_attrs(param_name, &labels);
+        self.set_study_attrs(study_id, attrs, true)
     }
 
     fn get_trial_id_from_study_id_trial_number(


### PR DESCRIPTION
This PR contains following changes to reduce the memory usage by lazy trial evaluation.

- Add `get_category_labels` and `set_category_labels` methods in Storage trait.
- Add `PyPersistedTrial::from_storage` method