### PR TITLE
macOS: avoid `F_FULLFSYNC` and use `fsync(2)` on JournalStorage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,6 +778,7 @@ name = "rustuna_storages"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "libc",
  "rusqlite",
  "rustuna_core",
  "serde",

--- a/rustuna_storages/Cargo.toml
+++ b/rustuna_storages/Cargo.toml
@@ -14,6 +14,7 @@ rusqlite = "0.37.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = { workspace = true }
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/rustuna_storages/src/journal/file.rs
+++ b/rustuna_storages/src/journal/file.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
+#[cfg(target_os = "macos")]
+use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -12,6 +14,32 @@ use super::{JournalBackend, JournalLog};
 
 const LOCK_FILE_SUFFIX: &str = ".lock";
 const RENAME_FILE_SUFFIX: &str = ".rename";
+
+fn fsync_file(file: &File) -> std::io::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        // NOTE:
+        // Rust's File::sync_all() uses F_FULLFSYNC on macOS, which can be very slow.
+        // Using fsync(2) is faster but may provide weaker durability guarantees
+        // (e.g., device internal cache might not be flushed on power loss).
+        loop {
+            let rc = unsafe { libc::fsync(file.as_raw_fd()) };
+            if rc == 0 {
+                return Ok(());
+            }
+            let err = std::io::Error::last_os_error();
+            if err.kind() == std::io::ErrorKind::Interrupted {
+                continue; // retry on EINTR
+            }
+            return Err(err);
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        file.sync_all()
+    }
+}
 
 pub trait JournalFileLock: Send + Sync {
     fn acquire(&self) -> Result<()>;
@@ -150,7 +178,7 @@ impl JournalBackend for JournalFileBackend {
         file.flush().map_err(|e| {
             Error::with_reason(ErrorKind::StorageError, format!("Failed to flush: {e}"))
         })?;
-        file.sync_all().map_err(|e| {
+        fsync_file(&file).map_err(|e| {
             Error::with_reason(ErrorKind::StorageError, format!("Failed to fsync: {e}"))
         })?;
         Ok(())


### PR DESCRIPTION
`File::sync_all()` uses `F_FULLFSYNC `on macOS, which increases the latency per write. Use `fsync(2)` instead to significantly improves the performance (An elapsed time for my local benchmark is changed from 9.2s to 0.5s).

Please refer to https://stackoverflow.com/questions/78626405/surprisingly-high-latency-for-rusts-sync-all-on-macos for details.