### PR TITLE
Add `ToRustunaSampler`

### DIFF
--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -785,7 +785,7 @@ class Sampler:
     def sample_joint(
         self,
         ctx: SamplerContext,
-        storage: StorageProtocol,
+        storage: Storage | PyObjectStorage,
         search_space: dict[str, Distribution],
     ) -> dict[str, float]:
         """Sample multiple parameters simultaneously.
@@ -801,7 +801,7 @@ class Sampler:
     def sample_independent(
         self,
         ctx: SamplerContext,
-        storage: StorageProtocol,
+        storage: Storage | PyObjectStorage,
         name: str,
         distribution: Distribution,
     ) -> float:

--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -437,6 +437,25 @@ class OptunaStorageProtocol(StorageProtocol, Protocol):
         self, trial_id: int, step: int, intermediate_value: float
     ) -> None: ...
 
+class PyObjectStorage:
+    """Wrapper to convert a StorageProtocol implementation to Rust Storage trait.
+
+    This class wraps a Python object implementing StorageProtocol and makes it
+    usable as a Rust Storage trait implementation.
+
+    Note:
+        This class is not intended for direct use by end users. It is used internally
+        by rustuna converters (e.g., ToOptunaSampler) to bridge Python StorageProtocol
+        implementations with Rust components.
+    """
+
+    def __init__(self, storage: StorageProtocol) -> None:
+        """Create a PyObjectStorage from a StorageProtocol instance.
+
+        Args:
+            storage: A Python object implementing StorageProtocol.
+        """
+
 class Storage:
     """Storage for persisting optimization history."""
 
@@ -704,13 +723,13 @@ class SamplerProtocol(Protocol):
     def sample_joint(
         self,
         ctx: SamplerContext,
-        storage: StorageProtocol,
+        storage: Storage | PyObjectStorage,
         search_space: dict[str, Distribution],
     ) -> dict[str, float]: ...
     def sample_independent(
         self,
         ctx: SamplerContext,
-        storage: StorageProtocol,
+        storage: Storage | PyObjectStorage,
         name: str,
         distribution: Distribution,
     ) -> float: ...

--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -704,13 +704,13 @@ class SamplerProtocol(Protocol):
     def sample_joint(
         self,
         ctx: SamplerContext,
-        storage: Storage,
+        storage: StorageProtocol,
         search_space: dict[str, Distribution],
     ) -> dict[str, float]: ...
     def sample_independent(
         self,
         ctx: SamplerContext,
-        storage: Storage,
+        storage: StorageProtocol,
         name: str,
         distribution: Distribution,
     ) -> float: ...
@@ -719,7 +719,7 @@ class Sampler:
     """Factory class for creating sampler instances."""
 
     @classmethod
-    def tpe(cls, seed: int | None = None) -> Sampler:
+    def tpe(cls, seed: int | None = None, multivariate: bool = True) -> Sampler:
         """Create a Tree-structured Parzen Estimator sampler.
 
         Args:
