### PR TITLE
Add `datetime_start` and `datetime_complete` to `rustuna_core::trial::PersistedTrial`

### DIFF
--- a/rustuna_core/src/study.rs
+++ b/rustuna_core/src/study.rs
@@ -105,6 +105,8 @@ impl Study {
         let trial = guard.create_new_trial(self.id)?;
         let trial_id = trial.id;
         let trial_number = trial.number;
+        let datetime_start = trial.datetime_start.clone();
+        let datetime_complete = trial.datetime_complete.clone();
         drop(guard);
 
         // Joint sampling
@@ -141,6 +143,8 @@ impl Study {
             trial_id,
             self.id,
             trial_number,
+            datetime_start,
+            datetime_complete,
             self.directions.clone(),
             Arc::clone(&self.storage),
             sampler.clone(),

--- a/rustuna_core/src/study_cache.rs
+++ b/rustuna_core/src/study_cache.rs
@@ -118,6 +118,8 @@ mod tests {
                 .cloned()
                 .collect(),
                 attrs: Attrs::new(),
+                datetime_start: None,
+                datetime_complete: None,
             },
             PersistedTrial {
                 id: 1,
@@ -127,6 +129,8 @@ mod tests {
                 internal_params: HashMap::new(),
                 distributions: HashMap::new(),
                 attrs: Attrs::new(),
+                datetime_start: None,
+                datetime_complete: None,
             },
             PersistedTrial {
                 id: 2,
@@ -136,6 +140,8 @@ mod tests {
                 internal_params: HashMap::new(),
                 distributions: HashMap::new(),
                 attrs: Attrs::new(),
+                datetime_start: None,
+                datetime_complete: None,
             },
             PersistedTrial {
                 id: 3,
@@ -170,6 +176,8 @@ mod tests {
                 .cloned()
                 .collect(),
                 attrs: Attrs::new(),
+                datetime_start: None,
+                datetime_complete: None,
             },
         ];
 
@@ -191,6 +199,8 @@ mod tests {
                 internal_params: HashMap::new(),
                 distributions: HashMap::new(),
                 attrs: Attrs::new(),
+                datetime_start: None,
+                datetime_complete: None,
             },
             PersistedTrial {
                 id: 1,
@@ -200,6 +210,8 @@ mod tests {
                 internal_params: HashMap::new(),
                 distributions: HashMap::new(),
                 attrs: Attrs::new(),
+                datetime_start: None,
+                datetime_complete: None,
             },
             PersistedTrial {
                 id: 2,
@@ -209,6 +221,8 @@ mod tests {
                 internal_params: HashMap::new(),
                 distributions: HashMap::new(),
                 attrs: Attrs::new(),
+                datetime_start: None,
+                datetime_complete: None,
             },
             PersistedTrial {
                 id: 3,
@@ -218,6 +232,8 @@ mod tests {
                 internal_params: HashMap::new(),
                 distributions: HashMap::new(),
                 attrs: Attrs::new(),
+                datetime_start: None,
+                datetime_complete: None,
             },
             PersistedTrial {
                 id: 4,
@@ -227,6 +243,8 @@ mod tests {
                 internal_params: HashMap::new(),
                 distributions: HashMap::new(),
                 attrs: Attrs::new(),
+                datetime_start: None,
+                datetime_complete: None,
             },
         ];
 

--- a/rustuna_core/src/trial.rs
+++ b/rustuna_core/src/trial.rs
@@ -13,6 +13,8 @@ pub struct Trial {
     pub id: u32,
     pub study_id: u32,
     pub number: u32,
+    pub datetime_start: Option<String>,
+    pub datetime_complete: Option<String>,
     directions: Vec<Direction>,
     storage: Arc<RwLock<dyn Storage>>,
     sampler: Arc<Mutex<dyn Sampler>>,
@@ -20,20 +22,27 @@ pub struct Trial {
     cached_trial: PersistedTrial,
 }
 impl Trial {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         trial_id: u32,
         study_id: u32,
         number: u32,
+        datetime_start: Option<String>,
+        datetime_complete: Option<String>,
         directions: Vec<Direction>,
         storage: Arc<RwLock<dyn Storage>>,
         sampler: Arc<Mutex<dyn Sampler>>,
         joint_params: HashMap<String, (Distribution, f64)>,
     ) -> Self {
-        let cached_trial = PersistedTrial::new(trial_id, study_id, number);
+        let mut cached_trial = PersistedTrial::new(trial_id, study_id, number);
+        cached_trial.datetime_start = datetime_start.clone();
+        cached_trial.datetime_complete = datetime_complete.clone();
         Trial {
             id: trial_id,
             study_id,
             number,
+            datetime_start,
+            datetime_complete,
             directions,
             storage,
             sampler,
@@ -177,6 +186,8 @@ pub struct PersistedTrial {
     pub internal_params: HashMap<String, f64>,
     pub distributions: HashMap<String, Distribution>,
     pub attrs: Attrs,
+    pub datetime_start: Option<String>,
+    pub datetime_complete: Option<String>,
 }
 impl PersistedTrial {
     pub fn new(id: u32, study_id: u32, number: u32) -> PersistedTrial {
@@ -188,6 +199,8 @@ impl PersistedTrial {
             internal_params: HashMap::new(),
             distributions: HashMap::new(),
             attrs: Attrs::new(),
+            datetime_start: None,
+            datetime_complete: None,
         }
     }
 

--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -91,6 +91,8 @@ class PersistedTrial:
         distributions: dict[str, Distribution] | None = None,
         user_attrs: dict[str, str] | None = None,
         system_attrs: dict[str, str] | None = None,
+        datetime_start: datetime.datetime | None = None,
+        datetime_complete: datetime.datetime | None = None,
         id: int | None = None,
     ) -> None: ...
     @property
@@ -115,6 +117,10 @@ class PersistedTrial:
     def internal_params(self) -> dict[str, float]: ...
     @property
     def params(self) -> dict[str, CategoricalChoiceType]: ...
+    @property
+    def datetime_start(self) -> datetime.datetime | None: ...
+    @property
+    def datetime_complete(self) -> datetime.datetime | None: ...
 
 # Study
 ObjectiveFuncType = Callable[[Trial], float | tuple[float, ...]]
@@ -234,12 +240,6 @@ class StorageProtocol(Protocol):
     ) -> list[CategoricalChoiceType]: ...
 
 class OptunaStorageProtocol(StorageProtocol, Protocol):
-    def set_trial_datetime(
-        self,
-        trial_id: int,
-        datetime_start: datetime.datetime | None,
-        datetime_complete: datetime.datetime | None,
-    ) -> None: ...
     def set_trial_intermediate_value(
         self, trial_id: int, step: int, intermediate_value: float
     ) -> None: ...

--- a/rustuna_pyo3/rustuna/converter/_storage.py
+++ b/rustuna_pyo3/rustuna/converter/_storage.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import copy
-import datetime
 import json
 import threading
 import typing
@@ -207,7 +206,6 @@ class ToOptunaStorage(BaseStorage):
         trial_id = trial.id
 
         if template_trial is None:
-            self._storage.set_trial_datetime(trial_id, datetime.datetime.now(), None)
             return trial_id
         if template_trial.user_attrs:
             user_attrs = {
@@ -235,9 +233,6 @@ class ToOptunaStorage(BaseStorage):
         rustuna_state = to_rustuna_state(template_trial.state)
         self._storage.set_trial_state_values(
             trial_id, rustuna_state, template_trial.values
-        )
-        self._storage.set_trial_datetime(
-            trial_id, template_trial.datetime_start, template_trial.datetime_complete
         )
         return trial_id
 

--- a/rustuna_pyo3/rustuna/converter/_trial.py
+++ b/rustuna_pyo3/rustuna/converter/_trial.py
@@ -26,10 +26,6 @@ if typing.TYPE_CHECKING:
     from optuna.distributions import BaseDistribution
     from optuna.trial import TrialState
 
-# This is a dummy datetime since Rustuna does not store the datetime_start and datetime_complete.
-dummy_datetime = datetime.datetime(
-    2023, 11, 26, 16, 56, 38
-)  # Date of the initial commit of Rustuna
 
 to_rustuna_state_map = {
     optuna.trial.TrialState.RUNNING: rustuna.TrialState.RUNNING,
@@ -66,14 +62,6 @@ def to_persisted_trial(
     study_id: int,
 ) -> rustuna.PersistedTrial:
     optuna_system_attrs = trial.system_attrs.copy()
-    if trial.datetime_start is not None:
-        optuna_system_attrs["datetime_start"] = trial.datetime_start.isoformat(
-            timespec="microseconds"
-        )
-    if trial.datetime_complete is not None:
-        optuna_system_attrs["datetime_complete"] = trial.datetime_complete.isoformat(
-            timespec="microseconds"
-        )
     if trial.intermediate_values:
         optuna_system_attrs["intermediate_values"] = trial.intermediate_values
 
@@ -96,6 +84,8 @@ def to_persisted_trial(
         distributions=distributions,
         user_attrs={k: json.dumps(v) for k, v in trial.user_attrs.items()},
         system_attrs={k: json.dumps(v) for k, v in optuna_system_attrs.items()},
+        datetime_start=trial.datetime_start,
+        datetime_complete=trial.datetime_complete,
     )
 
 
@@ -201,14 +191,8 @@ class FrozenTrialLike(FrozenTrial):
     @property
     def datetime_start(self) -> datetime.datetime | None:
         if self.__datetime_start is not None:
-            return self._datetime_start
-        system_attrs = self._persisted_trial.system_attrs
-        if "datetime_start" in system_attrs:
-            datetime_start_raw = typing.cast(
-                str, json.loads(system_attrs["datetime_start"])
-            )
-            return datetime.datetime.fromisoformat(datetime_start_raw)
-        return None
+            return self.__datetime_start
+        return self._persisted_trial.datetime_start
 
     @datetime_start.setter
     def datetime_start(self, value: datetime.datetime | None) -> None:
@@ -218,13 +202,7 @@ class FrozenTrialLike(FrozenTrial):
     def datetime_complete(self) -> datetime.datetime | None:
         if self.__datetime_complete is not None:
             return self.__datetime_complete
-        system_attrs = self._persisted_trial.system_attrs
-        if "datetime_complete" in system_attrs:
-            datetime_complete_raw = typing.cast(
-                str, json.loads(system_attrs["datetime_complete"])
-            )
-            return datetime.datetime.fromisoformat(datetime_complete_raw)
-        return None
+        return self._persisted_trial.datetime_complete
 
     @datetime_complete.setter
     def datetime_complete(self, value: datetime.datetime | None) -> None:

--- a/rustuna_pyo3/src/storage.rs
+++ b/rustuna_pyo3/src/storage.rs
@@ -3,7 +3,6 @@ use std::sync::{Arc, RwLock};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 
-use chrono::NaiveDateTime;
 use pyo3::types::{PyList, PyType};
 use rustuna_core::attr::CategoryLabel;
 use rustuna_core::distribution::Distribution;
@@ -379,25 +378,6 @@ impl PyStorage {
         intermediate_values.insert(step, intermediate_value);
         guard
             .set_trial_intermediate_values(trial_id, intermediate_values)
-            .map_err(err_to_exceptions)?;
-        Ok(())
-    }
-
-    #[pyo3(signature = (trial_id, datetime_start=None, datetime_complete=None))]
-    fn set_trial_datetime(
-        &mut self,
-        trial_id: u32,
-        datetime_start: Option<NaiveDateTime>,
-        datetime_complete: Option<NaiveDateTime>,
-    ) -> PyResult<()> {
-        let optuna_storage = self.optuna_compatible.as_ref().ok_or_else(|| {
-            PyRuntimeError::new_err("This storage does not support Optuna-compatible operations")
-        })?;
-        let mut guard = optuna_storage
-            .write()
-            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
-        guard
-            .set_trial_datetime(trial_id, datetime_start, datetime_complete)
             .map_err(err_to_exceptions)?;
         Ok(())
     }

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
+use chrono::NaiveDateTime;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
@@ -162,6 +163,8 @@ enum PyPersistedTrialSource {
         values: Option<Vec<f64>>,
         internal_params: HashMap<String, f64>,
         distributions: HashMap<String, Distribution>,
+        datetime_start: Option<String>,
+        datetime_complete: Option<String>,
     },
 }
 
@@ -209,6 +212,8 @@ impl PyPersistedTrial {
                 values,
                 internal_params: trial.internal_params.clone(),
                 distributions: trial.distributions.clone(),
+                datetime_start: trial.datetime_start.clone(),
+                datetime_complete: trial.datetime_complete.clone(),
             },
             study_attrs: None,
         }
@@ -313,7 +318,7 @@ impl PyPersistedTrial {
 #[pymethods]
 impl PyPersistedTrial {
     #[new]
-    #[pyo3(signature = (trial_id, study_id, number, state, values=None, internal_params=None, distributions=None, user_attrs=None, system_attrs=None))]
+    #[pyo3(signature = (trial_id, study_id, number, state, values=None, internal_params=None, distributions=None, user_attrs=None, system_attrs=None, datetime_start=None, datetime_complete=None))]
     #[allow(clippy::too_many_arguments)]
     pub fn py_new(
         trial_id: u32,
@@ -325,6 +330,8 @@ impl PyPersistedTrial {
         distributions: Option<HashMap<String, PyDistribution>>,
         user_attrs: Option<HashMap<String, String>>,
         system_attrs: Option<HashMap<String, String>>,
+        datetime_start: Option<NaiveDateTime>,
+        datetime_complete: Option<NaiveDateTime>,
     ) -> PyResult<Self> {
         if matches!(state, PyTrialState::COMPLETE) && values.is_none() {
             Err(PyValueError::new_err(
@@ -363,6 +370,8 @@ impl PyPersistedTrial {
             trial_attrs.insert(AttrKey::System(key.into()), value);
         }
         trial.attrs = trial_attrs;
+        trial.datetime_start = datetime_start.map(|dt| dt.to_string());
+        trial.datetime_complete = datetime_complete.map(|dt| dt.to_string());
 
         let study_attrs = Attrs::new();
         Ok(PyPersistedTrial::new(trial, study_attrs))
@@ -446,6 +455,32 @@ impl PyPersistedTrial {
     }
 
     #[getter]
+    fn datetime_start(&self) -> PyResult<Option<NaiveDateTime>> {
+        let value = match &self.source {
+            PyPersistedTrialSource::Owned(trial) => trial.datetime_start.as_ref(),
+            PyPersistedTrialSource::StorageBacked { datetime_start, .. } => datetime_start.as_ref(),
+        };
+        match value {
+            Some(raw) => Ok(Some(parse_naive_datetime(raw)?)),
+            None => Ok(None),
+        }
+    }
+
+    #[getter]
+    fn datetime_complete(&self) -> PyResult<Option<NaiveDateTime>> {
+        let value = match &self.source {
+            PyPersistedTrialSource::Owned(trial) => trial.datetime_complete.as_ref(),
+            PyPersistedTrialSource::StorageBacked {
+                datetime_complete, ..
+            } => datetime_complete.as_ref(),
+        };
+        match value {
+            Some(raw) => Ok(Some(parse_naive_datetime(raw)?)),
+            None => Ok(None),
+        }
+    }
+
+    #[getter]
     fn params(&self) -> PyResult<HashMap<String, PyObject>> {
         let (study_id, params) = self.collect_params()?;
         let mut labels_map: HashMap<String, Option<Vec<CategoryLabel>>> = HashMap::new();
@@ -522,6 +557,12 @@ impl PyPersistedTrial {
     }
 }
 
+fn parse_naive_datetime(value: &str) -> PyResult<NaiveDateTime> {
+    NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S%.f")
+        .or_else(|_| NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S"))
+        .map_err(|e| PyValueError::new_err(format!("Failed to parse datetime: {e}")))
+}
+
 pub fn pyobject_to_persisted_trial(
     trial: &Bound<'_, PyAny>,
     study_id: u32,
@@ -547,6 +588,16 @@ pub fn pyobject_to_persisted_trial(
         PyTrialState::WAITING => TrialStateValues::Waiting,
         PyTrialState::FAIL => TrialStateValues::Fail,
     };
+    let datetime_start = match trial.getattr("datetime_start") {
+        Ok(value) => value.extract::<Option<NaiveDateTime>>()?,
+        Err(_) => None,
+    };
+    let datetime_complete = match trial.getattr("datetime_complete") {
+        Ok(value) => value.extract::<Option<NaiveDateTime>>()?,
+        Err(_) => None,
+    };
+    persisted_trial.datetime_start = datetime_start.map(|dt| dt.to_string());
+    persisted_trial.datetime_complete = datetime_complete.map(|dt| dt.to_string());
 
     let src_internal_params = trial.getattr("internal_params")?;
     if !src_internal_params.is_instance_of::<PyDict>() {

--- a/rustuna_storages/src/cache.rs
+++ b/rustuna_storages/src/cache.rs
@@ -467,23 +467,6 @@ impl rustuna_core::storage::Storage for CachedStorage {
 }
 
 impl OptunaCompatibleStorage for CachedStorage {
-    fn set_trial_datetime(
-        &mut self,
-        trial_id: u32,
-        datetime_start: Option<chrono::NaiveDateTime>,
-        datetime_complete: Option<chrono::NaiveDateTime>,
-    ) -> Result<()> {
-        let (study_id, trial_number) = self.resolve_trial_location(trial_id)?;
-        self.backend
-            .set_trial_datetime(trial_id, datetime_start, datetime_complete)?;
-        self.unfinished_trials
-            .entry(study_id)
-            .or_default()
-            .push(trial_number);
-        self.refresh_trials(study_id)?;
-        Ok(())
-    }
-
     fn set_trial_intermediate_values(
         &mut self,
         trial_id: u32,
@@ -608,15 +591,6 @@ mod tests {
         }
     }
     impl OptunaCompatibleStorage for DummyBackend {
-        fn set_trial_datetime(
-            &mut self,
-            _trial_id: u32,
-            _datetime_start: Option<chrono::NaiveDateTime>,
-            _datetime_complete: Option<chrono::NaiveDateTime>,
-        ) -> Result<()> {
-            todo!()
-        }
-
         fn set_trial_intermediate_values(
             &mut self,
             _trial_id: u32,

--- a/rustuna_storages/src/journal/storage.rs
+++ b/rustuna_storages/src/journal/storage.rs
@@ -120,7 +120,7 @@ impl Storage for JournalStorage {
         );
         fields.insert(
             "datetime_start".to_string(),
-            Value::String(chrono::Utc::now().naive_utc().to_string()),
+            Value::String(chrono::Local::now().naive_local().to_string()),
         );
         self.write_log(JournalOperation::CreateTrial, fields)?;
         self.sync_with_backend()?;
@@ -255,18 +255,16 @@ impl Storage for JournalStorage {
         }
         if state_code == 0
             && (!matches!(existing_trial.state_values, TrialStateValues::Running)
-                || !existing_trial
-                    .attrs
-                    .contains_key(&AttrKey::System("datetime_start".into())))
+                || existing_trial.datetime_start.is_none())
         {
             fields.insert(
                 "datetime_start".to_string(),
-                Value::String(chrono::Utc::now().naive_utc().to_string()),
+                Value::String(chrono::Local::now().naive_local().to_string()),
             );
         } else if matches!(state_code, 1 | 2 | 4) {
             fields.insert(
                 "datetime_complete".to_string(),
-                Value::String(chrono::Utc::now().naive_utc().to_string()),
+                Value::String(chrono::Local::now().naive_local().to_string()),
             );
         }
         self.write_log(JournalOperation::SetTrialStateValues, fields)?;
@@ -485,52 +483,6 @@ impl Storage for JournalStorage {
 }
 
 impl OptunaCompatibleStorage for JournalStorage {
-    fn set_trial_datetime(
-        &mut self,
-        trial_id: u32,
-        datetime_start: Option<chrono::NaiveDateTime>,
-        datetime_complete: Option<chrono::NaiveDateTime>,
-    ) -> Result<()> {
-        self.sync_with_backend()?;
-        self.replay
-            .trial_id_to_study_number
-            .get(&trial_id)
-            .copied()
-            .ok_or_else(|| {
-                Error::with_reason(
-                    ErrorKind::TrialNotFound,
-                    format!("Trial not found in storage: trial_id={trial_id}"),
-                )
-            })?;
-        if let Some(dt) = datetime_start {
-            let mut fields = Map::new();
-            fields.insert(
-                "trial_id".to_string(),
-                Value::Number(Number::from(trial_id)),
-            );
-            let mut system_attr = Map::new();
-            system_attr.insert("datetime_start".to_string(), Value::String(dt.to_string()));
-            fields.insert("system_attr".to_string(), Value::Object(system_attr));
-            self.write_log(JournalOperation::SetTrialSystemAttr, fields)?;
-        }
-        if let Some(dt) = datetime_complete {
-            let mut fields = Map::new();
-            fields.insert(
-                "trial_id".to_string(),
-                Value::Number(Number::from(trial_id)),
-            );
-            let mut system_attr = Map::new();
-            system_attr.insert(
-                "datetime_complete".to_string(),
-                Value::String(dt.to_string()),
-            );
-            fields.insert("system_attr".to_string(), Value::Object(system_attr));
-            self.write_log(JournalOperation::SetTrialSystemAttr, fields)?;
-        }
-        self.sync_with_backend()?;
-        Ok(())
-    }
-
     fn set_trial_intermediate_values(
         &mut self,
         trial_id: u32,
@@ -890,28 +842,6 @@ impl JournalReplayState {
 
         let mut attrs: Attrs = Attrs::new();
 
-        if let Some(dt) = log.fields.get("datetime_start").and_then(|v| v.as_str()) {
-            attrs.insert(
-                AttrKey::System("datetime_start".into()),
-                serde_json::to_string(&dt).map_err(|_| {
-                    Error::with_reason(
-                        ErrorKind::StorageError,
-                        "Failed to serialize datetime_start",
-                    )
-                })?,
-            );
-        }
-        if let Some(dt) = log.fields.get("datetime_complete").and_then(|v| v.as_str()) {
-            attrs.insert(
-                AttrKey::System("datetime_complete".into()),
-                serde_json::to_string(&dt).map_err(|_| {
-                    Error::with_reason(
-                        ErrorKind::StorageError,
-                        "Failed to serialize datetime_complete",
-                    )
-                })?,
-            );
-        }
         if let Some(user_attrs) = log.fields.get("user_attrs").and_then(|v| v.as_object()) {
             for (k, v) in user_attrs {
                 let value = json_value_to_attr(v)?;
@@ -938,8 +868,14 @@ impl JournalReplayState {
             })?;
             attrs.insert(AttrKey::System("intermediate_values".into()), json);
         }
-
         trial.attrs = attrs;
+
+        if let Some(dt) = log.fields.get("datetime_start").and_then(|v| v.as_str()) {
+            trial.datetime_start = Some(dt.to_string());
+        }
+        if let Some(dt) = log.fields.get("datetime_complete").and_then(|v| v.as_str()) {
+            trial.datetime_complete = Some(dt.to_string());
+        }
         self.trials_by_study
             .entry(study_id)
             .or_default()
@@ -1093,15 +1029,7 @@ impl JournalReplayState {
         };
         if state_code == 0 {
             if let Some(dt) = log.fields.get("datetime_start").and_then(|v| v.as_str()) {
-                trial.attrs.insert(
-                    AttrKey::System("datetime_start".into()),
-                    serde_json::to_string(&dt).map_err(|_| {
-                        Error::with_reason(
-                            ErrorKind::StorageError,
-                            "Failed to serialize datetime_start",
-                        )
-                    })?,
-                );
+                trial.datetime_start = Some(dt.to_string());
             }
             if issued_by_this_worker {
                 self.worker_id_to_owned_trial_id
@@ -1109,15 +1037,7 @@ impl JournalReplayState {
             }
         } else if matches!(state_code, 1 | 2 | 4) {
             if let Some(dt) = log.fields.get("datetime_complete").and_then(|v| v.as_str()) {
-                trial.attrs.insert(
-                    AttrKey::System("datetime_complete".into()),
-                    serde_json::to_string(&dt).map_err(|_| {
-                        Error::with_reason(
-                            ErrorKind::StorageError,
-                            "Failed to serialize datetime_complete",
-                        )
-                    })?,
-                );
+                trial.datetime_complete = Some(dt.to_string());
             }
         }
         trial.state_values = state;
@@ -1259,8 +1179,7 @@ impl JournalReplayState {
         })?;
         let is_finished = trial.is_finished();
         for (key, value) in attrs {
-            let allows_finished = key == "datetime_start" || key == "datetime_complete";
-            if is_finished && !allows_finished {
+            if is_finished {
                 if self.is_issued_by_this_worker(log, worker_id) {
                     return Err(Error::with_reason(
                         ErrorKind::TrialAlreadyFinished,

--- a/rustuna_storages/src/optuna.rs
+++ b/rustuna_storages/src/optuna.rs
@@ -1,16 +1,9 @@
 use std::collections::HashMap;
 
-use chrono::NaiveDateTime;
 use rustuna_core::Result;
 use serde::{Deserialize, Serialize};
 
 pub trait OptunaCompatibleStorage: Send + Sync {
-    fn set_trial_datetime(
-        &mut self,
-        trial_id: u32,
-        datetime_start: Option<NaiveDateTime>,
-        datetime_complete: Option<NaiveDateTime>,
-    ) -> Result<()>;
     fn set_trial_intermediate_values(
         &mut self,
         trial_id: u32,

--- a/rustuna_storages/src/sqlite3.rs
+++ b/rustuna_storages/src/sqlite3.rs
@@ -1,9 +1,5 @@
-use std::collections::HashMap;
-use std::sync::Mutex;
-
 use crate::cache::{CachedStorageBackend, OptunaCachedStorageBackend};
 use crate::optuna::{IntermediateValueEntry, OptunaCompatibleStorage};
-use chrono::NaiveDateTime;
 use rusqlite::{params, Connection, Error as RusqliteError, OptionalExtension};
 use rustuna_core::attr::{AttrKey, Attrs, CategoryLabel};
 use rustuna_core::distribution::Distribution;
@@ -11,6 +7,8 @@ use rustuna_core::study::{Direction, PersistedStudy};
 use rustuna_core::trial::{PersistedTrial, TrialStateValues};
 use rustuna_core::{Error, ErrorKind, Result};
 use serde_json::{json, Number, Value};
+use std::collections::HashMap;
+use std::sync::Mutex;
 
 pub struct SQLite3Storage {
     conn: Mutex<Connection>,
@@ -145,7 +143,7 @@ impl CachedStorageBackend for SQLite3Storage {
         guard
             .execute(
                 "INSERT INTO trials (number, study_id, state, datetime_start, datetime_complete) \
-             VALUES (NULL, ?, ?, datetime('now','localtime'), NULL)",
+             VALUES (NULL, ?, ?, strftime('%Y-%m-%d %H:%M:%f','now','localtime'), NULL)",
                 params![study_id, "RUNNING"],
             )
             .map_err(|e| {
@@ -196,17 +194,7 @@ impl CachedStorageBackend for SQLite3Storage {
             })?;
 
         let mut trial = PersistedTrial::new(trial_id, study_id, number);
-        if let Some(dt) = datetime_start {
-            let v = serde_json::to_string(&dt).map_err(|e| {
-                Error::with_reason(
-                    ErrorKind::StorageError,
-                    format!("JSON serialization failed: {e}"),
-                )
-            })?;
-            trial
-                .attrs
-                .insert(AttrKey::System("datetime_start".into()), v);
-        }
+        trial.datetime_start = datetime_start;
         Ok(trial)
     }
 
@@ -289,7 +277,7 @@ impl CachedStorageBackend for SQLite3Storage {
             TrialStateValues::Complete(values) => {
                 guard
                     .execute(
-                        "UPDATE trials SET state = ?, datetime_complete = CURRENT_TIMESTAMP WHERE trial_id = ?",
+                        "UPDATE trials SET state = ?, datetime_complete = strftime('%Y-%m-%d %H:%M:%f','now','localtime') WHERE trial_id = ?",
                         params!["COMPLETE", trial_id],
                     )
                     .map_err(|e| Error::with_reason(ErrorKind::StorageError, format!("Database query failed: {e}")))?;
@@ -318,7 +306,7 @@ impl CachedStorageBackend for SQLite3Storage {
             TrialStateValues::Pruned => {
                 guard
                     .execute(
-                        "UPDATE trials SET state = ?, datetime_complete = CURRENT_TIMESTAMP WHERE trial_id = ?",
+                        "UPDATE trials SET state = ?, datetime_complete = strftime('%Y-%m-%d %H:%M:%f','now','localtime') WHERE trial_id = ?",
                         params!["PRUNED", trial_id],
                     )
                     .map_err(|e| Error::with_reason(ErrorKind::StorageError, format!("Database query failed: {e}")))?;
@@ -326,7 +314,7 @@ impl CachedStorageBackend for SQLite3Storage {
             TrialStateValues::Fail => {
                 guard
                     .execute(
-                        "UPDATE trials SET state = ?, datetime_complete = CURRENT_TIMESTAMP WHERE trial_id = ?",
+                        "UPDATE trials SET state = ?, datetime_complete = strftime('%Y-%m-%d %H:%M:%f','now','localtime') WHERE trial_id = ?",
                         params!["FAIL", trial_id],
                     )
                     .map_err(|e| Error::with_reason(ErrorKind::StorageError, format!("Database query failed: {e}")))?;
@@ -652,32 +640,6 @@ impl CachedStorageBackend for SQLite3Storage {
             })?;
             attrs.insert(AttrKey::System(key.into()), value);
         }
-        if let Some(dt) = datetime_start {
-            if let std::collections::hash_map::Entry::Vacant(e) =
-                attrs.entry(AttrKey::System("datetime_start".into()))
-            {
-                let v = serde_json::to_string(&dt).map_err(|e| {
-                    Error::with_reason(
-                        ErrorKind::StorageError,
-                        format!("JSON serialization failed: {e}"),
-                    )
-                })?;
-                e.insert(v);
-            }
-        }
-        if let Some(dt) = datetime_complete {
-            if let std::collections::hash_map::Entry::Vacant(e) =
-                attrs.entry(AttrKey::System("datetime_complete".into()))
-            {
-                let v = serde_json::to_string(&dt).map_err(|e| {
-                    Error::with_reason(
-                        ErrorKind::StorageError,
-                        format!("JSON serialization failed: {e}"),
-                    )
-                })?;
-                e.insert(v);
-            }
-        }
 
         // Intermediate values
         let mut stmt = guard
@@ -729,6 +691,8 @@ impl CachedStorageBackend for SQLite3Storage {
         trial.internal_params = internal_params;
         trial.distributions = distributions;
         trial.attrs = attrs;
+        trial.datetime_start = datetime_start;
+        trial.datetime_complete = datetime_complete;
         Ok(trial)
     }
 
@@ -1175,32 +1139,6 @@ impl CachedStorageBackend for SQLite3Storage {
                 })?;
                 attrs.insert(AttrKey::System(key.into()), value);
             }
-            if let Some(dt) = datetime_start.clone() {
-                if let std::collections::hash_map::Entry::Vacant(e) =
-                    attrs.entry(AttrKey::System("datetime_start".into()))
-                {
-                    let v = serde_json::to_string(&dt).map_err(|e| {
-                        Error::with_reason(
-                            ErrorKind::StorageError,
-                            format!("JSON serialization failed: {e}"),
-                        )
-                    })?;
-                    e.insert(v);
-                }
-            }
-            if let Some(dt) = datetime_complete.clone() {
-                if let std::collections::hash_map::Entry::Vacant(e) =
-                    attrs.entry(AttrKey::System("datetime_complete".into()))
-                {
-                    let v = serde_json::to_string(&dt).map_err(|e| {
-                        Error::with_reason(
-                            ErrorKind::StorageError,
-                            format!("JSON serialization failed: {e}"),
-                        )
-                    })?;
-                    e.insert(v);
-                }
-            }
 
             // Intermediate values
             let mut intermediate_stmt = guard
@@ -1253,6 +1191,8 @@ impl CachedStorageBackend for SQLite3Storage {
             trial.internal_params = internal_params;
             trial.distributions = distributions;
             trial.attrs = attrs;
+            trial.datetime_start = datetime_start;
+            trial.datetime_complete = datetime_complete;
             trials.push(trial);
         }
 
@@ -1439,51 +1379,9 @@ impl OptunaCompatibleStorage for SQLite3Storage {
 
         Ok(())
     }
-
-    fn set_trial_datetime(
-        &mut self,
-        trial_id: u32,
-        datetime_start: Option<NaiveDateTime>,
-        datetime_complete: Option<NaiveDateTime>,
-    ) -> Result<()> {
-        let guard = self
-            .conn
-            .lock()
-            .map_err(|_| Error::new(ErrorKind::StorageError))?;
-        let exists: Option<u32> = guard
-            .query_row(
-                "SELECT trial_id FROM trials WHERE trial_id = ?",
-                params![trial_id],
-                |row| row.get(0),
-            )
-            .optional()
-            .map_err(|e| {
-                Error::with_reason(
-                    ErrorKind::StorageError,
-                    format!("Database query failed: {e}"),
-                )
-            })?;
-        if exists.is_none() {
-            return Err(Error::new(ErrorKind::TrialNotFound));
-        }
-
-        let start_str = datetime_start.map(format_naive_datetime);
-        let complete_str = datetime_complete.map(format_naive_datetime);
-        guard
-            .execute(
-                "UPDATE trials SET datetime_start = COALESCE(?, datetime_start), datetime_complete = COALESCE(?, datetime_complete) WHERE trial_id = ?",
-                params![start_str, complete_str, trial_id],
-            )
-            .map_err(|e| Error::with_reason(ErrorKind::StorageError, format!("Database query failed: {e}")))?;
-        Ok(())
-    }
 }
 
 impl OptunaCachedStorageBackend for SQLite3Storage {}
-
-fn format_naive_datetime(dt: NaiveDateTime) -> String {
-    dt.format("%Y-%m-%d %H:%M:%S%.f").to_string()
-}
 
 fn distribution_to_json(distribution: &Distribution, labels: Option<&[CategoryLabel]>) -> String {
     let (name, attributes) = match distribution {


### PR DESCRIPTION
Refs #31 

This PR simplifies `OptunaCompatibleStorage` trait by introducing `datetime_start` and `datetime_complete` to `rustuna_core::trial::PersistedTrial`.