### PR TITLE
Use `trial_id` instead of `number` on `storage.set_trial_attrs()`

### DIFF
--- a/rustuna_core/src/sampler.rs
+++ b/rustuna_core/src/sampler.rs
@@ -13,6 +13,7 @@ pub struct Context {
     pub study_id: u32,
     pub directions: Vec<Direction>,
     pub trial_number: u32,
+    pub trial_id: u32,
 }
 
 pub trait Sampler: Send {

--- a/rustuna_core/src/storage.rs
+++ b/rustuna_core/src/storage.rs
@@ -72,8 +72,7 @@ pub trait Storage: Send + Sync {
     ) -> Result<()>;
     fn set_trial_attrs(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         attrs: Attrs,
         error_on_overwrite: bool,
     ) -> Result<()>;
@@ -339,11 +338,12 @@ impl Storage for InMemoryStorage {
 
     fn set_trial_attrs(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         attrs: Attrs,
         error_on_overwrite: bool,
     ) -> Result<()> {
+        let (study_id, trial_number) =
+            get_study_id_trial_number_by_trial_id(&self.trial_id_to_study_number, trial_id)?;
         let trial = get_mut_trials_by_study_id(&mut self.trials, study_id)?
             .get_mut(trial_number as usize)
             .ok_or(Error::new(ErrorKind::TrialNotFound))?;

--- a/rustuna_core/src/study.rs
+++ b/rustuna_core/src/study.rs
@@ -123,6 +123,7 @@ impl Study {
             let ctx = SamplerContext {
                 study_id: self.id,
                 trial_number,
+                trial_id,
                 directions: self.directions.clone(),
             };
             let params = guard.sample_joint(&ctx, self.storage.clone(), &joint_search_space)?;

--- a/rustuna_core/src/trial.rs
+++ b/rustuna_core/src/trial.rs
@@ -68,6 +68,7 @@ impl Trial {
         let context = SamplerContext {
             study_id: self.study_id,
             trial_number: self.number,
+            trial_id: self.id,
             directions: self.directions.clone(),
         };
         let mut sampler_guard = self
@@ -169,7 +170,7 @@ impl Trial {
 
         let key = AttrKey::User(key.into());
         attrs.insert(key.clone(), value.clone());
-        guard.set_trial_attrs(self.study_id, self.number, attrs, false)?;
+        guard.set_trial_attrs(self.id, attrs, false)?;
         self.cached_trial.attrs.insert(key, value);
         Ok(())
     }
@@ -246,7 +247,7 @@ mod tests {
             .map_err(|_| Error::new(ErrorKind::StorageError))?;
         let mut attrs = Attrs::new();
         attrs.insert(AttrKey::System("key".into()), "system".to_string());
-        guard.set_trial_attrs(study.id, 0, attrs, false)?;
+        guard.set_trial_attrs(trial.id, attrs, false)?;
 
         // Check the attributes
         let trial = guard.get_trial(trial.id)?;

--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -103,7 +103,9 @@ class Trial:
     instantiation of this object.
     """
 
+    id: int
     number: int
+    study_id: int
 
     def suggest_float(
         self,
@@ -669,12 +671,15 @@ class SamplerContext:
 
     study_id: int
     trial_number: int
+    trial_id: int
     directions: list[StudyDirection]
 
     def __init__(
         self,
+        *,
         study_id: int,
         trial_number: int,
+        trial_id: int,
         directions: list[StudyDirection],
     ) -> None: ...
 

--- a/rustuna_pyo3/src/pyobject_storage.rs
+++ b/rustuna_pyo3/src/pyobject_storage.rs
@@ -276,7 +276,7 @@ impl PyObjectStorage {
             return Ok(());
         }
         self.cache
-            .set_trial_attrs(cache_study_id, cache_trial.number, src_trial.attrs, false)?;
+            .set_trial_attrs(src_trial.id, src_trial.attrs, false)?;
 
         for (name, distribution) in src_trial.distributions {
             let internal_repr =
@@ -538,37 +538,22 @@ impl Storage for PyObjectStorage {
 
     fn set_trial_attrs(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         attrs: rustuna_core::attr::Attrs,
         _error_on_overwrite: bool,
     ) -> rustuna_core::Result<()> {
         // TODO(c-bata): Emit warnings if error_on_overwrite is true, since Optuna storage cannot support it.
         let attrs_for_obj = attrs.clone();
         let attrs_for_retry = attrs.clone();
-        let trial_id = match self
-            .cache
-            .get_trial_id_from_study_id_trial_number(study_id, trial_number)
-        {
-            Ok(trial_id) => trial_id,
-            Err(_) => {
-                self.sync_all_trials()?;
-                self.cache
-                    .get_trial_id_from_study_id_trial_number(study_id, trial_number)?
-            }
-        };
         self.obj_set_trial_attrs(trial_id, attrs_for_obj)
             .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::StorageError))?;
-        match self
-            .cache
-            .set_trial_attrs(study_id, trial_number, attrs, false)
-        {
+        match self.cache.set_trial_attrs(trial_id, attrs, false) {
             Ok(_) => Ok(()),
             Err(e) => match e.kind {
                 rustuna_core::ErrorKind::StudyNotFound | rustuna_core::ErrorKind::TrialNotFound => {
                     self.sync_all_trials()?;
                     self.cache
-                        .set_trial_attrs(study_id, trial_number, attrs_for_retry, false)?;
+                        .set_trial_attrs(trial_id, attrs_for_retry, false)?;
                     Ok(())
                 }
                 _ => Err(e),

--- a/rustuna_pyo3/src/sampler.rs
+++ b/rustuna_pyo3/src/sampler.rs
@@ -153,7 +153,7 @@ impl From<SamplerContext> for PySamplerContext {
 #[pymethods]
 impl PySamplerContext {
     #[new]
-    #[pyo3(signature = (study_id, trial_number, trial_id, directions))]
+    #[pyo3(signature = (*, study_id, trial_number, trial_id, directions))]
     pub fn py_new(
         study_id: u32,
         trial_number: u32,

--- a/rustuna_pyo3/src/sampler.rs
+++ b/rustuna_pyo3/src/sampler.rs
@@ -153,16 +153,18 @@ impl From<SamplerContext> for PySamplerContext {
 #[pymethods]
 impl PySamplerContext {
     #[new]
-    #[pyo3(signature = (study_id, trial_number, directions))]
+    #[pyo3(signature = (study_id, trial_number, trial_id, directions))]
     pub fn py_new(
         study_id: u32,
         trial_number: u32,
+        trial_id: u32,
         directions: Vec<PyDirection>,
     ) -> PyResult<Self> {
         Ok(PySamplerContext {
             context: SamplerContext {
                 study_id,
                 trial_number,
+                trial_id,
                 directions: directions.into_iter().map(|d| d.into()).collect(),
             },
         })
@@ -174,6 +176,10 @@ impl PySamplerContext {
     #[getter]
     fn trial_number(&self) -> u32 {
         self.context.trial_number
+    }
+    #[getter]
+    fn trial_id(&self) -> u32 {
+        self.context.trial_id
     }
     #[getter]
     fn directions(&self) -> Vec<PyDirection> {

--- a/rustuna_pyo3/src/storage.rs
+++ b/rustuna_pyo3/src/storage.rs
@@ -333,12 +333,8 @@ impl PyStorage {
             .storage
             .write()
             .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
-        let (study_id, trial_number) = {
-            let trial = guard.get_trial(trial_id).map_err(err_to_exceptions)?;
-            (trial.study_id, trial.number)
-        };
         guard
-            .set_trial_attrs(study_id, trial_number, system_attrs, false)
+            .set_trial_attrs(trial_id, system_attrs, false)
             .map_err(err_to_exceptions)?;
         Ok(())
     }
@@ -352,12 +348,8 @@ impl PyStorage {
             .storage
             .write()
             .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
-        let (study_id, trial_number) = {
-            let trial = guard.get_trial(trial_id).map_err(err_to_exceptions)?;
-            (trial.study_id, trial.number)
-        };
         guard
-            .set_trial_attrs(study_id, trial_number, user_attrs, false)
+            .set_trial_attrs(trial_id, user_attrs, false)
             .map_err(err_to_exceptions)?;
         Ok(())
     }

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -59,6 +59,10 @@ impl From<Trial> for PyTrial {
 #[pymethods]
 impl PyTrial {
     #[getter]
+    pub fn id(&self) -> PyResult<u32> {
+        Ok(self.0.id)
+    }
+    #[getter]
     pub fn study_id(&self) -> PyResult<u32> {
         Ok(self.0.study_id)
     }

--- a/rustuna_pyo3/tests/test_rustuna.py
+++ b/rustuna_pyo3/tests/test_rustuna.py
@@ -131,7 +131,10 @@ def test_sample():
         study = rustuna.create_study(sampler=sampler, storage=storage)
         trial = study.ask()
         ctx = rustuna.SamplerContext(
-            study.id, trial.number, directions=study.directions
+            study_id=study.id,
+            trial_number=trial.number,
+            trial_id=trial.id,
+            directions=study.directions,
         )
         value = sampler.sample_independent(
             ctx, storage, "x", rustuna.Distribution.float(0, 1)

--- a/rustuna_samplers/src/nsgaii.rs
+++ b/rustuna_samplers/src/nsgaii.rs
@@ -229,7 +229,7 @@ impl Sampler for NSGAIISampler {
             AttrKey::System("generation".into()),
             (child_generation as f64).to_string(),
         );
-        guard.set_trial_attrs(ctx.study_id, ctx.trial_number, attrs, false)?;
+        guard.set_trial_attrs(ctx.trial_id, attrs, false)?;
         drop(guard);
 
         if parent_generation < 0 {

--- a/rustuna_storages/src/cache.rs
+++ b/rustuna_storages/src/cache.rs
@@ -45,8 +45,7 @@ pub trait CachedStorageBackend: Send + Sync {
     ) -> Result<()>;
     fn set_trial_attrs(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         attrs: Attrs,
         error_on_overwrite: bool,
     ) -> Result<()>;
@@ -419,11 +418,11 @@ impl rustuna_core::storage::Storage for CachedStorage {
 
     fn set_trial_attrs(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         attrs: Attrs,
         error_on_overwrite: bool,
     ) -> Result<()> {
+        let (study_id, trial_number) = self.resolve_trial_location(trial_id)?;
         self.refresh_trials(study_id)?;
         {
             let trials = self
@@ -438,7 +437,7 @@ impl rustuna_core::storage::Storage for CachedStorage {
             }
         }
         self.backend
-            .set_trial_attrs(study_id, trial_number, attrs.clone(), error_on_overwrite)?;
+            .set_trial_attrs(trial_id, attrs.clone(), error_on_overwrite)?;
         self.refresh_trials(study_id)?;
         let trials = self
             .trials
@@ -581,13 +580,12 @@ mod tests {
 
         fn set_trial_attrs(
             &mut self,
-            study_id: u32,
-            trial_number: u32,
+            trial_id: u32,
             attrs: Attrs,
             error_on_overwrite: bool,
         ) -> Result<()> {
             self.inner
-                .set_trial_attrs(study_id, trial_number, attrs, error_on_overwrite)
+                .set_trial_attrs(trial_id, attrs, error_on_overwrite)
         }
     }
     impl OptunaCompatibleStorage for DummyBackend {
@@ -782,7 +780,7 @@ mod tests {
     fn set_study_and_trial_attrs_update_cache() -> Result<()> {
         let mut storage = CachedStorage::new(Box::new(DummyBackend::new()));
         let study_id = storage.create_new_study("s", vec![Direction::Minimize])?.id;
-        storage.create_new_trial(study_id)?;
+        let trial_id = storage.create_new_trial(study_id)?.id;
 
         let mut s_attrs = Attrs::new();
         s_attrs.insert(AttrKey::User("foo".into()), "bar".to_string());
@@ -798,8 +796,7 @@ mod tests {
 
         let mut t_attrs = Attrs::new();
         t_attrs.insert(AttrKey::System("key".into()), "val".to_string());
-        storage.set_trial_attrs(study_id, 0, t_attrs, false)?;
-        let trial_id = storage.get_trials(study_id)?[0].id;
+        storage.set_trial_attrs(trial_id, t_attrs, false)?;
         let trial = storage.get_trial(trial_id)?;
         assert_eq!(
             trial

--- a/rustuna_storages/src/journal/storage.rs
+++ b/rustuna_storages/src/journal/storage.rs
@@ -421,12 +421,22 @@ impl Storage for JournalStorage {
 
     fn set_trial_attrs(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         attrs: Attrs,
         error_on_overwrite: bool,
     ) -> Result<()> {
         self.sync_with_backend()?;
+        let (study_id, trial_number) = self
+            .replay
+            .trial_id_to_study_number
+            .get(&trial_id)
+            .copied()
+            .ok_or_else(|| {
+                Error::with_reason(
+                    ErrorKind::TrialNotFound,
+                    format!("Trial not found during set_trial_attrs: trial_id={trial_id}"),
+                )
+            })?;
         let trial = self
             .replay
             .trial_from_study_number(study_id, trial_number)?;
@@ -440,9 +450,6 @@ impl Storage for JournalStorage {
                 }
             }
         }
-        let trial_id = self
-            .replay
-            .trial_id_from_study_number(study_id, trial_number)?;
         for (key, value) in attrs {
             let mut fields = Map::new();
             fields.insert(
@@ -1973,7 +1980,7 @@ mod tests {
     fn get_trials_replays_from_backend_logs() -> Result<()> {
         let (mut storage, logs) = new_storage()?;
         let study_id = storage.create_new_study("s", vec![Direction::Minimize])?.id;
-        storage.create_new_trial(study_id)?;
+        let _trial = storage.create_new_trial(study_id)?;
 
         let backend = InMemoryJournalBackend { logs: logs.clone() };
         let mut storage2 = JournalStorage::new(Box::new(backend))?;
@@ -2044,7 +2051,7 @@ mod tests {
     fn set_study_and_trial_attrs_update_cache() -> Result<()> {
         let (mut storage, _logs) = new_storage()?;
         let study_id = storage.create_new_study("s", vec![Direction::Minimize])?.id;
-        storage.create_new_trial(study_id)?;
+        let trial_id = storage.create_new_trial(study_id)?.id;
 
         let mut s_attrs = Attrs::new();
         s_attrs.insert(AttrKey::User("foo".into()), "bar".to_string());
@@ -2060,8 +2067,7 @@ mod tests {
 
         let mut t_attrs = Attrs::new();
         t_attrs.insert(AttrKey::System("key".into()), "val".to_string());
-        storage.set_trial_attrs(study_id, 0, t_attrs, false)?;
-        let trial_id = storage.get_trials(study_id)?[0].id;
+        storage.set_trial_attrs(trial_id, t_attrs, false)?;
         let trial = storage.get_trial(trial_id)?;
         assert_eq!(
             trial

--- a/rustuna_storages/src/sqlite3.rs
+++ b/rustuna_storages/src/sqlite3.rs
@@ -813,8 +813,7 @@ impl CachedStorageBackend for SQLite3Storage {
 
     fn set_trial_attrs(
         &mut self,
-        study_id: u32,
-        trial_number: u32,
+        trial_id: u32,
         attrs: rustuna_core::attr::Attrs,
         error_on_overwrite: bool,
     ) -> rustuna_core::Result<()> {
@@ -831,20 +830,6 @@ impl CachedStorageBackend for SQLite3Storage {
             .conn
             .lock()
             .map_err(|_| Error::new(ErrorKind::StorageError))?;
-        let trial_id: Option<u32> = guard
-            .query_row(
-                "SELECT trial_id FROM trials WHERE study_id = ? AND number = ?",
-                params![study_id, trial_number],
-                |row| row.get(0),
-            )
-            .optional()
-            .map_err(|e| {
-                Error::with_reason(
-                    ErrorKind::StorageError,
-                    format!("Database query failed: {e}"),
-                )
-            })?;
-        let trial_id = trial_id.ok_or(Error::new(ErrorKind::TrialNotFound))?;
 
         let tx = guard.transaction().map_err(|e| {
             Error::with_reason(
@@ -1820,7 +1805,7 @@ mod tests {
             "trial_system_value".to_string(),
         );
 
-        storage.set_trial_attrs(study_id, trial.number, attrs, false)?;
+        storage.set_trial_attrs(trial.id, attrs, false)?;
 
         let trial = storage.get_trial(trial.id)?;
         assert_eq!(
@@ -1847,7 +1832,7 @@ mod tests {
             AttrKey::User("trial_user_key".into()),
             "trial_user_value".to_string(),
         );
-        storage.set_trial_attrs(study_id, trial.number, attrs, false)?;
+        storage.set_trial_attrs(trial.id, attrs, false)?;
 
         let mut overwrite = Attrs::new();
         overwrite.insert(
@@ -1859,7 +1844,7 @@ mod tests {
             "new_value".to_string(),
         );
         let err = storage
-            .set_trial_attrs(study_id, trial.number, overwrite, true)
+            .set_trial_attrs(trial.id, overwrite, true)
             .expect_err("Expected AttrOverwriteNotAllowed error");
         assert!(matches!(err.kind, ErrorKind::AttrOverwriteNotAllowed));
 


### PR DESCRIPTION
This PR updates the signature of `storage.set_trial_attrs` to reduce the differences with Optuna storage APIs.