@@ -766,7 +766,7 @@ class Sampler:
     def sample_joint(
         self,
         ctx: SamplerContext,
-        storage: Storage,
+        storage: StorageProtocol,
         search_space: dict[str, Distribution],
     ) -> dict[str, float]:
         """Sample multiple parameters simultaneously.
@@ -782,7 +782,7 @@ class Sampler:
     def sample_independent(
         self,
         ctx: SamplerContext,
-        storage: Storage,
+        storage: StorageProtocol,
         name: str,
         distribution: Distribution,
     ) -> float:

--- a/rustuna_pyo3/rustuna/converter/__init__.py
+++ b/rustuna_pyo3/rustuna/converter/__init__.py
@@ -10,6 +10,9 @@ from ._distribution import (
     to_rustuna_distribution,
     to_rustuna_distributions,
 )
+from ._sampler import (
+    ToOptunaSampler,
+)
 from ._storage import (
     ToOptunaStorage,
     ToRustunaStorage,

--- a/rustuna_pyo3/rustuna/converter/_sampler.py
+++ b/rustuna_pyo3/rustuna/converter/_sampler.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+from optuna.distributions import BaseDistribution
+from optuna.samplers import BaseSampler
+from optuna.search_space import IntersectionSearchSpace
+from optuna.storages import BaseStorage
+from optuna.study import Study
+from optuna.trial import FrozenTrial
+
+
+import rustuna
+from rustuna.converter._storage import ToRustunaStorage
+from rustuna.converter import to_rustuna_directions
+from rustuna.converter import to_rustuna_distributions
+from rustuna.converter import to_rustuna_distributions
+from rustuna.converter import to_rustuna_distribution
+
+if TYPE_CHECKING:
+    from rustuna import SamplerProtocol
+    from rustuna import StorageProtocol
+
+
+class ToOptunaSampler(BaseSampler):
+    def __init__(self, sampler: SamplerProtocol) -> None:
+        self._sampler = sampler
+        self._inter_section_search_space = IntersectionSearchSpace()
+        self._storage: StorageProtocol | None = None
+
+    def _get_storage(self, storage: BaseStorage) -> StorageProtocol:
+        if self._storage is None:
+            self._storage = ToRustunaStorage(storage)
+        return self._storage
+
+    def sample_relative(
+        self,
+        study: Study,
+        trial: FrozenTrial,
+        search_space: dict[str, BaseDistribution],
+    ) -> dict[str, Any]:
+        if search_space == {}:
+            return {}
+
+        ctx = rustuna.SamplerContext(
+            study_id=study._study_id,
+            trial_number=trial.number,
+            trial_id=trial._trial_id,
+            directions=to_rustuna_directions(study._directions),
+        )
+        storage = self._get_storage(study._storage)
+        rustuna_search_space = to_rustuna_distributions(search_space)
+        return self._sampler.sample_joint(ctx, storage, rustuna_search_space)
+
+    def sample_independent(
+        self,
+        study: Study,
+        trial: FrozenTrial,
+        param_name: str,
+        param_distribution: BaseDistribution,
+    ) -> Any:
+        ctx = rustuna.SamplerContext(
+            study_id=study._study_id,
+            trial_number=trial.number,
+            trial_id=trial._trial_id,
+            directions=to_rustuna_directions(study._directions),
+        )
+        storage = self._get_storage(study._storage)
+        distribution = to_rustuna_distribution(param_distribution)
+        return self._sampler.sample_independent(ctx, storage, param_name, distribution)
+
+    def infer_relative_search_space(
+        self,
+        study: Study,
+        trial: FrozenTrial,
+    ) -> dict[str, BaseDistribution]:
+        if not self._sampler.support_joint_sampling:
+            return {}
+
+        # TODO(y0z): Support study.get_joint_search_space insead of using Optuna Python API
+        # search_space = study.get_joint_search_space(study._study_id)
+        search_space: dict[str, BaseDistribution] = {}
+        for name, distribution in self._inter_section_search_space.calculate(
+            study, use_cache=True
+        ).items():
+            if distribution.single():
+                continue
+            search_space[name] = distribution
+
+        return search_space

--- a/rustuna_pyo3/rustuna/converter/_sampler.py
+++ b/rustuna_pyo3/rustuna/converter/_sampler.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from optuna.distributions import BaseDistribution
 from optuna.samplers import BaseSampler
@@ -9,28 +9,27 @@ from optuna.storages import BaseStorage
 from optuna.study import Study
 from optuna.trial import FrozenTrial
 
-
 import rustuna
+from rustuna.converter import (
+    to_rustuna_directions,
+    to_rustuna_distribution,
+    to_rustuna_distributions,
+)
 from rustuna.converter._storage import ToRustunaStorage
-from rustuna.converter import to_rustuna_directions
-from rustuna.converter import to_rustuna_distributions
-from rustuna.converter import to_rustuna_distributions
-from rustuna.converter import to_rustuna_distribution
 
 if TYPE_CHECKING:
-    from rustuna import SamplerProtocol
-    from rustuna import StorageProtocol
+    from rustuna import SamplerProtocol, StorageProtocol
 
 
 class ToOptunaSampler(BaseSampler):
     def __init__(self, sampler: SamplerProtocol) -> None:
         self._sampler = sampler
         self._inter_section_search_space = IntersectionSearchSpace()
-        self._storage: StorageProtocol | None = None
+        self._storage: rustuna.PyObjectStorage | None = None
 
-    def _get_storage(self, storage: BaseStorage) -> StorageProtocol:
+    def _get_storage(self, storage: BaseStorage) -> rustuna.PyObjectStorage:
         if self._storage is None:
-            self._storage = ToRustunaStorage(storage)
+            self._storage = rustuna.PyObjectStorage(ToRustunaStorage(storage))
         return self._storage
 
     def sample_relative(

--- a/rustuna_pyo3/rustuna/converter/_sampler.py
+++ b/rustuna_pyo3/rustuna/converter/_sampler.py
@@ -49,7 +49,15 @@ class ToOptunaSampler(BaseSampler):
         )
         storage = self._get_storage(study._storage)
         rustuna_search_space = to_rustuna_distributions(search_space)
-        return self._sampler.sample_joint(ctx, storage, rustuna_search_space)
+        internal_params = self._sampler.sample_joint(ctx, storage, rustuna_search_space)
+        external_params: dict[str, Any] = {}
+        for param_name in internal_params:
+            distribution = search_space[param_name]
+            external_param_value = distribution.to_external_repr(
+                internal_params[param_name]
+            )
+            external_params[param_name] = external_param_value
+        return external_params
 
     def sample_independent(
         self,
@@ -66,7 +74,10 @@ class ToOptunaSampler(BaseSampler):
         )
         storage = self._get_storage(study._storage)
         distribution = to_rustuna_distribution(param_distribution)
-        return self._sampler.sample_independent(ctx, storage, param_name, distribution)
+        internal_param = self._sampler.sample_independent(
+            ctx, storage, param_name, distribution
+        )
+        return param_distribution.to_external_repr(internal_param)
 
     def infer_relative_search_space(
         self,

--- a/rustuna_pyo3/src/lib.rs
+++ b/rustuna_pyo3/src/lib.rs
@@ -30,6 +30,7 @@ fn rustuna(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<distribution::PyDistribution>()?;
     // storage
     m.add_class::<storage::PyStorage>()?;
+    m.add_class::<pyobject_storage::PyPyObjectStorage>()?;
     // sampler
     m.add_class::<sampler::PySampler>()?;
     m.add_class::<sampler::PySamplerContext>()?;

--- a/rustuna_pyo3/src/pyobject_storage.rs
+++ b/rustuna_pyo3/src/pyobject_storage.rs
@@ -16,6 +16,14 @@ use crate::exception::err_to_exceptions;
 use crate::study::{pyobject_to_persisted_study, PyDirection};
 use crate::trial::{pyobject_to_persisted_trial, PyTrialState};
 
+// PyObjectStorage wraps an Optuna storage object and maintains an in-memory cache.
+//
+// When using Optuna's API (e.g., `study.optimize()` with `ToOptunaSampler`), write operations
+// (such as `set_trial_state_values`) are performed directly on the Optuna storage, bypassing
+// PyObjectStorage's write methods. Therefore, the cache is not updated during these operations.
+//
+// To ensure consistency, all `get_*` methods must synchronize with the backend storage before
+// returning cached data.
 pub struct PyObjectStorage {
     obj: Py<PyAny>,
     is_distributed: bool,
@@ -448,6 +456,7 @@ impl Storage for PyObjectStorage {
     }
 
     fn get_studies(&mut self) -> rustuna_core::Result<&Vec<rustuna_core::study::PersistedStudy>> {
+        self.sync_studies(true)?;
         self.cache.get_studies()
     }
 
@@ -455,6 +464,7 @@ impl Storage for PyObjectStorage {
         &mut self,
         study_id: u32,
     ) -> rustuna_core::Result<&rustuna_core::study::PersistedStudy> {
+        self.sync_study_from_id(study_id, true)?;
         self.cache.get_study(study_id)
     }
 
@@ -462,6 +472,9 @@ impl Storage for PyObjectStorage {
         &mut self,
         study_id: u32,
     ) -> rustuna_core::Result<&Vec<rustuna_core::trial::PersistedTrial>> {
+        // Ensure study mapping exists before sync_trials, which requires cache_study_to_src_study.
+        self.sync_study_from_id(study_id, false)?;
+        self.sync_trials(study_id)?;
         self.cache.get_trials(study_id)
     }
 
@@ -469,6 +482,7 @@ impl Storage for PyObjectStorage {
         &mut self,
         trial_id: u32,
     ) -> rustuna_core::Result<&rustuna_core::trial::PersistedTrial> {
+        self.sync_all_trials()?;
         self.cache.get_trial(trial_id)
     }
 
@@ -578,7 +592,9 @@ impl Storage for PyObjectStorage {
         &mut self,
         study_id: u32,
     ) -> rustuna_core::Result<HashMap<String, Distribution>> {
+        // Ensure study mapping exists before sync_trials, which requires cache_study_to_src_study.
         self.sync_study_from_id(study_id, false)?;
+        self.sync_trials(study_id)?;
         self.cache.get_joint_search_space(study_id)
     }
 }

--- a/rustuna_pyo3/src/pyobject_storage.rs
+++ b/rustuna_pyo3/src/pyobject_storage.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
 
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
@@ -11,6 +12,7 @@ use rustuna_core::study::{Direction, PersistedStudy};
 use rustuna_core::trial::{PersistedTrial, TrialStateValues};
 
 use crate::distribution::PyDistribution;
+use crate::exception::err_to_exceptions;
 use crate::study::{pyobject_to_persisted_study, PyDirection};
 use crate::trial::{pyobject_to_persisted_trial, PyTrialState};
 
@@ -578,5 +580,31 @@ impl Storage for PyObjectStorage {
     ) -> rustuna_core::Result<HashMap<String, Distribution>> {
         self.sync_study_from_id(study_id, false)?;
         self.cache.get_joint_search_space(study_id)
+    }
+}
+
+// TODO(c-bata): Rename PyStorage, PyObjectStorage, and PyPyObjectStorage to more descriptive names.
+// Current naming is confusing: PyStorage wraps Rust-native storages, PyObjectStorage implements
+// Storage trait from Python StorageProtocol, and PyPyObjectStorage exposes PyObjectStorage to Python.
+#[derive(Clone)]
+#[pyclass(name = "PyObjectStorage")]
+#[pyo3(module = "rustuna")]
+pub struct PyPyObjectStorage {
+    pub storage: Arc<RwLock<PyObjectStorage>>,
+}
+
+#[pymethods]
+impl PyPyObjectStorage {
+    #[new]
+    fn new(storage: Py<PyAny>) -> PyResult<Self> {
+        Python::attach(|py| {
+            let storage_ref = storage.bind(py);
+            let is_distributed = storage_ref.getattr("is_distributed")?.extract::<bool>()?;
+            let mut inner = PyObjectStorage::new(storage, is_distributed);
+            inner.sync_studies(true).map_err(err_to_exceptions)?;
+            Ok(PyPyObjectStorage {
+                storage: Arc::new(RwLock::new(inner)),
+            })
+        })
     }
 }

--- a/rustuna_pyo3/src/sampler.rs
+++ b/rustuna_pyo3/src/sampler.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::types::PyDict;
@@ -11,6 +11,7 @@ use rustuna_core::storage::Storage;
 use rustuna_samplers::tpe::{TpeConfig, TpeSampler};
 
 use crate::distribution::PyDistribution;
+use crate::pyobject_storage::PyPyObjectStorage;
 use crate::storage::PyStorage;
 use crate::study::PyDirection;
 
@@ -101,16 +102,17 @@ impl PySampler {
     fn sample_independent(
         &self,
         ctx: &PySamplerContext,
-        storage: &PyStorage,
+        storage: Py<PyAny>,
         name: &str,
         distribution: &PyDistribution,
     ) -> PyResult<f64> {
+        let arc_storage = extract_storage(storage)?;
         self.sampler
             .lock()
             .map_err(|_| PyRuntimeError::new_err("Failed to acquire the sampler guard"))?
             .sample_independent(
                 &ctx.context.clone(),
-                storage.storage.clone(),
+                arc_storage,
                 name,
                 &distribution.distribution,
             )
@@ -120,15 +122,16 @@ impl PySampler {
     fn sample_joint(
         &self,
         ctx: &PySamplerContext,
-        storage: &PyStorage,
+        storage: Py<PyAny>,
         search_space: HashMap<String, PyDistribution>,
     ) -> PyResult<HashMap<String, f64>> {
+        let arc_storage = extract_storage(storage)?;
         self.sampler
             .lock()
             .map_err(|_| PyRuntimeError::new_err("Failed to acquire the sampler guard"))?
             .sample_joint(
                 &ctx.context.clone(),
-                storage.storage.clone(),
+                arc_storage,
                 &search_space
                     .into_iter()
                     .map(|(k, v)| (k, v.distribution))
@@ -136,6 +139,21 @@ impl PySampler {
             )
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to sample joint: {e:?}")))
     }
+}
+
+fn extract_storage(storage: Py<PyAny>) -> PyResult<Arc<RwLock<dyn Storage>>> {
+    Python::attach(|py| {
+        let storage_ref = storage.bind(py);
+        if let Ok(py_storage) = storage_ref.extract::<PyStorage>() {
+            Ok(py_storage.storage.clone())
+        } else if let Ok(py_obj_storage) = storage_ref.extract::<PyPyObjectStorage>() {
+            Ok(py_obj_storage.storage.clone() as Arc<RwLock<dyn Storage>>)
+        } else {
+            Err(PyRuntimeError::new_err(
+                "Invalid storage type. Use rustuna.Storage for Rust-native storages or rustuna.PyObjectStorage for Python StorageProtocol implementations.",
+            ))
+        }
+    })
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Introduce `ToOptunaSampler`, allowing Rustuna samplers to be used with Optuna's `study.optimize()`.

```python
import tempfile
import optuna
import optunahub
import rustuna
from rustuna.converter import ToOptunaSampler

wfg = optunahub.load_module("benchmarks/wfg")

def main() -> None:
    problem = wfg.Problem(function_id=4, n_objectives=2, dimension=9, k=1)
    study = optuna.create_study(
        study_name="multi_objective_study",
        sampler=ToOptunaSampler(rustuna.Sampler.tpe(seed=42)),
        directions=problem.directions,
    )
    study.optimize(problem, n_trials=100)

    print(f"{len(study.best_trials)=}")

if __name__ == "__main__":
    main()
```

```
$ python example.py
...
[I 2026-02-03 17:28:49,781] Trial 93 finished with values: [0.9129976055829767, 3.9477620256035233] and parameters: {'x0': 1.3825404149233012, 'x1': 1.9341029209122134, 'x2': 1.673117851300169, 'x3': 5.672361321255677, 'x4': 5.0070273492725015, 'x5': 3.733228110628848, 'x6': 8.267585760285204, 'x7': 12.85996130357277, 'x8': 8.77877718770182}.
[I 2026-02-03 17:28:49,781] Trial 94 finished with values: [0.7255067558605224, 4.12491560111963] and parameters: {'x0': 0.6676693653010992, 'x1': 0.1379810661001315, 'x2': 1.8759877374373852, 'x3': 3.2266090991282343, 'x4': 3.9556330486984415, 'x5': 2.429225510184428, 'x6': 5.487020100628756, 'x7': 7.9651226288251, 'x8': 1.3846483878178426}.
[I 2026-02-03 17:28:49,782] Trial 95 finished with values: [2.0145585530640946, 2.466108652626043] and parameters: {'x0': 1.754172310064258, 'x1': 3.2597360405959686, 'x2': 3.7091395575297677, 'x3': 4.364928656983681, 'x4': 1.5340652726303694, 'x5': 0.27852777095018677, 'x6': 6.930654158204877, 'x7': 8.494933644677477, 'x8': 4.175682510589294}.
[I 2026-02-03 17:28:49,782] Trial 96 finished with values: [1.8874642118588891, 3.306807768880004] and parameters: {'x0': 0.22523691323680683, 'x1': 2.851982700619078, 'x2': 4.800831347816104, 'x3': 1.1149317539006187, 'x4': 1.7358402978529797, 'x5': 2.5206279742124407, 'x6': 0.4392625562434498, 'x7': 14.98459324411034, 'x8': 14.835210812614083}.
[I 2026-02-03 17:28:49,782] Trial 97 finished with values: [2.3578491776049404, 1.8312864880736124] and parameters: {'x0': 1.8258642094812028, 'x1': 2.148583114919302, 'x2': 5.373140468901965, 'x3': 6.560427440800959, 'x4': 9.085945670072473, 'x5': 10.081541357296391, 'x6': 5.894953712814633, 'x7': 13.251023133156494, 'x8': 1.108205760080974}.
[I 2026-02-03 17:28:49,782] Trial 98 finished with values: [2.258451726272891, 2.165869239213225] and parameters: {'x0': 1.7814500885950881, 'x1': 2.9311593516575245, 'x2': 5.8511240881465, 'x3': 7.362481552438284, 'x4': 5.974805447785423, 'x5': 3.6810942702309184, 'x6': 1.895008130960791, 'x7': 11.008872368674279, 'x8': 15.75732163373547}.
[I 2026-02-03 17:28:49,783] Trial 99 finished with values: [0.8710261081806305, 4.266308323046802] and parameters: {'x0': 0.9413125887749443, 'x1': 0.5445666603792647, 'x2': 0.1812140925266803, 'x3': 7.1035344046020565, 'x4': 8.038606939250265, 'x5': 8.648375745756937, 'x6': 9.713082521930339, 'x7': 4.6908082597380165, 'x8': 7.8879046159591795}.
len(study.best_trials)=27
```