### PR TITLE
Add `no_sync` option to avoid syncing with backend

### DIFF
--- a/rustuna_core/src/storage.rs
+++ b/rustuna_core/src/storage.rs
@@ -33,8 +33,12 @@ pub trait Storage: Send + Sync {
     // references without relying on unsafe patterns.
     fn get_studies(&mut self) -> Result<&Vec<PersistedStudy>>;
     fn get_study(&mut self, study_id: u32) -> Result<&PersistedStudy>;
-    fn get_trials(&mut self, study_id: u32) -> Result<&Vec<PersistedTrial>>;
-    fn get_trial(&mut self, trial_id: u32) -> Result<&PersistedTrial>;
+    // Design Note:
+    // `no_sync` avoids refreshing or syncing from the backend and reads from the
+    // current in-memory cache. Implementations may return TrialNotFound or StudyNotFound
+    // if the requested data is not cached yet.
+    fn get_trials(&mut self, study_id: u32, no_sync: bool) -> Result<&Vec<PersistedTrial>>;
+    fn get_trial(&mut self, trial_id: u32, no_sync: bool) -> Result<&PersistedTrial>;
     // Design Note:
     // Category labels are stored in study system attrs internally, but exposed via dedicated
     // APIs for caching efficiency. Since category labels cannot be overwritten once set for
@@ -300,11 +304,11 @@ impl Storage for InMemoryStorage {
         Ok(study)
     }
 
-    fn get_trials(&mut self, study_id: u32) -> Result<&Vec<PersistedTrial>> {
+    fn get_trials(&mut self, study_id: u32, _no_sync: bool) -> Result<&Vec<PersistedTrial>> {
         get_trials_by_study_id(&self.trials, study_id)
     }
 
-    fn get_trial(&mut self, trial_id: u32) -> Result<&PersistedTrial> {
+    fn get_trial(&mut self, trial_id: u32, _no_sync: bool) -> Result<&PersistedTrial> {
         let (study_id, trial_number) =
             get_study_id_trial_number_by_trial_id(&self.trial_id_to_study_number, trial_id)?;
         let trial = get_trials_by_study_id(&self.trials, study_id)?

--- a/rustuna_core/src/study.rs
+++ b/rustuna_core/src/study.rs
@@ -202,7 +202,7 @@ impl Study {
             .storage
             .write()
             .map_err(|_| Error::new(ErrorKind::StorageError))?;
-        let trials = guard.get_trials(self.id)?;
+        let trials = guard.get_trials(self.id, false)?;
         Ok(trials.clone())
     }
 
@@ -278,7 +278,7 @@ pub fn get_best_trial(study: &Study) -> Result<u32> {
         .storage
         .write()
         .map_err(|_| Error::new(ErrorKind::StorageError))?;
-    let trials = guard.get_trials(study.id)?;
+    let trials = guard.get_trials(study.id, false)?;
 
     let best_trial = trials
         .iter()
@@ -313,7 +313,7 @@ pub fn get_pareto_front(study: &Study) -> Result<Vec<u32>> {
         .write()
         .map_err(|_| Error::new(ErrorKind::StorageError))?;
     let trials = guard
-        .get_trials(study.id)?
+        .get_trials(study.id, false)?
         .iter()
         .filter(|t| matches!(t.state_values, TrialStateValues::Complete(ref _v)))
         .collect::<Vec<_>>();

--- a/rustuna_core/src/trial.rs
+++ b/rustuna_core/src/trial.rs
@@ -250,7 +250,7 @@ mod tests {
         guard.set_trial_attrs(trial.id, attrs, false)?;
 
         // Check the attributes
-        let trial = guard.get_trial(trial.id)?;
+        let trial = guard.get_trial(trial.id, false)?;
         assert_eq!(
             trial.attrs.get(&AttrKey::User("key".into())),
             Some(&"user".to_string())

--- a/rustuna_importance/src/fanova.rs
+++ b/rustuna_importance/src/fanova.rs
@@ -11,7 +11,7 @@ pub fn get_param_importance(study: &Study) -> Result<Vec<Vec<f64>>> {
         .map_err(|_e| Error::new(ErrorKind::Unexpected))?;
     // TODO(c-bata): Avoid to clone trials.
     let completed_trials: Vec<PersistedTrial> = guard
-        .get_trials(study.id)?
+        .get_trials(study.id, false)?
         .clone()
         .into_iter()
         .filter(|t| matches!(t.state_values, TrialStateValues::Complete(_)))

--- a/rustuna_js/src/study.rs
+++ b/rustuna_js/src/study.rs
@@ -45,7 +45,7 @@ impl JsStudy {
                 JsError::new(&format!("Failed to acquire the storage guard: {e:?}"))
             })?;
             let trials = guard
-                .get_trials(self.0.id)
+                .get_trials(self.0.id, false)
                 .map_err(|e| JsError::new(&format!("Failed to get trials: {:?}", e.kind)))?
                 .clone();
             let study_attrs = guard

--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -409,8 +409,10 @@ class StorageProtocol(Protocol):
     ) -> None: ...
     def get_studies(self) -> list[PersistedStudy]: ...
     def get_study(self, study_id: int) -> PersistedStudy: ...
-    def get_trials(self, study_id: int) -> list[PersistedTrial]: ...
-    def get_trial(self, trial_id: int) -> PersistedTrial: ...
+    def get_trials(
+        self, study_id: int, *, no_sync: bool = ...
+    ) -> list[PersistedTrial]: ...
+    def get_trial(self, trial_id: int, *, no_sync: bool = ...) -> PersistedTrial: ...
     def get_trial_id_from_study_id_trial_number(
         self, study_id: int, trial_number: int
     ) -> int: ...
@@ -542,7 +544,7 @@ class Storage:
         Returns:
             The study.
         """
-    def get_trials(self, study_id: int) -> list[PersistedTrial]:
+    def get_trials(self, study_id: int, *, no_sync: bool = ...) -> list[PersistedTrial]:
         """Get all trials in a study.
 
         Args:
@@ -560,7 +562,7 @@ class Storage:
         Returns:
             Number of trials.
         """
-    def get_trial(self, trial_id: int) -> PersistedTrial:
+    def get_trial(self, trial_id: int, *, no_sync: bool = ...) -> PersistedTrial:
         """Get a trial by ID.
 
         Args:

--- a/rustuna_pyo3/rustuna/converter/_storage.py
+++ b/rustuna_pyo3/rustuna/converter/_storage.py
@@ -101,7 +101,9 @@ class ToRustunaStorage:
                 return to_persisted_study(s)
         raise KeyError(f"Study {study_id} not found")
 
-    def get_trials(self, study_id: int) -> list[rustuna.PersistedTrial]:
+    def get_trials(
+        self, study_id: int, *, no_sync: bool = False
+    ) -> list[rustuna.PersistedTrial]:
         frozen_trials = self._storage.get_all_trials(study_id)
 
         persisted_trials: list[rustuna.PersistedTrial] = []
@@ -111,7 +113,9 @@ class ToRustunaStorage:
                 self._trial_id_to_study_id[t._trial_id] = study_id
         return persisted_trials
 
-    def get_trial(self, trial_id: int) -> rustuna.PersistedTrial:
+    def get_trial(
+        self, trial_id: int, *, no_sync: bool = False
+    ) -> rustuna.PersistedTrial:
         with self._lock:
             study_id = self._trial_id_to_study_id.get(trial_id, -1)
         if study_id == -1:

--- a/rustuna_pyo3/src/pyobject_storage.rs
+++ b/rustuna_pyo3/src/pyobject_storage.rs
@@ -249,7 +249,7 @@ impl PyObjectStorage {
     ) -> rustuna_core::Result<()> {
         let cache_n_trials = match cache_n_trials {
             Some(n) => n,
-            None => self.cache.get_trials(cache_study_id)?.len() as u32,
+            None => self.cache.get_trials(cache_study_id, false)?.len() as u32,
         };
         match src_trial.number.cmp(&cache_n_trials) {
             std::cmp::Ordering::Equal => {
@@ -273,7 +273,7 @@ impl PyObjectStorage {
             }
         }
 
-        let cache_trial = self.cache.get_trial(src_trial.id)?.clone();
+        let cache_trial = self.cache.get_trial(src_trial.id, false)?.clone();
         if cache_trial.is_finished() {
             return Ok(());
         }
@@ -315,10 +315,10 @@ impl PyObjectStorage {
             .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::StorageError))?;
         src_trials.sort_by_key(|trial| trial.number);
 
-        let mut cache_n_trials = self.cache.get_trials(cache_study_id)?.len() as u32;
+        let mut cache_n_trials = self.cache.get_trials(cache_study_id, false)?.len() as u32;
         for src_trial in src_trials {
             self.sync_trial(cache_study_id, src_trial, Some(cache_n_trials))?;
-            cache_n_trials = self.cache.get_trials(cache_study_id)?.len() as u32;
+            cache_n_trials = self.cache.get_trials(cache_study_id, false)?.len() as u32;
         }
         Ok(())
     }
@@ -385,15 +385,15 @@ impl Storage for PyObjectStorage {
         let src_trial_id = src_trial.id;
         if self.is_distributed {
             self.sync_trials(study_id)?;
-            return self.cache.get_trial(src_trial_id);
+            return self.cache.get_trial(src_trial_id, false);
         }
-        let cached_n_trials = self.cache.get_trials(study_id)?.len() as u32;
+        let cached_n_trials = self.cache.get_trials(study_id, false)?.len() as u32;
         if src_trial.number != cached_n_trials {
             self.sync_trials(study_id)?;
-            return self.cache.get_trial(src_trial_id);
+            return self.cache.get_trial(src_trial_id, false);
         }
         self.sync_trial(study_id, src_trial, Some(cached_n_trials))?;
-        self.cache.get_trial(src_trial_id)
+        self.cache.get_trial(src_trial_id, false)
     }
 
     fn set_trial_param(
@@ -459,15 +459,17 @@ impl Storage for PyObjectStorage {
     fn get_trials(
         &mut self,
         study_id: u32,
+        _no_sync: bool,
     ) -> rustuna_core::Result<&Vec<rustuna_core::trial::PersistedTrial>> {
-        self.cache.get_trials(study_id)
+        self.cache.get_trials(study_id, false)
     }
 
     fn get_trial(
         &mut self,
         trial_id: u32,
+        _no_sync: bool,
     ) -> rustuna_core::Result<&rustuna_core::trial::PersistedTrial> {
-        self.cache.get_trial(trial_id)
+        self.cache.get_trial(trial_id, false)
     }
 
     fn get_category_labels(

--- a/rustuna_pyo3/src/storage.rs
+++ b/rustuna_pyo3/src/storage.rs
@@ -133,7 +133,7 @@ impl PyStorage {
                     .write()
                     .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
                 guard
-                    .get_trial(trial_id)
+                    .get_trial(trial_id, false)
                     .map_err(err_to_exceptions)?
                     .study_id
             };
@@ -249,12 +249,15 @@ impl PyStorage {
         Ok(study.clone().into())
     }
 
-    fn get_trials(&mut self, study_id: u32) -> PyResult<Vec<PyPersistedTrial>> {
+    #[pyo3(signature = (study_id, *, no_sync = false))]
+    fn get_trials(&mut self, study_id: u32, no_sync: bool) -> PyResult<Vec<PyPersistedTrial>> {
         let mut guard = self
             .storage
             .write()
             .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
-        let trials = guard.get_trials(study_id).map_err(err_to_exceptions)?;
+        let trials = guard
+            .get_trials(study_id, no_sync)
+            .map_err(err_to_exceptions)?;
         let py_trials: Vec<PyPersistedTrial> = trials
             .iter()
             .map(|t| PyPersistedTrial::from_storage(self.storage.clone(), t))
@@ -262,13 +265,18 @@ impl PyStorage {
         Ok(py_trials)
     }
 
-    fn get_trial(&mut self, trial_id: u32) -> PyResult<PyPersistedTrial> {
+    #[pyo3(signature = (trial_id, *, no_sync = false))]
+    fn get_trial(&mut self, trial_id: u32, no_sync: bool) -> PyResult<PyPersistedTrial> {
         let mut guard = self
             .storage
             .write()
             .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
+        if no_sync {
+            let trial = guard.get_trial(trial_id, true).map_err(err_to_exceptions)?;
+            return Ok(PyPersistedTrial::from_storage(self.storage.clone(), trial));
+        }
         let trial = guard
-            .get_trial(trial_id)
+            .get_trial(trial_id, false)
             .map_err(err_to_exceptions)?
             .clone();
         let study_attrs = guard

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -309,7 +309,7 @@ impl PyStudy {
                 PyRuntimeError::new_err(format!("Failed to get trial id: {:?}", e.kind))
             })?;
         let trial = guard
-            .get_trial(trial_id)
+            .get_trial(trial_id, false)
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to get trial: {:?}", e.kind)))?;
         Ok(PyPersistedTrial::from_storage(
             self.study.storage.clone(),
@@ -325,7 +325,7 @@ impl PyStudy {
             .write()
             .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
         let trials_vec = guard
-            .get_trials(self.study.id)
+            .get_trials(self.study.id, false)
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind)))?;
         let trials: Vec<PyPersistedTrial> = trials_vec
             .iter()
@@ -361,7 +361,7 @@ impl PyStudy {
             .write()
             .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
         let trials_vec = guard
-            .get_trials(self.study.id)
+            .get_trials(self.study.id, false)
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind)))?;
         let best_trials = pareto_front_numbers
             .iter()

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -230,7 +230,9 @@ impl PyPersistedTrial {
                 let mut guard = storage
                     .write()
                     .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
-                let trial = guard.get_trial(*trial_id).map_err(err_to_exceptions)?;
+                let trial = guard
+                    .get_trial(*trial_id, true)
+                    .map_err(err_to_exceptions)?;
                 f(trial)
             }
         }

--- a/rustuna_samplers/src/nsgaii.rs
+++ b/rustuna_samplers/src/nsgaii.rs
@@ -131,7 +131,7 @@ impl NSGAIISampler {
         let mut guard = storage
             .write()
             .map_err(|_e| Error::new(ErrorKind::Unexpected))?;
-        let trials = guard.get_trials(ctx.study_id)?;
+        let trials = guard.get_trials(ctx.study_id, false)?;
         let population_params = trials
             .iter()
             .filter(|trial| population_numbers.contains(&trial.number))
@@ -220,7 +220,7 @@ impl Sampler for NSGAIISampler {
         let mut guard = storage
             .write()
             .map_err(|_e| Error::new(ErrorKind::Unexpected))?;
-        let trials = guard.get_trials(ctx.study_id)?;
+        let trials = guard.get_trials(ctx.study_id, false)?;
         let (parent_generation, parent_population_numbers) =
             self.get_parent_population_numbers(ctx, trials)?;
         let child_generation = u32::try_from(parent_generation + 1).unwrap();

--- a/rustuna_samplers/src/tpe/sampler.rs
+++ b/rustuna_samplers/src/tpe/sampler.rs
@@ -84,7 +84,7 @@ impl TpeSampler {
         let mut guard = storage
             .write()
             .map_err(|_e| Error::new(ErrorKind::Unexpected))?;
-        let trials = guard.get_trials(ctx.study_id)?.clone();
+        let trials = guard.get_trials(ctx.study_id, false)?.clone();
         drop(guard);
 
         let complete_trials: Vec<_> = trials.into_iter().filter(|t| t.is_finished()).collect();
@@ -396,7 +396,7 @@ impl Sampler for TpeSampler {
         let mut guard = storage
             .write()
             .map_err(|_e| Error::new(ErrorKind::Unexpected))?;
-        let trials = guard.get_trials(ctx.study_id)?.clone();
+        let trials = guard.get_trials(ctx.study_id, false)?.clone();
         drop(guard);
 
         let complete_trials: Vec<_> = trials.into_iter().filter(|t| t.is_finished()).collect();
@@ -425,7 +425,7 @@ impl Sampler for TpeSampler {
         let mut guard = storage
             .write()
             .map_err(|_e| Error::new(ErrorKind::Unexpected))?;
-        let trials = guard.get_trials(ctx.study_id)?.clone();
+        let trials = guard.get_trials(ctx.study_id, false)?.clone();
         drop(guard);
 
         let complete_trials: Vec<_> = trials.into_iter().filter(|t| t.is_finished()).collect();

--- a/rustuna_storages/src/cache.rs
+++ b/rustuna_storages/src/cache.rs
@@ -319,8 +319,10 @@ impl rustuna_core::storage::Storage for CachedStorage {
         Ok(study)
     }
 
-    fn get_trials(&mut self, study_id: u32) -> Result<&Vec<PersistedTrial>> {
-        self.refresh_trials(study_id)?;
+    fn get_trials(&mut self, study_id: u32, no_sync: bool) -> Result<&Vec<PersistedTrial>> {
+        if !no_sync {
+            self.refresh_trials(study_id)?;
+        }
         let trials_map = self
             .trials
             .get(&study_id)
@@ -336,7 +338,21 @@ impl rustuna_core::storage::Storage for CachedStorage {
         Ok(&self.trials_sorted_buffer)
     }
 
-    fn get_trial(&mut self, trial_id: u32) -> Result<&PersistedTrial> {
+    fn get_trial(&mut self, trial_id: u32, no_sync: bool) -> Result<&PersistedTrial> {
+        if no_sync {
+            let (study_id, trial_number) = self
+                .trial_id_to_study_number
+                .get(&trial_id)
+                .copied()
+                .ok_or_else(|| Error::new(ErrorKind::TrialNotFound))?;
+            let trials = self
+                .trials
+                .get(&study_id)
+                .ok_or_else(|| Error::new(ErrorKind::StudyNotFound))?;
+            return trials
+                .get(&trial_number)
+                .ok_or_else(|| Error::new(ErrorKind::TrialNotFound));
+        }
         let (study_id, trial_number) = self.resolve_trial_location(trial_id)?;
         self.refresh_trials(study_id)?;
         let trials = self
@@ -454,7 +470,7 @@ impl rustuna_core::storage::Storage for CachedStorage {
 
     fn get_joint_search_space(&mut self, study_id: u32) -> Result<HashMap<String, Distribution>> {
         let trials_vec = {
-            let trials = self.get_trials(study_id)?;
+            let trials = self.get_trials(study_id, false)?;
             let mut v = trials.clone();
             v.sort_by_key(|t| t.number);
             v
@@ -552,7 +568,7 @@ mod tests {
             included_numbers: &[u32],
             trial_number_greater_than: i32,
         ) -> Result<Vec<PersistedTrial>> {
-            let all = self.inner.get_trials(study_id)?.clone();
+            let all = self.inner.get_trials(study_id, false)?.clone();
             let mut trials = Vec::new();
             for t in all {
                 if included_numbers.contains(&t.number)
@@ -565,7 +581,7 @@ mod tests {
         }
 
         fn get_trial(&mut self, trial_id: u32) -> Result<PersistedTrial> {
-            Ok(self.inner.get_trial(trial_id)?.clone())
+            Ok(self.inner.get_trial(trial_id, false)?.clone())
         }
 
         fn set_study_attrs(
@@ -649,7 +665,7 @@ mod tests {
     }
 
     #[test]
-    fn get_study_and_get_studies_use_cache() -> Result<()> {
+    fn get_study_and_get_studies_no_sync() -> Result<()> {
         let mut storage = CachedStorage::new(Box::new(DummyBackend::new()));
         storage.create_new_study("s1", vec![Direction::Minimize])?;
         storage.create_new_study("s2", vec![Direction::Maximize])?;
@@ -687,11 +703,11 @@ mod tests {
         let t0_id = storage.create_new_trial(study_id)?.id;
         let t1_id = storage.create_new_trial(study_id)?.id;
 
-        let trials = storage.get_trials(study_id)?;
+        let trials = storage.get_trials(study_id, false)?;
         assert_eq!(trials.len(), 2);
-        let t0 = storage.get_trial(t0_id)?;
+        let t0 = storage.get_trial(t0_id, false)?;
         assert_eq!(t0.number, 0);
-        let t1 = storage.get_trial(t1_id)?;
+        let t1 = storage.get_trial(t1_id, false)?;
         assert_eq!(t1.number, 1);
         Ok(())
     }
@@ -703,7 +719,7 @@ mod tests {
         storage.create_new_trial(study_id)?;
 
         storage.trials.clear();
-        let trials = storage.get_trials(study_id)?;
+        let trials = storage.get_trials(study_id, false)?;
         assert_eq!(trials.len(), 1);
         Ok(())
     }
@@ -734,11 +750,11 @@ mod tests {
         backend.create_new_trial(study_id)?;
 
         let mut storage = CachedStorage::new(Box::new(backend));
-        let trials1 = storage.get_trials(study_id)?;
+        let trials1 = storage.get_trials(study_id, false)?;
         assert_eq!(trials1.len(), 1);
 
         storage.backend.create_new_trial(study_id)?;
-        let trials2 = storage.get_trials(study_id)?;
+        let trials2 = storage.get_trials(study_id, false)?;
         assert_eq!(trials2.len(), 2);
         Ok(())
     }
@@ -751,7 +767,7 @@ mod tests {
 
         let mut storage = CachedStorage::new(Box::new(backend));
         storage.set_trial_state_values(trial_id, TrialStateValues::Complete(vec![1.0]))?;
-        let trial = storage.get_trial(trial_id)?;
+        let trial = storage.get_trial(trial_id, false)?;
         assert!(matches!(trial.state_values, TrialStateValues::Complete(_)));
         Ok(())
     }
@@ -797,7 +813,7 @@ mod tests {
         let mut t_attrs = Attrs::new();
         t_attrs.insert(AttrKey::System("key".into()), "val".to_string());
         storage.set_trial_attrs(trial_id, t_attrs, false)?;
-        let trial = storage.get_trial(trial_id)?;
+        let trial = storage.get_trial(trial_id, false)?;
         assert_eq!(
             trial
                 .attrs
@@ -821,10 +837,10 @@ mod tests {
             step: None,
             log: false,
         };
-        let trial_id = storage.get_trials(study_id)?[0].id;
+        let trial_id = storage.get_trials(study_id, false)?[0].id;
         storage.set_trial_param(trial_id, "x", &dist, 0.5)?;
 
-        let trial = storage.get_trial(trial_id)?;
+        let trial = storage.get_trial(trial_id, false)?;
         assert_eq!(trial.internal_params.get("x"), Some(&0.5));
         assert_eq!(
             trial.distributions.get("x"),
@@ -871,14 +887,14 @@ mod tests {
         // Set new params.
         storage.set_trial_param(trial_1_id, "x", &distribution_x, 0.5)?;
         storage.set_trial_param(trial_1_id, "y", &distribution_y_1, 2.0)?;
-        let trial = storage.get_trial(trial_1_id)?;
+        let trial = storage.get_trial(trial_1_id, false)?;
         assert_eq!(trial.internal_params["x"], 0.5);
         assert_eq!(trial.internal_params["y"], 2.0);
 
         // Set params to another trial
         storage.set_trial_param(trial_2_id, "x", &distribution_x, 0.3)?;
         storage.set_trial_param(trial_2_id, "z", &distribution_z, 0.1)?;
-        let trial = storage.get_trial(trial_2_id)?;
+        let trial = storage.get_trial(trial_2_id, false)?;
         assert_eq!(trial.internal_params["x"], 0.3);
         assert_eq!(trial.internal_params["z"], 0.1);
 

--- a/rustuna_storages/src/journal/storage.rs
+++ b/rustuna_storages/src/journal/storage.rs
@@ -280,8 +280,10 @@ impl Storage for JournalStorage {
         })
     }
 
-    fn get_trials(&mut self, study_id: u32) -> Result<&Vec<PersistedTrial>> {
-        self.sync_with_backend()?;
+    fn get_trials(&mut self, study_id: u32, no_sync: bool) -> Result<&Vec<PersistedTrial>> {
+        if !no_sync {
+            self.sync_with_backend()?;
+        }
         let trials = self.replay.trials_by_study.get(&study_id).ok_or_else(|| {
             Error::with_reason(
                 ErrorKind::StudyNotFound,
@@ -291,8 +293,10 @@ impl Storage for JournalStorage {
         Ok(trials)
     }
 
-    fn get_trial(&mut self, trial_id: u32) -> Result<&PersistedTrial> {
-        self.sync_with_backend()?;
+    fn get_trial(&mut self, trial_id: u32, no_sync: bool) -> Result<&PersistedTrial> {
+        if !no_sync {
+            self.sync_with_backend()?;
+        }
         let (study_id, trial_number) = self
             .replay
             .trial_id_to_study_number
@@ -1964,7 +1968,7 @@ mod tests {
     }
 
     #[test]
-    fn get_study_and_get_studies_use_cache() -> Result<()> {
+    fn get_study_and_get_studies_no_sync() -> Result<()> {
         let (mut storage, _logs) = new_storage()?;
         storage.create_new_study("s1", vec![Direction::Minimize])?;
         storage.create_new_study("s2", vec![Direction::Maximize])?;
@@ -1987,7 +1991,7 @@ mod tests {
         let t1_num = storage.create_new_trial(study)?.number;
         assert_eq!(t0_num, 0);
         assert_eq!(t1_num, 1);
-        let trials = storage.get_trials(study)?;
+        let trials = storage.get_trials(study, false)?;
         assert_eq!(trials.len(), 2);
         Ok(())
     }
@@ -1999,11 +2003,11 @@ mod tests {
         let t0_id = storage.create_new_trial(study_id)?.id;
         let t1_id = storage.create_new_trial(study_id)?.id;
 
-        let trials = storage.get_trials(study_id)?;
+        let trials = storage.get_trials(study_id, false)?;
         assert_eq!(trials.len(), 2);
-        let t0 = storage.get_trial(t0_id)?;
+        let t0 = storage.get_trial(t0_id, false)?;
         assert_eq!(t0.number, 0);
-        let t1 = storage.get_trial(t1_id)?;
+        let t1 = storage.get_trial(t1_id, false)?;
         assert_eq!(t1.number, 1);
         Ok(())
     }
@@ -2016,7 +2020,7 @@ mod tests {
 
         let backend = InMemoryJournalBackend { logs: logs.clone() };
         let mut storage2 = JournalStorage::new(Box::new(backend))?;
-        let trials = storage2.get_trials(study_id)?;
+        let trials = storage2.get_trials(study_id, false)?;
         assert_eq!(trials.len(), 1);
         Ok(())
     }
@@ -2042,7 +2046,7 @@ mod tests {
         storage.create_new_trial(study_id)?;
 
         append_external_log(&logs, create_trial_log(study_id));
-        let trials = storage.get_trials(study_id)?;
+        let trials = storage.get_trials(study_id, false)?;
         assert_eq!(trials.len(), 2);
         Ok(())
     }
@@ -2054,7 +2058,7 @@ mod tests {
         let trial_id = storage.create_new_trial(study_id)?.id;
 
         storage.set_trial_state_values(trial_id, TrialStateValues::Complete(vec![1.0]))?;
-        let trial = storage.get_trial(trial_id)?;
+        let trial = storage.get_trial(trial_id, false)?;
         assert!(matches!(trial.state_values, TrialStateValues::Complete(_)));
         Ok(())
     }
@@ -2100,7 +2104,7 @@ mod tests {
         let mut t_attrs = Attrs::new();
         t_attrs.insert(AttrKey::System("key".into()), "val".to_string());
         storage.set_trial_attrs(trial_id, t_attrs, false)?;
-        let trial = storage.get_trial(trial_id)?;
+        let trial = storage.get_trial(trial_id, false)?;
         assert_eq!(
             trial
                 .attrs
@@ -2123,10 +2127,10 @@ mod tests {
             step: None,
             log: false,
         };
-        let trial_id = storage.get_trials(study_id)?[0].id;
+        let trial_id = storage.get_trials(study_id, false)?[0].id;
         storage.set_trial_param(trial_id, "x", &dist, 0.5)?;
 
-        let trial = storage.get_trial(trial_id)?;
+        let trial = storage.get_trial(trial_id, false)?;
         assert_eq!(trial.internal_params.get("x"), Some(&0.5));
         assert_eq!(
             trial.distributions.get("x"),
@@ -2166,13 +2170,13 @@ mod tests {
 
         storage.set_trial_param(trial_1_id, "x", &distribution_x, 0.5)?;
         storage.set_trial_param(trial_1_id, "y", &distribution_y_1, 2.0)?;
-        let trial = storage.get_trial(trial_1_id)?;
+        let trial = storage.get_trial(trial_1_id, false)?;
         assert_eq!(trial.internal_params["x"], 0.5);
         assert_eq!(trial.internal_params["y"], 2.0);
 
         storage.set_trial_param(trial_2_id, "x", &distribution_x, 0.3)?;
         storage.set_trial_param(trial_2_id, "z", &distribution_z, 0.1)?;
-        let trial = storage.get_trial(trial_2_id)?;
+        let trial = storage.get_trial(trial_2_id, false)?;
         assert_eq!(trial.internal_params["x"], 0.3);
         assert_eq!(trial.internal_params["z"], 0.1);
 

--- a/rustuna_storages/tests/journal.rs
+++ b/rustuna_storages/tests/journal.rs
@@ -120,8 +120,8 @@ study.optimize(objective, n_trials=10)
         studies[0].id
     };
 
-    let trial_id = storage.get_trials(study_id)?[0].id;
-    let trial0 = storage.get_trial(trial_id)?;
+    let trial_id = storage.get_trials(study_id, false)?[0].id;
+    let trial0 = storage.get_trial(trial_id, false)?;
     assert_eq!(trial0.number, 0);
 
     // Distributions
@@ -192,7 +192,7 @@ study.optimize(objective, n_trials=10)
         assert_eq!(studies.len(), 1);
         studies[0].id
     };
-    let trials = storage.get_trials(study_id)?;
+    let trials = storage.get_trials(study_id, false)?;
     assert_eq!(trials.len(), 10);
 
     // Evaluate more 10 trials with load_if_exists=True
@@ -220,7 +220,7 @@ study.optimize(objective, n_trials=10)
         script_continue,
     )?;
     let mut storage = JournalStorage::new(Box::new(JournalFileBackend::new(&journal_path, None)?))?;
-    let trials = storage.get_trials(study_id)?;
+    let trials = storage.get_trials(study_id, false)?;
     assert_eq!(trials.len(), 20);
     assert_eq!(trials[0].distributions.len(), 3);
     assert_eq!(

--- a/rustuna_storages/tests/sqlite3.rs
+++ b/rustuna_storages/tests/sqlite3.rs
@@ -157,12 +157,12 @@ study.optimize(objective, n_trials=10)
         assert_eq!(studies.len(), 1);
         studies[0].id
     };
-    let trials = storage.get_trials(study_id)?;
+    let trials = storage.get_trials(study_id, false)?;
     assert_eq!(trials.len(), 10);
 
     // Evaluate more 10 trials
     run_optuna_script(&python, &db_path, script)?;
-    let trials = storage.get_trials(study_id)?;
+    let trials = storage.get_trials(study_id, false)?;
     assert_eq!(trials.len(), 20);
     assert_eq!(trials[0].distributions.len(), 3);
     assert_eq!(


### PR DESCRIPTION
This PR introduces `no_sync` option, preventing the data syncing when access to the `PyPersistedTrial` properties.