### PR TITLE
Introduce `compact_str` and string interner for `Attr` keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +78,20 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "windows-link",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -619,6 +642,7 @@ dependencies = [
 name = "rustuna_core"
 version = "0.1.0"
 dependencies = [
+ "compact_str",
  "rand",
  "rand_distr",
  "statrs",
@@ -776,6 +800,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "statrs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,24 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +144,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +243,16 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -224,7 +266,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -292,6 +334,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "lasso"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e14eda50a3494b3bf7b9ce51c52434a761e383d7238ce1dd5dcec2fbc13e9fb"
+dependencies = [
+ "dashmap",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +370,15 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -429,6 +490,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -612,6 +686,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,6 +726,8 @@ name = "rustuna_core"
 version = "0.1.0"
 dependencies = [
  "compact_str",
+ "lasso",
+ "once_cell",
  "rand",
  "rand_distr",
  "statrs",
@@ -721,6 +806,12 @@ checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -892,6 +983,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/rustuna_core/Cargo.toml
+++ b/rustuna_core/Cargo.toml
@@ -13,3 +13,4 @@ readme = "README.md"
 rand = { workspace = true }
 rand_distr = "0.4.3"
 statrs = "0.18.0"
+compact_str = "0.9"

--- a/rustuna_core/Cargo.toml
+++ b/rustuna_core/Cargo.toml
@@ -14,3 +14,5 @@ rand = { workspace = true }
 rand_distr = "0.4.3"
 statrs = "0.18.0"
 compact_str = "0.9"
+lasso = { version = "0.7", features = ["multi-threaded"] }
+once_cell = "1.21"

--- a/rustuna_core/src/attr.rs
+++ b/rustuna_core/src/attr.rs
@@ -1,11 +1,13 @@
 use std::collections::HashMap;
 
+use compact_str::CompactString;
+
 pub type Attrs = HashMap<AttrKey, String>;
 
 #[derive(Eq, Hash, Clone, Debug, PartialEq)]
 pub enum AttrKey {
-    User(String),
-    System(String),
+    User(CompactString),
+    System(CompactString),
 }
 
 // Compatible with CategoricalChoiceType.
@@ -67,7 +69,7 @@ impl CategoryLabel {
 }
 
 pub fn system_key_category_label(param_name: &str, choice_idx: usize) -> AttrKey {
-    AttrKey::System(format!("category_labels:{param_name}:{choice_idx}"))
+    AttrKey::System(format!("category_labels:{param_name}:{choice_idx}").into())
 }
 
 pub fn category_labels_to_attrs(param_name: &str, labels: &[CategoryLabel]) -> Attrs {

--- a/rustuna_core/src/attr.rs
+++ b/rustuna_core/src/attr.rs
@@ -1,13 +1,50 @@
 use std::collections::HashMap;
+use std::fmt;
 
-use compact_str::CompactString;
+use lasso::{Spur, ThreadedRodeo};
+use once_cell::sync::Lazy;
 
 pub type Attrs = HashMap<AttrKey, String>;
 
 #[derive(Eq, Hash, Clone, Debug, PartialEq)]
 pub enum AttrKey {
-    User(CompactString),
-    System(CompactString),
+    User(InternedString),
+    System(InternedString),
+}
+
+static INTERNER: Lazy<ThreadedRodeo> = Lazy::new(ThreadedRodeo::new);
+
+#[derive(Eq, Hash, Clone, Debug, PartialEq)]
+pub struct InternedString(Spur);
+
+impl InternedString {
+    pub fn as_str(&self) -> &'static str {
+        INTERNER.resolve(&self.0)
+    }
+}
+
+impl fmt::Display for InternedString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl AsRef<str> for InternedString {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl From<&str> for InternedString {
+    fn from(value: &str) -> Self {
+        InternedString(INTERNER.get_or_intern(value))
+    }
+}
+
+impl From<String> for InternedString {
+    fn from(value: String) -> Self {
+        InternedString(INTERNER.get_or_intern(value))
+    }
 }
 
 // Compatible with CategoricalChoiceType.

--- a/rustuna_core/src/study.rs
+++ b/rustuna_core/src/study.rs
@@ -208,7 +208,7 @@ impl Study {
             .map_err(|_| Error::new(ErrorKind::Unexpected))?;
         let study = guard.get_study(self.id)?;
 
-        let key = AttrKey::User(key);
+        let key = AttrKey::User(key.into());
         match study.attrs.get(&key) {
             Some(value) => Ok(Some(value.clone())),
             _ => Ok(None),
@@ -222,7 +222,7 @@ impl Study {
             .map_err(|_| Error::new(ErrorKind::Unexpected))?;
         let mut a = Attrs::new();
         for (key, value) in attrs {
-            a.insert(AttrKey::User(key), value);
+            a.insert(AttrKey::User(key.into()), value);
         }
         guard.set_study_attrs(self.id, a, false)?;
         Ok(())

--- a/rustuna_core/src/trial.rs
+++ b/rustuna_core/src/trial.rs
@@ -147,7 +147,7 @@ impl Trial {
     // as it may be updated without going through the `Trial` object,
     // making it difficult to cache the value.
     pub fn get_user_attr(&mut self, key: &str) -> Option<&String> {
-        let key = AttrKey::User(key.to_string());
+        let key = AttrKey::User(key.into());
         self.cached_trial.attrs.get(&key)
     }
 
@@ -158,7 +158,7 @@ impl Trial {
             .map_err(|_| Error::new(ErrorKind::StorageError))?;
         let mut attrs = Attrs::new();
 
-        let key = AttrKey::User(key.to_string());
+        let key = AttrKey::User(key.into());
         attrs.insert(key.clone(), value.clone());
         guard.set_trial_attrs(self.study_id, self.number, attrs, false)?;
         self.cached_trial.attrs.insert(key, value);
@@ -232,17 +232,17 @@ mod tests {
             .write()
             .map_err(|_| Error::new(ErrorKind::StorageError))?;
         let mut attrs = Attrs::new();
-        attrs.insert(AttrKey::System("key".to_string()), "system".to_string());
+        attrs.insert(AttrKey::System("key".into()), "system".to_string());
         guard.set_trial_attrs(study.id, 0, attrs, false)?;
 
         // Check the attributes
         let trial = guard.get_trial(trial.id)?;
         assert_eq!(
-            trial.attrs.get(&AttrKey::User("key".to_string())),
+            trial.attrs.get(&AttrKey::User("key".into())),
             Some(&"user".to_string())
         );
         assert_eq!(
-            trial.attrs.get(&AttrKey::System("key".to_string())),
+            trial.attrs.get(&AttrKey::System("key".into())),
             Some(&"system".to_string())
         );
         Ok(())

--- a/rustuna_js/src/trial.rs
+++ b/rustuna_js/src/trial.rs
@@ -156,14 +156,14 @@ impl JsPersistedTrial {
         let attrs = js_sys::Array::new();
         let user_attrs = self.0.attrs.iter().filter_map(|(key, value)| {
             if let rustuna_core::attr::AttrKey::User(key) = key {
-                Some((key, value))
+                Some((key.to_string(), value))
             } else {
                 None
             }
         });
         for (key, value) in user_attrs {
             let obj = js_sys::Object::new();
-            js_sys::Reflect::set(&obj, &JsValue::from_str("key"), &JsValue::from_str(key))
+            js_sys::Reflect::set(&obj, &JsValue::from_str("key"), &JsValue::from_str(&key))
                 .map_err(|e| JsError::new(&format!("Failed to set a property: {e:?}")))?;
             js_sys::Reflect::set(&obj, &JsValue::from_str("value"), &JsValue::from_str(value))
                 .map_err(|e| JsError::new(&format!("Failed to set a property: {e:?}")))?;

--- a/rustuna_pyo3/src/attrs.rs
+++ b/rustuna_pyo3/src/attrs.rs
@@ -13,7 +13,7 @@ pub fn pyobj_to_system_attrs(obj: &Bound<'_, PyAny>) -> PyResult<Attrs> {
     for (key, value) in user_attrs {
         let key = key.extract::<String>()?;
         let value = value.extract::<String>()?;
-        attrs.insert(AttrKey::System(key), value);
+        attrs.insert(AttrKey::System(key.into()), value);
     }
     Ok(attrs)
 }
@@ -27,7 +27,7 @@ pub fn pyobj_to_user_attrs(obj: &Bound<'_, PyAny>) -> PyResult<Attrs> {
     for (key, value) in system_attrs {
         let key = key.extract::<String>()?;
         let value = value.extract::<String>()?;
-        attrs.insert(AttrKey::User(key), value);
+        attrs.insert(AttrKey::User(key.into()), value);
     }
     Ok(attrs)
 }
@@ -48,12 +48,12 @@ pub fn pyobj_to_attrs(
     for (key, value) in user_attrs {
         let key = key.extract::<String>()?;
         let value = value.extract::<String>()?;
-        attrs.insert(AttrKey::User(key), value);
+        attrs.insert(AttrKey::User(key.into()), value);
     }
     for (key, value) in system_attrs {
         let key = key.extract::<String>()?;
         let value = value.extract::<String>()?;
-        attrs.insert(AttrKey::System(key), value);
+        attrs.insert(AttrKey::System(key.into()), value);
     }
     Ok(attrs)
 }

--- a/rustuna_pyo3/src/pyobject_storage.rs
+++ b/rustuna_pyo3/src/pyobject_storage.rs
@@ -132,10 +132,10 @@ impl PyObjectStorage {
             for (k, v) in attrs.into_iter() {
                 match k {
                     AttrKey::System(k) => {
-                        py_system_attrs.set_item(k, v)?;
+                        py_system_attrs.set_item(k.as_str(), v)?;
                     }
                     AttrKey::User(k) => {
-                        py_user_attrs.set_item(k, v)?;
+                        py_user_attrs.set_item(k.as_str(), v)?;
                     }
                 }
             }
@@ -154,10 +154,10 @@ impl PyObjectStorage {
             for (k, v) in attrs.into_iter() {
                 match k {
                     AttrKey::System(k) => {
-                        py_system_attrs.set_item(k, v)?;
+                        py_system_attrs.set_item(k.as_str(), v)?;
                     }
                     AttrKey::User(k) => {
-                        py_user_attrs.set_item(k, v)?;
+                        py_user_attrs.set_item(k.as_str(), v)?;
                     }
                 }
             }

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -468,10 +468,10 @@ impl From<PersistedStudy> for PyPersistedStudy {
         for (key, val) in item.attrs {
             match key {
                 AttrKey::User(k) => {
-                    user_attrs.insert(k, val);
+                    user_attrs.insert(k.to_string(), val);
                 }
                 AttrKey::System(k) => {
-                    system_attrs.insert(k, val);
+                    system_attrs.insert(k.to_string(), val);
                 }
             }
         }

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -357,10 +357,10 @@ impl PyPersistedTrial {
         let n_system_attrs = user_attrs.len();
         let mut trial_attrs = Attrs::with_capacity(n_user_attrs + n_system_attrs);
         for (key, value) in user_attrs {
-            trial_attrs.insert(AttrKey::User(key), value);
+            trial_attrs.insert(AttrKey::User(key.into()), value);
         }
         for (key, value) in system_attrs {
-            trial_attrs.insert(AttrKey::System(key), value);
+            trial_attrs.insert(AttrKey::System(key.into()), value);
         }
         trial.attrs = trial_attrs;
 
@@ -475,7 +475,7 @@ impl PyPersistedTrial {
                 .attrs
                 .iter()
                 .filter_map(|(key, value)| match key {
-                    AttrKey::User(k) => Some((k.clone(), value.clone())),
+                    AttrKey::User(k) => Some((k.to_string(), value.clone())),
                     _ => None,
                 })
                 .collect();
@@ -490,7 +490,7 @@ impl PyPersistedTrial {
                 .attrs
                 .iter()
                 .filter_map(|(key, value)| match key {
-                    AttrKey::System(k) => Some((k.clone(), value.clone())),
+                    AttrKey::System(k) => Some((k.to_string(), value.clone())),
                     _ => None,
                 })
                 .collect();

--- a/rustuna_samplers/src/nsgaii.rs
+++ b/rustuna_samplers/src/nsgaii.rs
@@ -85,7 +85,7 @@ impl NSGAIISampler {
         let mut generation_to_population_numbers =
             HashMap::<usize, Vec<u32>>::with_capacity(trials.len());
         for trial in trials {
-            let generation_or_none = trial.attrs.get(&AttrKey::System("generation".to_string()));
+            let generation_or_none = trial.attrs.get(&AttrKey::System("generation".into()));
             if generation_or_none.is_none() {
                 continue;
             }
@@ -226,7 +226,7 @@ impl Sampler for NSGAIISampler {
         let child_generation = u32::try_from(parent_generation + 1).unwrap();
         let mut attrs = Attrs::with_capacity(1);
         attrs.insert(
-            AttrKey::System("generation".to_string()),
+            AttrKey::System("generation".into()),
             (child_generation as f64).to_string(),
         );
         guard.set_trial_attrs(ctx.study_id, ctx.trial_number, attrs, false)?;

--- a/rustuna_storages/src/cache.rs
+++ b/rustuna_storages/src/cache.rs
@@ -811,26 +811,26 @@ mod tests {
         storage.create_new_trial(study_id)?;
 
         let mut s_attrs = Attrs::new();
-        s_attrs.insert(AttrKey::User("foo".to_string()), "bar".to_string());
+        s_attrs.insert(AttrKey::User("foo".into()), "bar".to_string());
         storage.set_study_attrs(study_id, s_attrs, false)?;
         let study = storage.get_study(study_id)?;
         assert_eq!(
             study
                 .attrs
-                .get(&AttrKey::User("foo".to_string()))
+                .get(&AttrKey::User("foo".into()))
                 .expect("User attr 'foo' should exist"),
             "bar"
         );
 
         let mut t_attrs = Attrs::new();
-        t_attrs.insert(AttrKey::System("key".to_string()), "val".to_string());
+        t_attrs.insert(AttrKey::System("key".into()), "val".to_string());
         storage.set_trial_attrs(study_id, 0, t_attrs, false)?;
         let trial_id = storage.get_trials(study_id)?[0].id;
         let trial = storage.get_trial(trial_id)?;
         assert_eq!(
             trial
                 .attrs
-                .get(&AttrKey::System("key".to_string()))
+                .get(&AttrKey::System("key".into()))
                 .expect("System attr 'key' should exist"),
             "val"
         );

--- a/rustuna_storages/src/journal/storage.rs
+++ b/rustuna_storages/src/journal/storage.rs
@@ -257,7 +257,7 @@ impl Storage for JournalStorage {
             && (!matches!(existing_trial.state_values, TrialStateValues::Running)
                 || !existing_trial
                     .attrs
-                    .contains_key(&AttrKey::System("datetime_start".to_string())))
+                    .contains_key(&AttrKey::System("datetime_start".into())))
         {
             fields.insert(
                 "datetime_start".to_string(),
@@ -405,13 +405,13 @@ impl Storage for JournalStorage {
             match key {
                 AttrKey::User(k) => {
                     let mut map = Map::new();
-                    map.insert(k, Value::String(value));
+                    map.insert(k.to_string(), Value::String(value));
                     fields.insert("user_attr".to_string(), Value::Object(map));
                     self.write_log(JournalOperation::SetStudyUserAttr, fields)?;
                 }
                 AttrKey::System(k) => {
                     let mut map = Map::new();
-                    map.insert(k, Value::String(value));
+                    map.insert(k.to_string(), Value::String(value));
                     fields.insert("system_attr".to_string(), Value::Object(map));
                     self.write_log(JournalOperation::SetStudySystemAttr, fields)?;
                 }
@@ -454,13 +454,13 @@ impl Storage for JournalStorage {
             match key {
                 AttrKey::User(k) => {
                     let mut map = Map::new();
-                    map.insert(k, Value::String(value));
+                    map.insert(k.to_string(), Value::String(value));
                     fields.insert("user_attr".to_string(), Value::Object(map));
                     self.write_log(JournalOperation::SetTrialUserAttr, fields)?;
                 }
                 AttrKey::System(k) => {
                     let mut map = Map::new();
-                    map.insert(k, Value::String(value));
+                    map.insert(k.to_string(), Value::String(value));
                     fields.insert("system_attr".to_string(), Value::Object(map));
                     self.write_log(JournalOperation::SetTrialSystemAttr, fields)?;
                 }
@@ -772,8 +772,8 @@ impl JournalReplayState {
             })?;
         if let Some(study) = self.studies.get_mut(&study_id) {
             for (key, value) in attrs {
-                let v = json_value_to_attr(value)?;
-                study.attrs.insert(AttrKey::User(key.clone()), v);
+                let value = json_value_to_attr(value)?;
+                study.attrs.insert(AttrKey::User(key.clone().into()), value);
             }
         }
         Ok(())
@@ -809,7 +809,7 @@ impl JournalReplayState {
                 } else {
                     json_value_to_attr(value)?
                 };
-                study.attrs.insert(AttrKey::System(key.clone()), v);
+                study.attrs.insert(AttrKey::System(key.clone().into()), v);
             }
         }
         Ok(())
@@ -892,7 +892,7 @@ impl JournalReplayState {
 
         if let Some(dt) = log.fields.get("datetime_start").and_then(|v| v.as_str()) {
             attrs.insert(
-                AttrKey::System("datetime_start".to_string()),
+                AttrKey::System("datetime_start".into()),
                 serde_json::to_string(&dt).map_err(|_| {
                     Error::with_reason(
                         ErrorKind::StorageError,
@@ -903,7 +903,7 @@ impl JournalReplayState {
         }
         if let Some(dt) = log.fields.get("datetime_complete").and_then(|v| v.as_str()) {
             attrs.insert(
-                AttrKey::System("datetime_complete".to_string()),
+                AttrKey::System("datetime_complete".into()),
                 serde_json::to_string(&dt).map_err(|_| {
                     Error::with_reason(
                         ErrorKind::StorageError,
@@ -915,13 +915,13 @@ impl JournalReplayState {
         if let Some(user_attrs) = log.fields.get("user_attrs").and_then(|v| v.as_object()) {
             for (k, v) in user_attrs {
                 let value = json_value_to_attr(v)?;
-                attrs.insert(AttrKey::User(k.clone()), value);
+                attrs.insert(AttrKey::User(k.clone().into()), value);
             }
         }
         if let Some(system_attrs) = log.fields.get("system_attrs").and_then(|v| v.as_object()) {
             for (k, v) in system_attrs {
                 let value = json_value_to_attr(v)?;
-                attrs.insert(AttrKey::System(k.clone()), value);
+                attrs.insert(AttrKey::System(k.clone().into()), value);
             }
         }
         if let Some(values) = log
@@ -936,7 +936,7 @@ impl JournalReplayState {
                     "Failed to serialize intermediate values",
                 )
             })?;
-            attrs.insert(AttrKey::System("intermediate_values".to_string()), json);
+            attrs.insert(AttrKey::System("intermediate_values".into()), json);
         }
 
         trial.attrs = attrs;
@@ -1094,7 +1094,7 @@ impl JournalReplayState {
         if state_code == 0 {
             if let Some(dt) = log.fields.get("datetime_start").and_then(|v| v.as_str()) {
                 trial.attrs.insert(
-                    AttrKey::System("datetime_start".to_string()),
+                    AttrKey::System("datetime_start".into()),
                     serde_json::to_string(&dt).map_err(|_| {
                         Error::with_reason(
                             ErrorKind::StorageError,
@@ -1110,7 +1110,7 @@ impl JournalReplayState {
         } else if matches!(state_code, 1 | 2 | 4) {
             if let Some(dt) = log.fields.get("datetime_complete").and_then(|v| v.as_str()) {
                 trial.attrs.insert(
-                    AttrKey::System("datetime_complete".to_string()),
+                    AttrKey::System("datetime_complete".into()),
                     serde_json::to_string(&dt).map_err(|_| {
                         Error::with_reason(
                             ErrorKind::StorageError,
@@ -1169,7 +1169,7 @@ impl JournalReplayState {
         })?;
         trial
             .attrs
-            .insert(AttrKey::System("intermediate_values".to_string()), json);
+            .insert(AttrKey::System("intermediate_values".into()), json);
         Ok(())
     }
 
@@ -1214,7 +1214,7 @@ impl JournalReplayState {
         })?;
         for (key, value) in attrs {
             let v = json_value_to_attr(value)?;
-            trial.attrs.insert(AttrKey::User(key.clone()), v);
+            trial.attrs.insert(AttrKey::User(key.clone().into()), v);
         }
         Ok(())
     }
@@ -1270,7 +1270,7 @@ impl JournalReplayState {
                 return Ok(());
             }
             let v = json_value_to_attr(value)?;
-            trial.attrs.insert(AttrKey::System(key.clone()), v);
+            trial.attrs.insert(AttrKey::System(key.clone().into()), v);
         }
         Ok(())
     }
@@ -1701,7 +1701,7 @@ fn intermediate_entries_from_map(map: &Map<String, Value>) -> Result<Vec<Interme
 fn intermediate_entries_from_attrs(trial: &PersistedTrial) -> Result<Vec<IntermediateValueEntry>> {
     let raw = trial
         .attrs
-        .get(&AttrKey::System("intermediate_values".to_string()))
+        .get(&AttrKey::System("intermediate_values".into()))
         .cloned();
     match raw {
         None => Ok(Vec::new()),
@@ -1818,7 +1818,7 @@ fn extract_category_labels(attrs: &Attrs, param_name: &str) -> Option<Vec<Catego
     let mut labels = Vec::new();
     let mut index = 0;
     loop {
-        let key = AttrKey::System(format!("category_labels:{param_name}:{index}"));
+        let key = AttrKey::System(format!("category_labels:{param_name}:{index}").into());
         match attrs.get(&key) {
             Some(raw) => {
                 let label = CategoryLabel::deserialize(raw)?;
@@ -2128,26 +2128,26 @@ mod tests {
         storage.create_new_trial(study_id)?;
 
         let mut s_attrs = Attrs::new();
-        s_attrs.insert(AttrKey::User("foo".to_string()), "bar".to_string());
+        s_attrs.insert(AttrKey::User("foo".into()), "bar".to_string());
         storage.set_study_attrs(study_id, s_attrs, false)?;
         let study = storage.get_study(study_id)?;
         assert_eq!(
             study
                 .attrs
-                .get(&AttrKey::User("foo".to_string()))
+                .get(&AttrKey::User("foo".into()))
                 .expect("User attr 'foo' should exist"),
             "\"bar\""
         );
 
         let mut t_attrs = Attrs::new();
-        t_attrs.insert(AttrKey::System("key".to_string()), "val".to_string());
+        t_attrs.insert(AttrKey::System("key".into()), "val".to_string());
         storage.set_trial_attrs(study_id, 0, t_attrs, false)?;
         let trial_id = storage.get_trials(study_id)?[0].id;
         let trial = storage.get_trial(trial_id)?;
         assert_eq!(
             trial
                 .attrs
-                .get(&AttrKey::System("key".to_string()))
+                .get(&AttrKey::System("key".into()))
                 .expect("System attr 'key' should exist"),
             "\"val\""
         );

--- a/rustuna_storages/src/sqlite3.rs
+++ b/rustuna_storages/src/sqlite3.rs
@@ -205,7 +205,7 @@ impl CachedStorageBackend for SQLite3Storage {
             })?;
             trial
                 .attrs
-                .insert(AttrKey::System("datetime_start".to_string()), v);
+                .insert(AttrKey::System("datetime_start".into()), v);
         }
         Ok(trial)
     }
@@ -458,7 +458,7 @@ impl CachedStorageBackend for SQLite3Storage {
                         format!("Database query failed: {e}"),
                     )
                 })?;
-                attrs.insert(AttrKey::User(key), value);
+                attrs.insert(AttrKey::User(key.into()), value);
             }
 
             let mut system_stmt = guard
@@ -486,7 +486,7 @@ impl CachedStorageBackend for SQLite3Storage {
                         format!("Database query failed: {e}"),
                     )
                 })?;
-                attrs.insert(AttrKey::System(key), value);
+                attrs.insert(AttrKey::System(key.into()), value);
             }
 
             let study = PersistedStudy::new_with_attrs(study_id, study_name, directions, attrs);
@@ -621,7 +621,7 @@ impl CachedStorageBackend for SQLite3Storage {
                     format!("Database query failed: {e}"),
                 )
             })?;
-            attrs.insert(AttrKey::User(key), value);
+            attrs.insert(AttrKey::User(key.into()), value);
         }
 
         // System attributes
@@ -650,11 +650,11 @@ impl CachedStorageBackend for SQLite3Storage {
                     format!("Database query failed: {e}"),
                 )
             })?;
-            attrs.insert(AttrKey::System(key), value);
+            attrs.insert(AttrKey::System(key.into()), value);
         }
         if let Some(dt) = datetime_start {
             if let std::collections::hash_map::Entry::Vacant(e) =
-                attrs.entry(AttrKey::System("datetime_start".to_string()))
+                attrs.entry(AttrKey::System("datetime_start".into()))
             {
                 let v = serde_json::to_string(&dt).map_err(|e| {
                     Error::with_reason(
@@ -667,7 +667,7 @@ impl CachedStorageBackend for SQLite3Storage {
         }
         if let Some(dt) = datetime_complete {
             if let std::collections::hash_map::Entry::Vacant(e) =
-                attrs.entry(AttrKey::System("datetime_complete".to_string()))
+                attrs.entry(AttrKey::System("datetime_complete".into()))
             {
                 let v = serde_json::to_string(&dt).map_err(|e| {
                     Error::with_reason(
@@ -719,7 +719,7 @@ impl CachedStorageBackend for SQLite3Storage {
                 )
             })?;
             attrs.insert(
-                AttrKey::System("intermediate_values".to_string()),
+                AttrKey::System("intermediate_values".into()),
                 intermediate_json,
             );
         }
@@ -744,8 +744,8 @@ impl CachedStorageBackend for SQLite3Storage {
         let mut system_attrs = Vec::new();
         for (key, value) in attrs {
             match key {
-                AttrKey::User(key_str) => user_attrs.push((key_str, value)),
-                AttrKey::System(key_str) => system_attrs.push((key_str, value)),
+                AttrKey::User(key_str) => user_attrs.push((key_str.to_string(), value)),
+                AttrKey::System(key_str) => system_attrs.push((key_str.to_string(), value)),
             }
         }
 
@@ -858,8 +858,8 @@ impl CachedStorageBackend for SQLite3Storage {
         let mut system_attrs = Vec::new();
         for (key, value) in attrs {
             match key {
-                AttrKey::User(key_str) => user_attrs.push((key_str, value)),
-                AttrKey::System(key_str) => system_attrs.push((key_str, value)),
+                AttrKey::User(key_str) => user_attrs.push((key_str.to_string(), value)),
+                AttrKey::System(key_str) => system_attrs.push((key_str.to_string(), value)),
             }
         }
 
@@ -1144,7 +1144,7 @@ impl CachedStorageBackend for SQLite3Storage {
                         format!("Database query failed: {e}"),
                     )
                 })?;
-                attrs.insert(AttrKey::User(key), value);
+                attrs.insert(AttrKey::User(key.into()), value);
             }
 
             // Get system attributes
@@ -1173,11 +1173,11 @@ impl CachedStorageBackend for SQLite3Storage {
                         format!("Database query failed: {e}"),
                     )
                 })?;
-                attrs.insert(AttrKey::System(key), value);
+                attrs.insert(AttrKey::System(key.into()), value);
             }
             if let Some(dt) = datetime_start.clone() {
                 if let std::collections::hash_map::Entry::Vacant(e) =
-                    attrs.entry(AttrKey::System("datetime_start".to_string()))
+                    attrs.entry(AttrKey::System("datetime_start".into()))
                 {
                     let v = serde_json::to_string(&dt).map_err(|e| {
                         Error::with_reason(
@@ -1190,7 +1190,7 @@ impl CachedStorageBackend for SQLite3Storage {
             }
             if let Some(dt) = datetime_complete.clone() {
                 if let std::collections::hash_map::Entry::Vacant(e) =
-                    attrs.entry(AttrKey::System("datetime_complete".to_string()))
+                    attrs.entry(AttrKey::System("datetime_complete".into()))
                 {
                     let v = serde_json::to_string(&dt).map_err(|e| {
                         Error::with_reason(
@@ -1243,7 +1243,7 @@ impl CachedStorageBackend for SQLite3Storage {
                         )
                     })?;
                 attrs.insert(
-                    AttrKey::System("intermediate_values".to_string()),
+                    AttrKey::System("intermediate_values".into()),
                     intermediate_json,
                 );
             }
@@ -1846,12 +1846,9 @@ mod tests {
             .id;
 
         let mut attrs = Attrs::new();
+        attrs.insert(AttrKey::User("user_key".into()), "user_value".to_string());
         attrs.insert(
-            AttrKey::User("user_key".to_string()),
-            "user_value".to_string(),
-        );
-        attrs.insert(
-            AttrKey::System("system_key".to_string()),
+            AttrKey::System("system_key".into()),
             "system_value".to_string(),
         );
 
@@ -1860,11 +1857,11 @@ mod tests {
         let study = storage.get_study(study_id)?;
         assert_eq!(study.attrs.len(), 2);
         assert_eq!(
-            study.attrs.get(&AttrKey::User("user_key".to_string())),
+            study.attrs.get(&AttrKey::User("user_key".into())),
             Some(&"user_value".to_string())
         );
         assert_eq!(
-            study.attrs.get(&AttrKey::System("system_key".to_string())),
+            study.attrs.get(&AttrKey::System("system_key".into())),
             Some(&"system_value".to_string())
         );
         Ok(())
@@ -1878,19 +1875,16 @@ mod tests {
             .id;
 
         let mut attrs = Attrs::new();
-        attrs.insert(
-            AttrKey::User("user_key".to_string()),
-            "user_value".to_string(),
-        );
+        attrs.insert(AttrKey::User("user_key".into()), "user_value".to_string());
         storage.set_study_attrs(study_id, attrs, false)?;
 
         let mut overwrite = Attrs::new();
         overwrite.insert(
-            AttrKey::User("user_key".to_string()),
+            AttrKey::User("user_key".into()),
             "user_value_overwrite".to_string(),
         );
         overwrite.insert(
-            AttrKey::User("another_key".to_string()),
+            AttrKey::User("another_key".into()),
             "another_value".to_string(),
         );
         let err = storage
@@ -1900,12 +1894,12 @@ mod tests {
 
         let study = storage.get_study(study_id)?;
         assert_eq!(
-            study.attrs.get(&AttrKey::User("user_key".to_string())),
+            study.attrs.get(&AttrKey::User("user_key".into())),
             Some(&"user_value".to_string())
         );
         assert!(!study
             .attrs
-            .contains_key(&AttrKey::User("another_key".to_string())));
+            .contains_key(&AttrKey::User("another_key".into())));
 
         Ok(())
     }
@@ -1920,11 +1914,11 @@ mod tests {
 
         let mut attrs = Attrs::new();
         attrs.insert(
-            AttrKey::User("trial_user_key".to_string()),
+            AttrKey::User("trial_user_key".into()),
             "trial_user_value".to_string(),
         );
         attrs.insert(
-            AttrKey::System("trial_system_key".to_string()),
+            AttrKey::System("trial_system_key".into()),
             "trial_system_value".to_string(),
         );
 
@@ -1932,15 +1926,11 @@ mod tests {
 
         let trial = storage.get_trial(trial.id)?;
         assert_eq!(
-            trial
-                .attrs
-                .get(&AttrKey::User("trial_user_key".to_string())),
+            trial.attrs.get(&AttrKey::User("trial_user_key".into())),
             Some(&"trial_user_value".to_string())
         );
         assert_eq!(
-            trial
-                .attrs
-                .get(&AttrKey::System("trial_system_key".to_string())),
+            trial.attrs.get(&AttrKey::System("trial_system_key".into())),
             Some(&"trial_system_value".to_string())
         );
         Ok(())
@@ -1956,18 +1946,18 @@ mod tests {
 
         let mut attrs = Attrs::new();
         attrs.insert(
-            AttrKey::User("trial_user_key".to_string()),
+            AttrKey::User("trial_user_key".into()),
             "trial_user_value".to_string(),
         );
         storage.set_trial_attrs(study_id, trial.number, attrs, false)?;
 
         let mut overwrite = Attrs::new();
         overwrite.insert(
-            AttrKey::User("trial_user_key".to_string()),
+            AttrKey::User("trial_user_key".into()),
             "overwritten".to_string(),
         );
         overwrite.insert(
-            AttrKey::User("new_user_key".to_string()),
+            AttrKey::User("new_user_key".into()),
             "new_value".to_string(),
         );
         let err = storage
@@ -1977,14 +1967,12 @@ mod tests {
 
         let trial = storage.get_trial(trial.id)?;
         assert_eq!(
-            trial
-                .attrs
-                .get(&AttrKey::User("trial_user_key".to_string())),
+            trial.attrs.get(&AttrKey::User("trial_user_key".into())),
             Some(&"trial_user_value".to_string())
         );
         assert!(!trial
             .attrs
-            .contains_key(&AttrKey::User("new_user_key".to_string())));
+            .contains_key(&AttrKey::User("new_user_key".into())));
 
         Ok(())
     }
@@ -2166,7 +2154,7 @@ mod tests {
         let trial1_result = storage.get_trial(trial1.id)?;
         let intermediate_json = trial1_result
             .attrs
-            .get(&AttrKey::System("intermediate_values".to_string()))
+            .get(&AttrKey::System("intermediate_values".into()))
             .expect("intermediate_values should exist");
         let intermediate_entries: Vec<IntermediateValueEntry> =
             serde_json::from_str(intermediate_json).expect("Failed to parse intermediate values");
@@ -2182,13 +2170,13 @@ mod tests {
         let trial2_result = storage.get_trial(trial2.id)?;
         assert!(!trial2_result
             .attrs
-            .contains_key(&AttrKey::System("intermediate_values".to_string())));
+            .contains_key(&AttrKey::System("intermediate_values".into())));
 
         // Verify trial 3
         let trial3_result = storage.get_trial(trial3.id)?;
         let intermediate_json = trial3_result
             .attrs
-            .get(&AttrKey::System("intermediate_values".to_string()))
+            .get(&AttrKey::System("intermediate_values".into()))
             .expect("intermediate_values should exist");
         let intermediate_entries: Vec<IntermediateValueEntry> =
             serde_json::from_str(intermediate_json).expect("Failed to parse intermediate values");
@@ -2210,7 +2198,7 @@ mod tests {
         let trial4_result = storage.get_trial(trial4.id)?;
         let intermediate_json = trial4_result
             .attrs
-            .get(&AttrKey::System("intermediate_values".to_string()))
+            .get(&AttrKey::System("intermediate_values".into()))
             .expect("intermediate_values should exist");
         let intermediate_entries: Vec<IntermediateValueEntry> =
             serde_json::from_str(intermediate_json).expect("Failed to parse intermediate values");
@@ -2227,7 +2215,7 @@ mod tests {
         let trial1_updated = storage.get_trial(trial1.id)?;
         let intermediate_json = trial1_updated
             .attrs
-            .get(&AttrKey::System("intermediate_values".to_string()))
+            .get(&AttrKey::System("intermediate_values".into()))
             .expect("intermediate_values should exist");
         let intermediate_entries: Vec<IntermediateValueEntry> =
             serde_json::from_str(intermediate_json).expect("Failed to parse intermediate values");


### PR DESCRIPTION
String interning and using CompactStr improves my local benchmark, which has over 50k trials and 10 user attributes for each.

Before:

```
$ python my_local_bench.py
Elapsed: 1.0223
Mem(Peak): 298.3 MiB
```

After:

```
$ python my_local_bench.py
Elapsed: 0.8506
Mem(Peak): 249.9 MiB
```