### PR TITLE
Add Scott's rule in `ParzenEstimator`

### DIFF
--- a/rustuna_core/src/parzen_estimator/mod.rs
+++ b/rustuna_core/src/parzen_estimator/mod.rs
@@ -1,6 +1,6 @@
 mod model;
 mod probability_distributions;
-mod truncnorm;
 mod scott;
+mod truncnorm;
 
 pub use model::ParzenEstimator;

--- a/rustuna_core/src/parzen_estimator/mod.rs
+++ b/rustuna_core/src/parzen_estimator/mod.rs
@@ -1,5 +1,6 @@
 mod model;
 mod probability_distributions;
 mod truncnorm;
+mod scott;
 
 pub use model::ParzenEstimator;

--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -132,8 +132,8 @@ pub(crate) trait CategoricalDistributionBuilder {
     ) -> Distributions;
 }
 
-pub struct DefaultNumericalDistributionBuilder;
-pub struct DefaultCategoricalDistributionBuilder;
+pub(crate) struct DefaultNumericalDistributionBuilder;
+pub(crate) struct DefaultCategoricalDistributionBuilder;
 
 impl NumericalDistributionBuilder for DefaultNumericalDistributionBuilder {
     fn calculate_numerical_distribution(

--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -19,7 +19,7 @@ impl ParzenEstimator {
         weights: &[f64],
         prior_weight: f64,
     ) -> Self {
-        Self::new_with_builder(
+        Self::with_builder(
             observations,
             search_space,
             weights,
@@ -29,7 +29,7 @@ impl ParzenEstimator {
         )
     }
 
-    pub(crate) fn new_with_builder(
+    pub(crate) fn with_builder(
         observations: &HashMap<String, Vec<f64>>,
         search_space: &HashMap<String, Distribution>,
         weights: &[f64],

--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -7,6 +7,7 @@ use super::probability_distributions::{
     MixtureOfProductDistribution, TruncLogNormDistributions, TruncNormDistributions,
 };
 use crate::distribution::Distribution;
+use crate::parzen_estimator::scott::ScottNumericalDistributionBuilder;
 
 pub struct ParzenEstimator {
     mixuture_distribution: MixtureOfProductDistribution,
@@ -25,6 +26,22 @@ impl ParzenEstimator {
             weights,
             prior_weight,
             &DefaultNumericalDistributionBuilder,
+            &DefaultCategoricalDistributionBuilder,
+        )
+    }
+
+    pub fn new_with_scott(
+        observations: &HashMap<String, Vec<f64>>,
+        search_space: &HashMap<String, Distribution>,
+        weights: &[f64],
+        prior_weight: f64,
+    ) -> Self {
+        Self::with_builder(
+            observations,
+            search_space,
+            weights,
+            prior_weight,
+            &ScottNumericalDistributionBuilder::new(weights),
             &DefaultCategoricalDistributionBuilder,
         )
     }

--- a/rustuna_core/src/parzen_estimator/scott.rs
+++ b/rustuna_core/src/parzen_estimator/scott.rs
@@ -5,8 +5,15 @@ use crate::parzen_estimator::probability_distributions::{
     TruncLogNormDistributions, TruncNormDistributions,
 };
 
-pub struct ScottNumericalDistributionBuilder<'a> {
+
+pub(crate) struct ScottNumericalDistributionBuilder<'a> {
     weights: &'a [f64],
+}
+
+impl<'a> ScottNumericalDistributionBuilder<'a> {
+    pub(crate) fn new(weights: &'a [f64]) -> Self {
+        Self { weights }
+    }
 }
 
 impl<'a> NumericalDistributionBuilder for ScottNumericalDistributionBuilder<'a> {

--- a/rustuna_core/src/parzen_estimator/scott.rs
+++ b/rustuna_core/src/parzen_estimator/scott.rs
@@ -1,0 +1,9 @@
+use crate::parzen_estimator::probability_distributions::Distributions;
+use crate::parzen_estimator::model::NumericalDistributionBuilder;
+use crate::distribution::Distribution;
+
+
+
+pub struct ScottNumericalDistributionBuilder {
+    weights: &[f64],
+}

--- a/rustuna_core/src/parzen_estimator/scott.rs
+++ b/rustuna_core/src/parzen_estimator/scott.rs
@@ -1,7 +1,9 @@
-use crate::parzen_estimator::probability_distributions::{Distributions, DiscreteTruncNormDistributions, TruncNormDistributions,TruncLogNormDistributions, DiscreteTruncLogNormDistributions};
-use crate::parzen_estimator::model::NumericalDistributionBuilder;
 use crate::distribution::Distribution;
-
+use crate::parzen_estimator::model::NumericalDistributionBuilder;
+use crate::parzen_estimator::probability_distributions::{
+    DiscreteTruncLogNormDistributions, DiscreteTruncNormDistributions, Distributions,
+    TruncLogNormDistributions, TruncNormDistributions,
+};
 
 pub struct ScottNumericalDistributionBuilder<'a> {
     weights: &'a [f64],
@@ -14,37 +16,63 @@ impl<'a> NumericalDistributionBuilder for ScottNumericalDistributionBuilder<'a> 
         search_space: &Distribution,
     ) -> Distributions {
         // NOTE: Since the Optuna TPE bandwidth selection is too wide for this analysis, we use the Scott's rule:
-        // David W. Scott. 1992. Multivariate Density Estimation: Theory, Practice, and Visualization. John Wiley & Sons. 
+        // David W. Scott. 1992. Multivariate Density Estimation: Theory, Practice, and Visualization. John Wiley & Sons.
         let (low, high, step, log) = match search_space {
-            Distribution::Int { low, high, step, log } => (*low as f64, *high as f64, Some(*step as f64), *log),
-            Distribution::Float { low, high, step, log } => (*low, *high, *step, *log),
+            Distribution::Int {
+                low,
+                high,
+                step,
+                log,
+            } => (*low as f64, *high as f64, Some(*step as f64), *log),
+            Distribution::Float {
+                low,
+                high,
+                step,
+                log,
+            } => (*low, *high, *step, *log),
             _ => panic!("Unsupported distribution type for ScottNumericalDistributionBuilder"),
         };
         let weights_sum = self.weights.iter().sum::<f64>();
         let n_observations = observations.len();
-        
-        let mean_est = observations.iter().zip(self.weights.iter()).map(|(v, w)| v * w).sum::<f64>() / weights_sum;
+
+        let mean_est = observations
+            .iter()
+            .zip(self.weights.iter())
+            .map(|(v, w)| v * w)
+            .sum::<f64>()
+            / weights_sum;
         let sigma_est = {
-            let var = observations.iter().zip(self.weights.iter())
-            .map(|(v, w)| w * (v - mean_est).powi(2)).sum::<f64>() / (weights_sum - 1.0).max(1.0);
+            let var = observations
+                .iter()
+                .zip(self.weights.iter())
+                .map(|(v, w)| w * (v - mean_est).powi(2))
+                .sum::<f64>()
+                / (weights_sum - 1.0).max(1.0);
             var.sqrt()
         };
 
-        let inter_quantile_range = if observations.is_empty() { 0.0 } else {
+        let inter_quantile_range = if observations.is_empty() {
+            0.0
+        } else {
             let mut sorted_obs = observations.to_vec();
             sorted_obs.sort_by(|a, b| a.total_cmp(b));
-            let q1_idx = ((0.25 * (n_observations as f64 - 1.0)).floor() as usize).min(n_observations - 1);
-            let q3_idx = ((0.75 * (n_observations as f64 - 1.0)).floor() as usize).min(n_observations - 1);
+            let q1_idx =
+                ((0.25 * (n_observations as f64 - 1.0)).floor() as usize).min(n_observations - 1);
+            let q3_idx =
+                ((0.75 * (n_observations as f64 - 1.0)).floor() as usize).min(n_observations - 1);
             sorted_obs[q3_idx] - sorted_obs[q1_idx]
         };
-        let sigma_est = (1.059 * sigma_est.min(inter_quantile_range / 1.34) * weights_sum).powf(-0.2);
+        let sigma_est =
+            (1.059 * sigma_est.min(inter_quantile_range / 1.34) * weights_sum).powf(-0.2);
         let sigmas = std::iter::repeat_n(sigma_est, n_observations);
 
-        let mus_with_prior = observations.iter().copied().chain(std::iter::once((low + high) / 2.0));
+        let mus_with_prior = observations
+            .iter()
+            .copied()
+            .chain(std::iter::once((low + high) / 2.0));
         let sigmas_with_prior = sigmas.chain(std::iter::once(high - low + 1.0));
 
-
-         match (step, log) {
+        match (step, log) {
             (None, false) => Distributions::TruncNorm(TruncNormDistributions {
                 mus: mus_with_prior.collect(),
                 sigmas: sigmas_with_prior.collect(),
@@ -52,7 +80,7 @@ impl<'a> NumericalDistributionBuilder for ScottNumericalDistributionBuilder<'a> 
                 high,
             }),
             (None, true) => Distributions::TruncLogNorm(TruncLogNormDistributions {
-               mus: mus_with_prior.collect(),
+                mus: mus_with_prior.collect(),
                 sigmas: sigmas_with_prior.collect(),
                 low,
                 high,
@@ -60,7 +88,7 @@ impl<'a> NumericalDistributionBuilder for ScottNumericalDistributionBuilder<'a> 
             (Some(step), false) => {
                 Distributions::DiscreteTruncNorm(DiscreteTruncNormDistributions {
                     mus: mus_with_prior.collect(),
-                sigmas: sigmas_with_prior.collect(),
+                    sigmas: sigmas_with_prior.collect(),
                     low,
                     high,
                     step,
@@ -69,7 +97,7 @@ impl<'a> NumericalDistributionBuilder for ScottNumericalDistributionBuilder<'a> 
             (Some(step), true) => {
                 Distributions::DiscreteTruncLogNorm(DiscreteTruncLogNormDistributions {
                     mus: mus_with_prior.collect(),
-                sigmas: sigmas_with_prior.collect(),
+                    sigmas: sigmas_with_prior.collect(),
                     low,
                     high,
                     step,

--- a/rustuna_core/src/parzen_estimator/scott.rs
+++ b/rustuna_core/src/parzen_estimator/scott.rs
@@ -1,4 +1,4 @@
-use crate::parzen_estimator::probability_distributions::{Distributions, DiscreteTruncNormDistributions};
+use crate::parzen_estimator::probability_distributions::{Distributions, DiscreteTruncNormDistributions, TruncNormDistributions,TruncLogNormDistributions, DiscreteTruncLogNormDistributions};
 use crate::parzen_estimator::model::NumericalDistributionBuilder;
 use crate::distribution::Distribution;
 
@@ -11,23 +11,22 @@ impl<'a> NumericalDistributionBuilder for ScottNumericalDistributionBuilder<'a> 
     fn calculate_numerical_distribution(
         &self,
         observations: &[f64],
-        search_space: &Distribution::Int,
+        search_space: &Distribution,
     ) -> Distributions {
         // NOTE: Since the Optuna TPE bandwidth selection is too wide for this analysis, we use the Scott's rule:
         // David W. Scott. 1992. Multivariate Density Estimation: Theory, Practice, and Visualization. John Wiley & Sons. 
-        let (low, high, step, log) = (
-            search_space.low as f64,
-            search_space.high as f64,
-            search_space.step as f64,
-            search_space.log,
-        );
-        let weights_sum = self.weights.iter().sum();
+        let (low, high, step, log) = match search_space {
+            Distribution::Int { low, high, step, log } => (*low as f64, *high as f64, Some(*step as f64), *log),
+            Distribution::Float { low, high, step, log } => (*low, *high, *step, *log),
+            _ => panic!("Unsupported distribution type for ScottNumericalDistributionBuilder"),
+        };
+        let weights_sum = self.weights.iter().sum::<f64>();
         let n_observations = observations.len();
         
-        let mean_est = observations.iter().zip(self.weights.iter()).map(|(v, w)| v * w / weights_sum);
+        let mean_est = observations.iter().zip(self.weights.iter()).map(|(v, w)| v * w).sum::<f64>() / weights_sum;
         let sigma_est = {
-            let var = observations.iter().zip(mean_est).zip(self.weights.iter())
-            .map(|((v, m), w)| w * (v - m).powi(2)).sum() / (weights_sum - 1.0).max(1.0);
+            let var = observations.iter().zip(self.weights.iter())
+            .map(|(v, w)| w * (v - mean_est).powi(2)).sum::<f64>() / (weights_sum - 1.0).max(1.0);
             var.sqrt()
         };
 
@@ -41,16 +40,41 @@ impl<'a> NumericalDistributionBuilder for ScottNumericalDistributionBuilder<'a> 
         let sigma_est = (1.059 * sigma_est.min(inter_quantile_range / 1.34) * weights_sum).powf(-0.2);
         let sigmas = std::iter::repeat_n(sigma_est, n_observations);
 
-        let mus_with_prior = observations.iter().chain(std::iter::once((low + high) / 2.0));
+        let mus_with_prior = observations.iter().copied().chain(std::iter::once((low + high) / 2.0));
         let sigmas_with_prior = sigmas.chain(std::iter::once(high - low + 1.0));
 
 
-        Distributions::DiscreteTruncNorm(DiscreteTruncNormDistributions {
-            mus: mus_with_prior.cloned().collect(),
-            sigmas: sigmas_with_prior.collect(),
-            low,
-            high,
-            step,
-        })
+         match (step, log) {
+            (None, false) => Distributions::TruncNorm(TruncNormDistributions {
+                mus: mus_with_prior.collect(),
+                sigmas: sigmas_with_prior.collect(),
+                low,
+                high,
+            }),
+            (None, true) => Distributions::TruncLogNorm(TruncLogNormDistributions {
+               mus: mus_with_prior.collect(),
+                sigmas: sigmas_with_prior.collect(),
+                low,
+                high,
+            }),
+            (Some(step), false) => {
+                Distributions::DiscreteTruncNorm(DiscreteTruncNormDistributions {
+                    mus: mus_with_prior.collect(),
+                sigmas: sigmas_with_prior.collect(),
+                    low,
+                    high,
+                    step,
+                })
+            }
+            (Some(step), true) => {
+                Distributions::DiscreteTruncLogNorm(DiscreteTruncLogNormDistributions {
+                    mus: mus_with_prior.collect(),
+                sigmas: sigmas_with_prior.collect(),
+                    low,
+                    high,
+                    step,
+                })
+            }
+        }
     }
 }

--- a/rustuna_core/src/parzen_estimator/scott.rs
+++ b/rustuna_core/src/parzen_estimator/scott.rs
@@ -73,8 +73,7 @@ impl<'a> NumericalDistributionBuilder for ScottNumericalDistributionBuilder<'a> 
                 ((0.75 * (n_observations as f64 - 1.0)).floor() as usize).min(n_observations - 1);
             sorted_obs[q3_idx] - sorted_obs[q1_idx]
         };
-        let sigma_est =
-            1.059 * sigma_est.min(inter_quantile_range / 1.34) * weights_sum.powf(-0.2);
+        let sigma_est = 1.059 * sigma_est.min(inter_quantile_range / 1.34) * weights_sum.powf(-0.2);
         let sigmas = std::iter::repeat_n(sigma_est, n_observations);
 
         let mus_with_prior = observations

--- a/rustuna_core/src/parzen_estimator/scott.rs
+++ b/rustuna_core/src/parzen_estimator/scott.rs
@@ -34,6 +34,11 @@ impl<'a> NumericalDistributionBuilder for ScottNumericalDistributionBuilder<'a> 
         };
         let weights_sum = self.weights.iter().sum::<f64>();
         let n_observations = observations.len();
+        let observations = if log {
+            observations.iter().map(|v| v.ln()).collect()
+        } else {
+            observations.to_vec()
+        };
 
         let mean_est = observations
             .iter()
@@ -54,7 +59,7 @@ impl<'a> NumericalDistributionBuilder for ScottNumericalDistributionBuilder<'a> 
         let inter_quantile_range = if observations.is_empty() {
             0.0
         } else {
-            let mut sorted_obs = observations.to_vec();
+            let mut sorted_obs = observations.clone();
             sorted_obs.sort_by(|a, b| a.total_cmp(b));
             let q1_idx =
                 ((0.25 * (n_observations as f64 - 1.0)).floor() as usize).min(n_observations - 1);
@@ -67,8 +72,7 @@ impl<'a> NumericalDistributionBuilder for ScottNumericalDistributionBuilder<'a> 
         let sigmas = std::iter::repeat_n(sigma_est, n_observations);
 
         let mus_with_prior = observations
-            .iter()
-            .copied()
+            .into_iter()
             .chain(std::iter::once((low + high) / 2.0));
         let sigmas_with_prior = sigmas.chain(std::iter::once(high - low + 1.0));
 

--- a/rustuna_core/src/parzen_estimator/scott.rs
+++ b/rustuna_core/src/parzen_estimator/scott.rs
@@ -5,7 +5,6 @@ use crate::parzen_estimator::probability_distributions::{
     TruncLogNormDistributions, TruncNormDistributions,
 };
 
-
 pub(crate) struct ScottNumericalDistributionBuilder<'a> {
     weights: &'a [f64],
 }

--- a/rustuna_core/src/parzen_estimator/scott.rs
+++ b/rustuna_core/src/parzen_estimator/scott.rs
@@ -1,4 +1,4 @@
-use crate::parzen_estimator::probability_distributions::Distributions;
+use crate::parzen_estimator::probability_distributions::{Distributions, DiscreteTruncNormDistributions};
 use crate::parzen_estimator::model::NumericalDistributionBuilder;
 use crate::distribution::Distribution;
 

--- a/rustuna_core/src/parzen_estimator/scott.rs
+++ b/rustuna_core/src/parzen_estimator/scott.rs
@@ -74,7 +74,9 @@ impl<'a> NumericalDistributionBuilder for ScottNumericalDistributionBuilder<'a> 
             sorted_obs[q3_idx] - sorted_obs[q1_idx]
         };
         let sigma_est = 1.059 * sigma_est.min(inter_quantile_range / 1.34) * weights_sum.powf(-0.2);
-        let sigmas = std::iter::repeat_n(sigma_est, n_observations);
+        // To avoid numerical errors. 0.5/1.64 means 1.64sigma (=90%) will fit in the target grid.
+        let sigma_min = 0.5 / 1.64;
+        let sigmas = std::iter::repeat_n(sigma_est.max(sigma_min), n_observations);
 
         let mus_with_prior = observations
             .into_iter()

--- a/rustuna_core/src/parzen_estimator/scott.rs
+++ b/rustuna_core/src/parzen_estimator/scott.rs
@@ -3,16 +3,18 @@ use crate::parzen_estimator::model::NumericalDistributionBuilder;
 use crate::distribution::Distribution;
 
 
-pub struct ScottNumericalDistributionBuilder {
-    weights: &[f64],
+pub struct ScottNumericalDistributionBuilder<'a> {
+    weights: &'a [f64],
 }
 
-impl NumericalDistributionBuilder for ScottNumericalDistributionBuilder {
+impl<'a> NumericalDistributionBuilder for ScottNumericalDistributionBuilder<'a> {
     fn calculate_numerical_distribution(
         &self,
         observations: &[f64],
         search_space: &Distribution::Int,
     ) -> Distributions {
+        // NOTE: Since the Optuna TPE bandwidth selection is too wide for this analysis, we use the Scott's rule:
+        // David W. Scott. 1992. Multivariate Density Estimation: Theory, Practice, and Visualization. John Wiley & Sons. 
         let (low, high, step, log) = (
             search_space.low as f64,
             search_space.high as f64,
@@ -20,6 +22,7 @@ impl NumericalDistributionBuilder for ScottNumericalDistributionBuilder {
             search_space.log,
         );
         let weights_sum = self.weights.iter().sum();
+        let n_observations = observations.len();
         
         let mean_est = observations.iter().zip(self.weights.iter()).map(|(v, w)| v * w / weights_sum);
         let sigma_est = {
@@ -27,6 +30,27 @@ impl NumericalDistributionBuilder for ScottNumericalDistributionBuilder {
             .map(|((v, m), w)| w * (v - m).powi(2)).sum() / (weights_sum - 1.0).max(1.0);
             var.sqrt()
         };
-        
+
+        let inter_quantile_range = if observations.is_empty() { 0.0 } else {
+            let mut sorted_obs = observations.to_vec();
+            sorted_obs.sort_by(|a, b| a.total_cmp(b));
+            let q1_idx = ((0.25 * (n_observations as f64 - 1.0)).floor() as usize).min(n_observations - 1);
+            let q3_idx = ((0.75 * (n_observations as f64 - 1.0)).floor() as usize).min(n_observations - 1);
+            sorted_obs[q3_idx] - sorted_obs[q1_idx]
+        };
+        let sigma_est = (1.059 * sigma_est.min(inter_quantile_range / 1.34) * weights_sum).powf(-0.2);
+        let sigmas = std::iter::repeat_n(sigma_est, n_observations);
+
+        let mus_with_prior = observations.iter().chain(std::iter::once((low + high) / 2.0));
+        let sigmas_with_prior = sigmas.chain(std::iter::once(high - low + 1.0));
+
+
+        Distributions::DiscreteTruncNorm(DiscreteTruncNormDistributions {
+            mus: mus_with_prior.cloned().collect(),
+            sigmas: sigmas_with_prior.collect(),
+            low,
+            high,
+            step,
+        })
     }
 }

--- a/rustuna_core/src/parzen_estimator/scott.rs
+++ b/rustuna_core/src/parzen_estimator/scott.rs
@@ -3,7 +3,30 @@ use crate::parzen_estimator::model::NumericalDistributionBuilder;
 use crate::distribution::Distribution;
 
 
-
 pub struct ScottNumericalDistributionBuilder {
     weights: &[f64],
+}
+
+impl NumericalDistributionBuilder for ScottNumericalDistributionBuilder {
+    fn calculate_numerical_distribution(
+        &self,
+        observations: &[f64],
+        search_space: &Distribution::Int,
+    ) -> Distributions {
+        let (low, high, step, log) = (
+            search_space.low as f64,
+            search_space.high as f64,
+            search_space.step as f64,
+            search_space.log,
+        );
+        let weights_sum = self.weights.iter().sum();
+        
+        let mean_est = observations.iter().zip(self.weights.iter()).map(|(v, w)| v * w / weights_sum);
+        let sigma_est = {
+            let var = observations.iter().zip(mean_est).zip(self.weights.iter())
+            .map(|((v, m), w)| w * (v - m).powi(2)).sum() / (weights_sum - 1.0).max(1.0);
+            var.sqrt()
+        };
+        
+    }
 }

--- a/rustuna_core/src/parzen_estimator/scott.rs
+++ b/rustuna_core/src/parzen_estimator/scott.rs
@@ -74,7 +74,7 @@ impl<'a> NumericalDistributionBuilder for ScottNumericalDistributionBuilder<'a> 
             sorted_obs[q3_idx] - sorted_obs[q1_idx]
         };
         let sigma_est =
-            (1.059 * sigma_est.min(inter_quantile_range / 1.34) * weights_sum).powf(-0.2);
+            1.059 * sigma_est.min(inter_quantile_range / 1.34) * weights_sum.powf(-0.2);
         let sigmas = std::iter::repeat_n(sigma_est, n_observations);
 
         let mus_with_prior = observations


### PR DESCRIPTION
## Motivation

In optuna, `_ScottParzenEstimator` is created for `PedAnovaImportanceEvaluator`. This PR aims to add the counterpart of the `_ScottParzenEstimator`'s functionalilly.

## Description of the changes

- Add `ScottNumericalDistributionBuilder`