### PR TITLE
Add `PedAnovaImportanceEvaluator`

### DIFF
--- a/rustuna_core/src/distribution.rs
+++ b/rustuna_core/src/distribution.rs
@@ -57,6 +57,22 @@ impl Distribution {
             _ => Err(Error::new(ErrorKind::IncompatibleDistribution)),
         }
     }
+
+    pub fn is_single(&self) -> bool {
+        match self {
+            Distribution::Float { low, high, step, ..} => {
+                if let Some(step) = step {
+                    low == high || high - low - step < 1e-12_f64
+                } else {
+                    low == high
+                }
+            },
+            Distribution::Int { low, high, step, log } => {
+                if *log { low == high } else { low == high || high - low < *step }
+            },
+            Distribution::Categorical { cardinality } => *cardinality == 1,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/rustuna_core/src/distribution.rs
+++ b/rustuna_core/src/distribution.rs
@@ -60,16 +60,27 @@ impl Distribution {
 
     pub fn is_single(&self) -> bool {
         match self {
-            Distribution::Float { low, high, step, ..} => {
+            Distribution::Float {
+                low, high, step, ..
+            } => {
                 if let Some(step) = step {
                     low == high || high - low - step < 1e-12
                 } else {
                     low == high
                 }
-            },
-            Distribution::Int { low, high, step, log } => {
-                if *log { low == high } else { low == high || high - low < *step }
-            },
+            }
+            Distribution::Int {
+                low,
+                high,
+                step,
+                log,
+            } => {
+                if *log {
+                    low == high
+                } else {
+                    low == high || high - low < *step
+                }
+            }
             Distribution::Categorical { cardinality } => *cardinality == 1,
         }
     }

--- a/rustuna_core/src/distribution.rs
+++ b/rustuna_core/src/distribution.rs
@@ -62,7 +62,7 @@ impl Distribution {
         match self {
             Distribution::Float { low, high, step, ..} => {
                 if let Some(step) = step {
-                    low == high || high - low - step < 1e-12_f64
+                    low == high || high - low - step < 1e-12
                 } else {
                     low == high
                 }

--- a/rustuna_core/src/error.rs
+++ b/rustuna_core/src/error.rs
@@ -60,4 +60,5 @@ pub enum ErrorKind {
     NoCompletedTrial,
     IncompatibleDistribution,
     Unexpected,
+    ImportanceEvaluatorError,
 }

--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -30,7 +30,7 @@ impl ParzenEstimator {
         )
     }
 
-    pub fn new_with_scott(
+    pub fn with_scott(
         observations: &HashMap<String, Vec<f64>>,
         search_space: &HashMap<String, Distribution>,
         weights: &[f64],

--- a/rustuna_importance/examples/ped_anova.rs
+++ b/rustuna_importance/examples/ped_anova.rs
@@ -1,0 +1,31 @@
+use std::sync::{Arc, Mutex};
+
+use rustuna_core::sampler::RandomSampler;
+use rustuna_core::storage::InMemoryStorage;
+use rustuna_core::study::{create_study, Direction};
+use rustuna_core::Result;
+use rustuna_importance::{self, PedAnovaImportanceEvaluator};
+
+fn main() -> Result<()> {
+    let storage = InMemoryStorage::new();
+    let directions = vec![Direction::Minimize];
+    let mut study = create_study("simple-quadratic", storage, directions)?;
+
+    let sampler = Arc::new(Mutex::new(RandomSampler::new()));
+    study.optimize(
+        |mut t| {
+            let x = t.suggest_float("x", 0.0, 10.0)?;
+            let y = t.suggest_float("y", 0.0, 10.0)?;
+            let value = x + y * 3.0;
+            println!("{:2} x: {}, y: {}, value: {}", t.number, x, y, value);
+            Ok(vec![value])
+        },
+        sampler,
+        50,
+    )?;
+    let evaluator = PedAnovaImportanceEvaluator::new(0.1, 1.0, true);
+    let importances = rustuna_importance::get_param_importances(&study, &evaluator)?;
+    println!("Parameter importances: {importances:?}");
+
+    Ok(())
+}

--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -4,10 +4,37 @@ use rustuna_core::trial::{PersistedTrial, TrialStateValues};
 use rustuna_core::{Error, ErrorKind, Result};
 use rustuna_core::distribution::Distribution;
 
-pub trait ImportanceEvaluator {
+pub struct ImportanceOptions<'a> {
     // NOTE(kAIto47802): Currently, the `param` argument is not implemented.
     // We plan to implement it when we support condPED-ANOVA:
     // - https://arxiv.org/abs/2601.20800
+    pub target: Option<&'a dyn Fn(&PersistedTrial) -> f64>,
+    pub normalize: bool,
+}
+
+impl<'a> Default for ImportanceOptions<'a> {
+    fn default() -> Self {
+        Self { target: None, normalize: true }
+    }
+}
+
+
+impl<'a> ImportanceOptions<'a> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_target(mut self, target: &'a dyn Fn(&PersistedTrial) -> f64) -> Self {
+        self.target = Some(target);
+        self
+    }
+
+    pub fn normalize(mut self, normalize: bool) -> Self {
+        self.normalize = normalize;
+        self
+    }
+}
+
     fn evaluate(&self, study: &Study) -> Result<HashMap<String, f64>> {
         self.evaluate_with_target(study, &|t| {
             match &t.state_values {

--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -1,8 +1,8 @@
+use rustuna_core::distribution::Distribution;
 use rustuna_core::study::Study;
-use std::collections::HashMap;
 use rustuna_core::trial::{PersistedTrial, TrialStateValues};
 use rustuna_core::{Error, ErrorKind, Result};
-use rustuna_core::distribution::Distribution;
+use std::collections::HashMap;
 
 pub struct ImportanceOptions<'a> {
     // NOTE(kAIto47802): Currently, the `param` argument is not implemented.
@@ -14,10 +14,12 @@ pub struct ImportanceOptions<'a> {
 
 impl<'a> Default for ImportanceOptions<'a> {
     fn default() -> Self {
-        Self { target: None, normalize: true }
+        Self {
+            target: None,
+            normalize: true,
+        }
     }
 }
-
 
 impl<'a> ImportanceOptions<'a> {
     pub fn new() -> Self {
@@ -35,43 +37,65 @@ impl<'a> ImportanceOptions<'a> {
     }
 }
 
-pub fn get_param_importances(study: &Study, evaluator: &impl ImportanceEvaluator) -> Result<HashMap<String, f64>> {
+pub fn get_param_importances(
+    study: &Study,
+    evaluator: &impl ImportanceEvaluator,
+) -> Result<HashMap<String, f64>> {
     get_param_importances_with(study, evaluator, ImportanceOptions::default())
 }
 
-pub fn get_param_importances_with(study: &Study, evaluator: &impl ImportanceEvaluator, opts: ImportanceOptions<'_>) -> Result<HashMap<String, f64>> {
+pub fn get_param_importances_with(
+    study: &Study,
+    evaluator: &impl ImportanceEvaluator,
+    opts: ImportanceOptions<'_>,
+) -> Result<HashMap<String, f64>> {
     let normalize = opts.normalize;
     let importances = evaluator.evaluate_with(study, opts)?;
-    if normalize { Ok(normalize_importances(importances)) } else { Ok(importances) }
+    if normalize {
+        Ok(normalize_importances(importances))
+    } else {
+        Ok(importances)
+    }
 }
 
 pub trait ImportanceEvaluator {
     fn evaluate(&self, study: &Study) -> Result<HashMap<String, f64>> {
         self.evaluate_with(study, ImportanceOptions::default())
     }
-    fn evaluate_with(&self, study: &Study, opts: ImportanceOptions<'_>) -> Result<HashMap<String, f64>>;
+    fn evaluate_with(
+        &self,
+        study: &Study,
+        opts: ImportanceOptions<'_>,
+    ) -> Result<HashMap<String, f64>>;
 }
 
 fn normalize_importances(importances: HashMap<String, f64>) -> HashMap<String, f64> {
     let total = importances.values().sum::<f64>();
     if total == 0.0 {
         let n_params = importances.len() as f64;
-        importances.into_keys().map(|k| (k, 1.0 / n_params)).collect()
+        importances
+            .into_keys()
+            .map(|k| (k, 1.0 / n_params))
+            .collect()
     } else {
-        importances.into_iter().map(|(k, v)| (k, v / total)).collect()
+        importances
+            .into_iter()
+            .map(|(k, v)| (k, v / total))
+            .collect()
     }
 }
 
 fn default_target(t: &PersistedTrial) -> f64 {
     match &t.state_values {
-        TrialStateValues::Complete(values) => {
-            values[0]
-        }
+        TrialStateValues::Complete(values) => values[0],
         _ => unreachable!("Only completed trials should be evaluated."),
     }
 }
 
-pub(crate) fn ensure_target_for_multi_objective(trials: &[PersistedTrial], target: Option<&dyn Fn(&PersistedTrial) -> f64>) -> Result<()> {
+pub(crate) fn ensure_target_for_multi_objective(
+    trials: &[PersistedTrial],
+    target: Option<&dyn Fn(&PersistedTrial) -> f64>,
+) -> Result<()> {
     let Some(first) = trials.first() else {
         return Ok(());
     };
@@ -90,14 +114,16 @@ pub(crate) fn ensure_target_for_multi_objective(trials: &[PersistedTrial], targe
     }
 }
 
-pub(crate) fn resolve_target(target: Option<&dyn Fn(&PersistedTrial) -> f64>)
-    -> &dyn Fn(&PersistedTrial) -> f64
-{
+pub(crate) fn resolve_target(
+    target: Option<&dyn Fn(&PersistedTrial) -> f64>,
+) -> &dyn Fn(&PersistedTrial) -> f64 {
     target.unwrap_or(&default_target)
 }
 
-
-pub(crate) fn get_filtered_trials(study: &Study, target: &dyn Fn(&PersistedTrial) -> f64) -> Result<Vec<PersistedTrial>> {
+pub(crate) fn get_filtered_trials(
+    study: &Study,
+    target: &dyn Fn(&PersistedTrial) -> f64,
+) -> Result<Vec<PersistedTrial>> {
     let mut guard = study
         .storage
         .write()
@@ -117,12 +143,13 @@ pub(crate) fn get_filtered_trials(study: &Study, target: &dyn Fn(&PersistedTrial
     }
 }
 
-pub(crate) fn get_intersection_search_space(trials: &[PersistedTrial]) -> HashMap<String, Distribution> {
+pub(crate) fn get_intersection_search_space(
+    trials: &[PersistedTrial],
+) -> HashMap<String, Distribution> {
     let mut intersection_search_space = trials[0].distributions.clone();
     for trial in &trials[1..] {
-        intersection_search_space.retain(|k, v| {
-            trial.distributions.get(k).is_some_and(|v2| v2 == v)
-        });
+        intersection_search_space
+            .retain(|k, v| trial.distributions.get(k).is_some_and(|v2| v2 == v));
     }
     intersection_search_space
 }

--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -5,8 +5,21 @@ use rustuna_core::{Error, ErrorKind, Result};
 use rustuna_core::distribution::Distribution;
 
 pub trait ImportanceEvaluator {
-    fn evaluate(&self, study: &Study) -> HashMap<String, f64>;
-    fn evaluate_with_target(&self, study: &Study, target: &dyn Fn(&PersistedTrial) -> f64) -> HashMap<String, f64>;
+    // NOTE(kAIto47802): Currently, the `param` argument is not implemented.
+    // We plan to implement it when we support condPED-ANOVA:
+    // - https://arxiv.org/abs/2601.20800
+    fn evaluate(&self, study: &Study) -> Result<HashMap<String, f64>> {
+        self.evaluate_with_target(study, &|t| {
+            match &t.state_values {
+                TrialStateValues::Complete(values) => {
+                    assert_eq!(values.len(), 1, "Specify the `target` function for multi-objective studies.");
+                    values[0]
+                },
+                _ => unreachable!("Only completed trials should be evaluated."),
+            }
+        })
+    }
+    fn evaluate_with_target(&self, study: &Study, target: &dyn Fn(&PersistedTrial) -> f64) -> Result<HashMap<String, f64>>;
 }
 
 fn get_filtered_trials(study: &Study, target: &dyn Fn(&PersistedTrial) -> f64) -> Result<Vec<PersistedTrial>> {

--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -200,12 +200,12 @@ mod tests {
                     &evaluator,
                     ImportanceOptions::new().normalize(normalize),
                 )?;
-                assert_eq!(!importances.len(), 6);
+                assert_eq!(importances.len(), 6, "{importances:?}");
                 if normalize {
                     assert!(importances
                         .values()
-                        .all(|v| (-1e-12..=1.0 + 1e-12).contains(v)));
-                    assert!((importances.values().sum::<f64>() - 1.0).abs() < 1e-12);
+                        .all(|v| (-1e-12..=1.0 + 1e-12).contains(v)), "{importances:?}");
+                    assert!((importances.values().sum::<f64>() - 1.0).abs() < 1e-12, "{importances:?}");
                 }
             }
         }
@@ -227,12 +227,12 @@ mod tests {
                         .with_target(&target)
                         .normalize(normalize),
                 )?;
-                assert_eq!(!importances.len(), 6);
+                assert_eq!(importances.len(), 6, "{importances:?}");
                 if normalize {
                     assert!(importances
                         .values()
-                        .all(|v| (-1e-12..=1.0 + 1e-12).contains(v)));
-                    assert!((importances.values().sum::<f64>() - 1.0).abs() < 1e-12);
+                        .all(|v| (-1e-12..=1.0 + 1e-12).contains(v)), "{importances:?}");
+                    assert!((importances.values().sum::<f64>() - 1.0).abs() < 1e-12, "{importances:?}");
                 }
 
                 let importances_wo_target = get_param_importances_with(
@@ -240,7 +240,7 @@ mod tests {
                     &evaluator,
                     ImportanceOptions::new().normalize(normalize),
                 )?;
-                assert_ne!(importances, importances_wo_target);
+                assert_ne!(importances, importances_wo_target, "{importances:?}, {importances_wo_target:?}");
             }
         }
         Ok(())
@@ -253,24 +253,15 @@ mod tests {
         let target =
             |t: &PersistedTrial| -> f64 { t.internal_params["x1"] + t.internal_params["x2"] };
         for evaluator in evaluators {
-            for normalize in [true, false] {
                 let importances = evaluator.evaluate_with(
                     &study,
                     ImportanceOptions::new()
                         .with_target(&target)
-                        .normalize(normalize),
                 )?;
-                assert_eq!(!importances.len(), 6);
-                if normalize {
-                    assert!(importances
-                        .values()
-                        .all(|v| (-1e-12..=1.0 + 1e-12).contains(v)));
-                    assert!((importances.values().sum::<f64>() - 1.0).abs() < 1e-12);
-                }
+                assert_eq!(importances.len(), 6, "{importances:?}");
                 let importances_wo_target = evaluator
-                    .evaluate_with(&study, ImportanceOptions::new().normalize(normalize))?;
-                assert_ne!(importances, importances_wo_target);
-            }
+                    .evaluate_with(&study, ImportanceOptions::new())?;
+                assert_ne!(importances, importances_wo_target, "{importances:?}, {importances_wo_target:?}");
         }
         Ok(())
     }
@@ -291,7 +282,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_param_importances_empty_search_space() -> Result<()> {
+    fn test_get_param_importances_single_search_space() -> Result<()> {
         let mut study = study::create_study(
             "empty-search-space",
             InMemoryStorage::new(),
@@ -300,7 +291,12 @@ mod tests {
         study.optimize(
             |mut t| {
                 let x1 = t.suggest_float("x1", 0.0, 5.0)?;
-                let x2 = t.suggest_float("x2", 1.0, 1.0)?;
+                let x2 = t.suggest("x2", &Distribution::Float {
+                    low: 0.0,
+                    high: 1.0,
+                    step: Some(1.0),
+                    log: false,
+                })?;
                 Ok(vec![x1 + x2])
             },
             Arc::new(Mutex::new(RandomSampler::new())),
@@ -314,9 +310,9 @@ mod tests {
                 .map(String::as_str)
                 .collect::<HashSet<_>>();
             let expected = HashSet::from(["x1", "x2"]);
-            assert_eq!(keys, expected);
-            assert!(importances["x1"] > 0.0);
-            assert!(importances["x2"] == 0.0);
+            assert_eq!(keys, expected, "{importances:?}");
+            assert!(importances["x1"] > 0.0, "{importances:?}");
+            assert!(importances["x2"] == 0.0, "{importances:?}");
         }
         Ok(())
     }

--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -65,8 +65,26 @@ fn normalize_importances(importances: HashMap<String, f64>) -> HashMap<String, f
 fn default_target(t: &PersistedTrial) -> f64 {
     match &t.state_values {
         TrialStateValues::Complete(values) => {
-            assert_eq!(values.len(), 1, "Specify the `target` function for multi-objective studies.");
             values[0]
+        }
+        _ => unreachable!("Only completed trials should be evaluated."),
+    }
+}
+
+pub(crate) fn ensure_target_for_multi_objective(trials: &[PersistedTrial], target: Option<&dyn Fn(&PersistedTrial) -> f64>) -> Result<()> {
+    let Some(first) = trials.first() else {
+        return Ok(());
+    };
+    match &first.state_values {
+        TrialStateValues::Complete(values) => {
+            if target.is_some() || values.len() == 1 {
+                Ok(())
+            } else {
+                Err(Error::with_reason(
+                    ErrorKind::ImportanceEvaluatorError,
+                    "Specify the `target` function for multi-objective studies.",
+                ))
+            }
         }
         _ => unreachable!("Only completed trials should be evaluated."),
     }

--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -1,0 +1,40 @@
+use rustuna_core::study::Study;
+use std::collections::HashMap;
+use rustuna_core::trial::{PersistedTrial, TrialStateValues};
+use rustuna_core::{Error, ErrorKind, Result};
+use rustuna_core::distribution::Distribution;
+
+pub trait ImportanceEvaluator {
+    fn evaluate(&self, study: &Study) -> HashMap<String, f64>;
+    fn evaluate_with_target(&self, study: &Study, target: &dyn Fn(&PersistedTrial) -> f64) -> HashMap<String, f64>;
+}
+
+fn get_filtered_trials(study: &Study, target: &dyn Fn(&PersistedTrial) -> f64) -> Result<Vec<PersistedTrial>> {
+    let mut guard = study
+        .storage
+        .write()
+        .map_err(|_e| Error::new(ErrorKind::Unexpected))?;
+    // TODO(c-bata): Avoid to clone trials.
+    let completed_trials = guard
+        .get_trials(study.id)?
+        .clone()
+        .into_iter()
+        .filter(|t| matches!(t.state_values, TrialStateValues::Complete(_)))
+        .filter(|t| target(t).is_finite())
+        .collect::<Vec<_>>();
+    if completed_trials.is_empty() {
+        Err(Error::new(ErrorKind::NoCompletedTrial))
+    } else {
+        Ok(completed_trials)
+    }
+}
+
+fn get_intersection_search_space(trials: &[PersistedTrial]) -> HashMap<String, Distribution> {
+    let mut intersection_search_space = trials[0].distributions.clone();
+    for trial in &trials[1..] {
+        intersection_search_space.retain(|k, v| {
+            trial.distributions.get(k).is_some_and(|v2| v2 == v)
+        });
+    }
+    intersection_search_space
+}

--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -35,6 +35,15 @@ impl<'a> ImportanceOptions<'a> {
     }
 }
 
+pub fn get_param_importances(study: &Study, evaluator: &impl ImportanceEvaluator) -> Result<HashMap<String, f64>> {
+    get_param_importances_with(study, evaluator, ImportanceOptions::default())
+}
+
+pub fn get_param_importances_with(study: &Study, evaluator: &impl ImportanceEvaluator, opts: ImportanceOptions<'_>) -> Result<HashMap<String, f64>> {
+    let normalize = opts.normalize;
+    let importances = evaluator.evaluate_with(study, opts)?;
+    if normalize { Ok(normalize_importances(importances)) } else { Ok(importances) }
+}
     fn evaluate(&self, study: &Study) -> Result<HashMap<String, f64>> {
         self.evaluate_with_target(study, &|t| {
             match &t.state_values {

--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -154,26 +154,22 @@ pub(crate) fn get_intersection_search_space(
     intersection_search_space
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Arc, Mutex};
-    use std::collections::HashSet;
-    use rustuna_core::sampler::RandomSampler;
-    use rustuna_core::{ErrorKind, Result};
-    use crate::test_utils;
     use crate::ped_anova::PedAnovaImportanceEvaluator;
+    use crate::test_utils;
+    use rustuna_core::sampler::RandomSampler;
+    use rustuna_core::storage::InMemoryStorage;
     use rustuna_core::study::{self, Direction};
     use rustuna_core::trial::PersistedTrial;
-    use rustuna_core::storage::InMemoryStorage;
-
+    use rustuna_core::{ErrorKind, Result};
+    use std::collections::HashSet;
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn test_error_multi_objective_wo_target() -> Result<()> {
-        let evaluators = vec![
-            PedAnovaImportanceEvaluator::default(),
-        ];
+        let evaluators = vec![PedAnovaImportanceEvaluator::default()];
         let study = test_utils::get_study(42, 5, true, Direction::Minimize)?;
         for evaluator in evaluators {
             let err = get_param_importances(&study, &evaluator).unwrap_err();
@@ -184,9 +180,7 @@ mod tests {
 
     #[test]
     fn test_evaluator_error_multi_objective_wo_target() -> Result<()> {
-        let evaluators = vec![
-            PedAnovaImportanceEvaluator::default(),
-        ];
+        let evaluators = vec![PedAnovaImportanceEvaluator::default()];
         let study = test_utils::get_study(42, 5, true, Direction::Minimize)?;
         for evaluator in evaluators {
             let err = evaluator.evaluate(&study).unwrap_err();
@@ -197,9 +191,7 @@ mod tests {
 
     #[test]
     fn test_get_param_importances() -> Result<()> {
-        let evaluators = vec![
-            PedAnovaImportanceEvaluator::default(),
-        ];
+        let evaluators = vec![PedAnovaImportanceEvaluator::default()];
         let study = test_utils::get_study(42, 20, false, Direction::Minimize)?;
         for evaluator in evaluators {
             for normalize in [true, false] {
@@ -210,7 +202,9 @@ mod tests {
                 )?;
                 assert_eq!(!importances.len(), 6);
                 if normalize {
-                    assert!(importances.values().all(|v| (-1e-12..=1.0 + 1e-12).contains(v)));
+                    assert!(importances
+                        .values()
+                        .all(|v| (-1e-12..=1.0 + 1e-12).contains(v)));
                     assert!((importances.values().sum::<f64>() - 1.0).abs() < 1e-12);
                 }
             }
@@ -220,13 +214,10 @@ mod tests {
 
     #[test]
     fn test_get_param_importances_with_target() -> Result<()> {
-        let evaluators = vec![
-            PedAnovaImportanceEvaluator::default(),
-        ];
+        let evaluators = vec![PedAnovaImportanceEvaluator::default()];
         let study = test_utils::get_study(42, 20, false, Direction::Minimize)?;
-        let target = |t: &PersistedTrial| -> f64 {
-            t.internal_params["x1"] + t.internal_params["x2"]
-        };
+        let target =
+            |t: &PersistedTrial| -> f64 { t.internal_params["x1"] + t.internal_params["x2"] };
         for evaluator in evaluators {
             for normalize in [true, false] {
                 let importances = get_param_importances_with(
@@ -238,7 +229,9 @@ mod tests {
                 )?;
                 assert_eq!(!importances.len(), 6);
                 if normalize {
-                    assert!(importances.values().all(|v| (-1e-12..=1.0 + 1e-12).contains(v)));
+                    assert!(importances
+                        .values()
+                        .all(|v| (-1e-12..=1.0 + 1e-12).contains(v)));
                     assert!((importances.values().sum::<f64>() - 1.0).abs() < 1e-12);
                 }
 
@@ -255,13 +248,10 @@ mod tests {
 
     #[test]
     fn test_evaluator_evaluate_with_target() -> Result<()> {
-        let evaluators = vec![
-            PedAnovaImportanceEvaluator::default(),
-        ];
+        let evaluators = vec![PedAnovaImportanceEvaluator::default()];
         let study = test_utils::get_study(42, 20, false, Direction::Minimize)?;
-        let target = |t: &PersistedTrial| -> f64 {
-            t.internal_params["x1"] + t.internal_params["x2"]
-        };
+        let target =
+            |t: &PersistedTrial| -> f64 { t.internal_params["x1"] + t.internal_params["x2"] };
         for evaluator in evaluators {
             for normalize in [true, false] {
                 let importances = evaluator.evaluate_with(
@@ -272,13 +262,13 @@ mod tests {
                 )?;
                 assert_eq!(!importances.len(), 6);
                 if normalize {
-                    assert!(importances.values().all(|v| (-1e-12..=1.0 + 1e-12).contains(v)));
+                    assert!(importances
+                        .values()
+                        .all(|v| (-1e-12..=1.0 + 1e-12).contains(v)));
                     assert!((importances.values().sum::<f64>() - 1.0).abs() < 1e-12);
                 }
-                let importances_wo_target = evaluator.evaluate_with(
-                    &study,
-                    ImportanceOptions::new().normalize(normalize),
-                )?;
+                let importances_wo_target = evaluator
+                    .evaluate_with(&study, ImportanceOptions::new().normalize(normalize))?;
                 assert_ne!(importances, importances_wo_target);
             }
         }
@@ -287,9 +277,7 @@ mod tests {
 
     #[test]
     fn test_get_param_importances_empty_study() -> Result<()> {
-        let evaluators = vec![
-            PedAnovaImportanceEvaluator::default(),
-        ];
+        let evaluators = vec![PedAnovaImportanceEvaluator::default()];
         let study = study::create_study(
             "empty-study",
             InMemoryStorage::new(),
@@ -318,12 +306,13 @@ mod tests {
             Arc::new(Mutex::new(RandomSampler::new())),
             5,
         )?;
-        let evaluators = vec![
-            PedAnovaImportanceEvaluator::default(),
-        ];
+        let evaluators = vec![PedAnovaImportanceEvaluator::default()];
         for evaluator in evaluators {
             let importances = get_param_importances(&study, &evaluator)?;
-            let keys = importances.keys().map(String::as_str).collect::<HashSet<_>>();
+            let keys = importances
+                .keys()
+                .map(String::as_str)
+                .collect::<HashSet<_>>();
             let expected = HashSet::from(["x1", "x2"]);
             assert_eq!(keys, expected);
             assert!(importances["x1"] > 0.0);

--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -44,7 +44,13 @@ pub fn get_param_importances_with(study: &Study, evaluator: &impl ImportanceEval
     let importances = evaluator.evaluate_with(study, opts)?;
     if normalize { Ok(normalize_importances(importances)) } else { Ok(importances) }
 }
+
+pub trait ImportanceEvaluator {
     fn evaluate(&self, study: &Study) -> Result<HashMap<String, f64>> {
+        self.evaluate_with(study, ImportanceOptions::default())
+    }
+    fn evaluate_with(&self, study: &Study, opts: ImportanceOptions<'_>) -> Result<HashMap<String, f64>>;
+}
 
 fn normalize_importances(importances: HashMap<String, f64>) -> HashMap<String, f64> {
     let total = importances.values().sum::<f64>();

--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -45,18 +45,33 @@ pub fn get_param_importances_with(study: &Study, evaluator: &impl ImportanceEval
     if normalize { Ok(normalize_importances(importances)) } else { Ok(importances) }
 }
     fn evaluate(&self, study: &Study) -> Result<HashMap<String, f64>> {
-        self.evaluate_with_target(study, &|t| {
-            match &t.state_values {
-                TrialStateValues::Complete(values) => {
-                    assert_eq!(values.len(), 1, "Specify the `target` function for multi-objective studies.");
-                    values[0]
-                },
-                _ => unreachable!("Only completed trials should be evaluated."),
-            }
-        })
+
+fn normalize_importances(importances: HashMap<String, f64>) -> HashMap<String, f64> {
+    let total = importances.values().sum::<f64>();
+    if total == 0.0 {
+        let n_params = importances.len() as f64;
+        importances.into_keys().map(|k| (k, 1.0 / n_params)).collect()
+    } else {
+        importances.into_iter().map(|(k, v)| (k, v / total)).collect()
     }
-    fn evaluate_with_target(&self, study: &Study, target: &dyn Fn(&PersistedTrial) -> f64) -> Result<HashMap<String, f64>>;
 }
+
+fn default_target(t: &PersistedTrial) -> f64 {
+    match &t.state_values {
+        TrialStateValues::Complete(values) => {
+            assert_eq!(values.len(), 1, "Specify the `target` function for multi-objective studies.");
+            values[0]
+        }
+        _ => unreachable!("Only completed trials should be evaluated."),
+    }
+}
+
+pub(crate) fn resolve_target(target: Option<&dyn Fn(&PersistedTrial) -> f64>)
+    -> &dyn Fn(&PersistedTrial) -> f64
+{
+    target.unwrap_or(&default_target)
+}
+
 
 pub(crate) fn get_filtered_trials(study: &Study, target: &dyn Fn(&PersistedTrial) -> f64) -> Result<Vec<PersistedTrial>> {
     let mut guard = study

--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -22,7 +22,7 @@ pub trait ImportanceEvaluator {
     fn evaluate_with_target(&self, study: &Study, target: &dyn Fn(&PersistedTrial) -> f64) -> Result<HashMap<String, f64>>;
 }
 
-fn get_filtered_trials(study: &Study, target: &dyn Fn(&PersistedTrial) -> f64) -> Result<Vec<PersistedTrial>> {
+pub(crate) fn get_filtered_trials(study: &Study, target: &dyn Fn(&PersistedTrial) -> f64) -> Result<Vec<PersistedTrial>> {
     let mut guard = study
         .storage
         .write()
@@ -30,10 +30,10 @@ fn get_filtered_trials(study: &Study, target: &dyn Fn(&PersistedTrial) -> f64) -
     // TODO(c-bata): Avoid to clone trials.
     let completed_trials = guard
         .get_trials(study.id)?
-        .clone()
-        .into_iter()
+        .iter()
         .filter(|t| matches!(t.state_values, TrialStateValues::Complete(_)))
         .filter(|t| target(t).is_finite())
+        .cloned()
         .collect::<Vec<_>>();
     if completed_trials.is_empty() {
         Err(Error::new(ErrorKind::NoCompletedTrial))
@@ -42,7 +42,7 @@ fn get_filtered_trials(study: &Study, target: &dyn Fn(&PersistedTrial) -> f64) -
     }
 }
 
-fn get_intersection_search_space(trials: &[PersistedTrial]) -> HashMap<String, Distribution> {
+pub(crate) fn get_intersection_search_space(trials: &[PersistedTrial]) -> HashMap<String, Distribution> {
     let mut intersection_search_space = trials[0].distributions.clone();
     for trial in &trials[1..] {
         intersection_search_space.retain(|k, v| {

--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -202,10 +202,16 @@ mod tests {
                 )?;
                 assert_eq!(importances.len(), 6, "{importances:?}");
                 if normalize {
-                    assert!(importances
-                        .values()
-                        .all(|v| (-1e-12..=1.0 + 1e-12).contains(v)), "{importances:?}");
-                    assert!((importances.values().sum::<f64>() - 1.0).abs() < 1e-12, "{importances:?}");
+                    assert!(
+                        importances
+                            .values()
+                            .all(|v| (-1e-12..=1.0 + 1e-12).contains(v)),
+                        "{importances:?}"
+                    );
+                    assert!(
+                        (importances.values().sum::<f64>() - 1.0).abs() < 1e-12,
+                        "{importances:?}"
+                    );
                 }
             }
         }
@@ -229,10 +235,16 @@ mod tests {
                 )?;
                 assert_eq!(importances.len(), 6, "{importances:?}");
                 if normalize {
-                    assert!(importances
-                        .values()
-                        .all(|v| (-1e-12..=1.0 + 1e-12).contains(v)), "{importances:?}");
-                    assert!((importances.values().sum::<f64>() - 1.0).abs() < 1e-12, "{importances:?}");
+                    assert!(
+                        importances
+                            .values()
+                            .all(|v| (-1e-12..=1.0 + 1e-12).contains(v)),
+                        "{importances:?}"
+                    );
+                    assert!(
+                        (importances.values().sum::<f64>() - 1.0).abs() < 1e-12,
+                        "{importances:?}"
+                    );
                 }
 
                 let importances_wo_target = get_param_importances_with(
@@ -240,7 +252,10 @@ mod tests {
                     &evaluator,
                     ImportanceOptions::new().normalize(normalize),
                 )?;
-                assert_ne!(importances, importances_wo_target, "{importances:?}, {importances_wo_target:?}");
+                assert_ne!(
+                    importances, importances_wo_target,
+                    "{importances:?}, {importances_wo_target:?}"
+                );
             }
         }
         Ok(())
@@ -253,15 +268,15 @@ mod tests {
         let target =
             |t: &PersistedTrial| -> f64 { t.internal_params["x1"] + t.internal_params["x2"] };
         for evaluator in evaluators {
-                let importances = evaluator.evaluate_with(
-                    &study,
-                    ImportanceOptions::new()
-                        .with_target(&target)
-                )?;
-                assert_eq!(importances.len(), 6, "{importances:?}");
-                let importances_wo_target = evaluator
-                    .evaluate_with(&study, ImportanceOptions::new())?;
-                assert_ne!(importances, importances_wo_target, "{importances:?}, {importances_wo_target:?}");
+            let importances =
+                evaluator.evaluate_with(&study, ImportanceOptions::new().with_target(&target))?;
+            assert_eq!(importances.len(), 6, "{importances:?}");
+            let importances_wo_target =
+                evaluator.evaluate_with(&study, ImportanceOptions::new())?;
+            assert_ne!(
+                importances, importances_wo_target,
+                "{importances:?}, {importances_wo_target:?}"
+            );
         }
         Ok(())
     }
@@ -291,12 +306,15 @@ mod tests {
         study.optimize(
             |mut t| {
                 let x1 = t.suggest_float("x1", 0.0, 5.0)?;
-                let x2 = t.suggest("x2", &Distribution::Float {
-                    low: 0.0,
-                    high: 1.0,
-                    step: Some(1.0),
-                    log: false,
-                })?;
+                let x2 = t.suggest(
+                    "x2",
+                    &Distribution::Float {
+                        low: 0.0,
+                        high: 1.0,
+                        step: Some(1.0),
+                        log: false,
+                    },
+                )?;
                 Ok(vec![x1 + x2])
             },
             Arc::new(Mutex::new(RandomSampler::new())),

--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -153,3 +153,182 @@ pub(crate) fn get_intersection_search_space(
     }
     intersection_search_space
 }
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use std::collections::HashSet;
+    use rustuna_core::sampler::RandomSampler;
+    use rustuna_core::{ErrorKind, Result};
+    use crate::test_utils;
+    use crate::ped_anova::PedAnovaImportanceEvaluator;
+    use rustuna_core::study::{self, Direction};
+    use rustuna_core::trial::PersistedTrial;
+    use rustuna_core::storage::InMemoryStorage;
+
+
+    #[test]
+    fn test_error_multi_objective_wo_target() -> Result<()> {
+        let evaluators = vec![
+            PedAnovaImportanceEvaluator::default(),
+        ];
+        let study = test_utils::get_study(42, 5, true, Direction::Minimize)?;
+        for evaluator in evaluators {
+            let err = get_param_importances(&study, &evaluator).unwrap_err();
+            assert!(matches!(err.kind, ErrorKind::ImportanceEvaluatorError));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_evaluator_error_multi_objective_wo_target() -> Result<()> {
+        let evaluators = vec![
+            PedAnovaImportanceEvaluator::default(),
+        ];
+        let study = test_utils::get_study(42, 5, true, Direction::Minimize)?;
+        for evaluator in evaluators {
+            let err = evaluator.evaluate(&study).unwrap_err();
+            assert!(matches!(err.kind, ErrorKind::ImportanceEvaluatorError));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_param_importances() -> Result<()> {
+        let evaluators = vec![
+            PedAnovaImportanceEvaluator::default(),
+        ];
+        let study = test_utils::get_study(42, 20, false, Direction::Minimize)?;
+        for evaluator in evaluators {
+            for normalize in [true, false] {
+                let importances = get_param_importances_with(
+                    &study,
+                    &evaluator,
+                    ImportanceOptions::new().normalize(normalize),
+                )?;
+                assert_eq!(!importances.len(), 6);
+                if normalize {
+                    assert!(importances.values().all(|v| (-1e-12..=1.0 + 1e-12).contains(v)));
+                    assert!((importances.values().sum::<f64>() - 1.0).abs() < 1e-12);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_param_importances_with_target() -> Result<()> {
+        let evaluators = vec![
+            PedAnovaImportanceEvaluator::default(),
+        ];
+        let study = test_utils::get_study(42, 20, false, Direction::Minimize)?;
+        let target = |t: &PersistedTrial| -> f64 {
+            t.internal_params["x1"] + t.internal_params["x2"]
+        };
+        for evaluator in evaluators {
+            for normalize in [true, false] {
+                let importances = get_param_importances_with(
+                    &study,
+                    &evaluator,
+                    ImportanceOptions::new()
+                        .with_target(&target)
+                        .normalize(normalize),
+                )?;
+                assert_eq!(!importances.len(), 6);
+                if normalize {
+                    assert!(importances.values().all(|v| (-1e-12..=1.0 + 1e-12).contains(v)));
+                    assert!((importances.values().sum::<f64>() - 1.0).abs() < 1e-12);
+                }
+
+                let importances_wo_target = get_param_importances_with(
+                    &study,
+                    &evaluator,
+                    ImportanceOptions::new().normalize(normalize),
+                )?;
+                assert_ne!(importances, importances_wo_target);
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_evaluator_evaluate_with_target() -> Result<()> {
+        let evaluators = vec![
+            PedAnovaImportanceEvaluator::default(),
+        ];
+        let study = test_utils::get_study(42, 20, false, Direction::Minimize)?;
+        let target = |t: &PersistedTrial| -> f64 {
+            t.internal_params["x1"] + t.internal_params["x2"]
+        };
+        for evaluator in evaluators {
+            for normalize in [true, false] {
+                let importances = evaluator.evaluate_with(
+                    &study,
+                    ImportanceOptions::new()
+                        .with_target(&target)
+                        .normalize(normalize),
+                )?;
+                assert_eq!(!importances.len(), 6);
+                if normalize {
+                    assert!(importances.values().all(|v| (-1e-12..=1.0 + 1e-12).contains(v)));
+                    assert!((importances.values().sum::<f64>() - 1.0).abs() < 1e-12);
+                }
+                let importances_wo_target = evaluator.evaluate_with(
+                    &study,
+                    ImportanceOptions::new().normalize(normalize),
+                )?;
+                assert_ne!(importances, importances_wo_target);
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_param_importances_empty_study() -> Result<()> {
+        let evaluators = vec![
+            PedAnovaImportanceEvaluator::default(),
+        ];
+        let study = study::create_study(
+            "empty-study",
+            InMemoryStorage::new(),
+            vec![Direction::Minimize],
+        )?;
+        for evaluator in evaluators {
+            let err = get_param_importances(&study, &evaluator).unwrap_err();
+            assert!(matches!(err.kind, ErrorKind::NoCompletedTrial));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_param_importances_empty_search_space() -> Result<()> {
+        let mut study = study::create_study(
+            "empty-search-space",
+            InMemoryStorage::new(),
+            vec![Direction::Minimize],
+        )?;
+        study.optimize(
+            |mut t| {
+                let x1 = t.suggest_float("x1", 0.0, 5.0)?;
+                let x2 = t.suggest_float("x2", 1.0, 1.0)?;
+                Ok(vec![x1 + x2])
+            },
+            Arc::new(Mutex::new(RandomSampler::new())),
+            5,
+        )?;
+        let evaluators = vec![
+            PedAnovaImportanceEvaluator::default(),
+        ];
+        for evaluator in evaluators {
+            let importances = get_param_importances(&study, &evaluator)?;
+            let keys = importances.keys().map(String::as_str).collect::<HashSet<_>>();
+            let expected = HashSet::from(["x1", "x2"]);
+            assert_eq!(keys, expected);
+            assert!(importances["x1"] > 0.0);
+            assert!(importances["x2"] == 0.0);
+        }
+        Ok(())
+    }
+}

--- a/rustuna_importance/src/lib.rs
+++ b/rustuna_importance/src/lib.rs
@@ -2,6 +2,9 @@ mod common;
 pub mod fanova;
 mod ped_anova;
 
+#[cfg(test)]
+pub(crate) mod test_utils;
+
 pub use common::{
     get_param_importances, get_param_importances_with, ImportanceEvaluator, ImportanceOptions,
 };

--- a/rustuna_importance/src/lib.rs
+++ b/rustuna_importance/src/lib.rs
@@ -1,6 +1,8 @@
+mod common;
 pub mod fanova;
 mod ped_anova;
-mod common;
 
+pub use common::{
+    get_param_importances, get_param_importances_with, ImportanceEvaluator, ImportanceOptions,
+};
 pub use ped_anova::PedAnovaImportanceEvaluator;
-pub use common::{get_param_importances, get_param_importances_with, ImportanceEvaluator, ImportanceOptions};

--- a/rustuna_importance/src/lib.rs
+++ b/rustuna_importance/src/lib.rs
@@ -1,1 +1,6 @@
 pub mod fanova;
+mod ped_anova;
+mod common;
+
+pub use ped_anova::PedAnovaImportanceEvaluator;
+pub use common::{get_param_importances, get_param_importances_with, ImportanceEvaluator, ImportanceOptions};

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -9,6 +9,47 @@ pub struct PedAnovaImportanceEvaluator {
     min_n_top_trials: usize,
 }
 
+impl PedAnovaImportanceEvaluator {
+    pub fn new(target_quantile: f64, region_quantile: f64, evaluate_on_local: bool) -> Self {
+        Self {
+            target_quantile,
+            region_quantile,
+            evaluate_on_local,
+            n_steps: 50,
+            prior_weight: 1.0,
+            min_n_top_trials: 2
+        }
+    }
+
+    fn get_top_quantile_trials<'a>(
+        &self,
+        study: &Study,
+        trials: &'a [PersistedTrial],
+        quantile: f64,
+        target: &dyn Fn(&PersistedTrial) -> f64,
+    ) -> Vec<&'a PersistedTrial> {
+        if quantile == 1.0 {
+            return trials.iter().collect();
+        }
+        let is_lower_better = study.directions[0] == Direction::Minimize;
+        let objective_values = trials.iter().map(|t| {
+            let v = target(t);
+            if is_lower_better { v } else { -v }
+        }).collect::<Vec<_>>();
+        let num_trials = trials.len();
+        let num_top_trials = ((quantile * (num_trials as f64 - 1.0)).floor() as usize).min(num_trials - 1);
+
+        let (_, &mut threshold, _) = objective_values.clone().select_nth_unstable_by(
+            num_top_trials,
+            |a, b| a.total_cmp(b),
+        );
+        let top_trials = trials.iter().zip(objective_values.iter())
+            .filter(|(_, &v)| v <= threshold)
+            .map(|(t, _)| t)
+            .collect();
+        top_trials
+    }
+}
 
 
 fn count_numerical_param_in_grid(

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -98,7 +98,7 @@ impl ImportanceEvaluator for PedAnovaImportanceEvaluator {
         let dists = common::get_intersection_search_space(&trials);
 
         if trials.len() < self.min_n_top_trials {
-            return Ok(dists.into_iter().map(|(name, _)| (name, 0.0)).collect());
+            return Ok(dists.into_keys().map(|name| (name, 0.0)).collect());
         }
 
         let target_trials = self.get_top_quantile_trials(study, &trials, self.target_quantile, target);
@@ -106,14 +106,14 @@ impl ImportanceEvaluator for PedAnovaImportanceEvaluator {
 
         let quantile = target_trials.len() as f64 / region_trials.len() as f64;
 
-        let mut importances = dists.into_iter().map(|(name, dist)| {
+        let importances = dists.into_iter().map(|(name, dist)| {
             let importance = if dist.is_single() {
                 0.0
             } else {
-                quantile.powi(2) * self.compute_pearson_divergence(name, &dist, &target_trials, &region_trials)
+                quantile.powi(2) * self.compute_pearson_divergence(&name, &dist, &target_trials, &region_trials)
             };
             (name, importance)
-        }).collect::<HashMap<_, _>>();
+        }).collect();
         Ok(importances)
     }
 }
@@ -122,7 +122,7 @@ impl ImportanceEvaluator for PedAnovaImportanceEvaluator {
 fn count_numerical_param_in_grid(
     param_name: &str,
     dist: &Distribution,
-    trials: &[PersistedTrial],
+    trials: &[&PersistedTrial],
     n_steps: usize,
 ) -> Vec<u32> {
     let (low, high, log, n_steps) = match dist {
@@ -179,7 +179,7 @@ fn count_numerical_param_in_grid(
 fn count_categorical_param_in_grid(
     param_name: &str,
     dist: &Distribution,
-    trials: &[PersistedTrial],
+    trials: &[&PersistedTrial],
 ) -> Vec<u32> {
     let cardinality = match dist {
         Distribution::Categorical { cardinality } => *cardinality,
@@ -193,13 +193,13 @@ fn count_categorical_param_in_grid(
     counts
 }
 
-fn build_parzen_estimator(
+fn build_parzen_estimator_on_grid(
     param_name: &str,
     dist: &Distribution,
-    trials: &[PersistedTrial],
+    trials: &[&PersistedTrial],
     n_steps: usize,
     prior_weight: f64,
-) -> ParzenEstimator {
+) -> (ParzenEstimator, usize) {
     let (counts, rounded_dist) = match dist {
         Distribution::Int {..} | Distribution::Float {..} => {
             let counts = count_numerical_param_in_grid(param_name, dist, trials, n_steps);
@@ -215,10 +215,11 @@ fn build_parzen_estimator(
     };
     let observation = counts.iter().enumerate().filter(|(_, &c)| c > 0).map(|(i, _)| i as f64).collect();
     let weights = counts.iter().filter(|&&c| c > 0).map(|&c| c as f64).collect::<Vec<_>>();
-    ParzenEstimator::with_scott(
-        &HashMap::from([(param_name.to_string(), observation)]),
-        &HashMap::from([(param_name.to_string(), rounded_dist)]),
+    let pe = ParzenEstimator::with_scott(
+        &[(param_name.to_string(), observation)].into(),
+        &[(param_name.to_string(), rounded_dist)].into(),
         &weights,
         prior_weight,
-    )
+    );
+    (pe, counts.len())
 }

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use rustuna_core::trial::PersistedTrial;
 use rustuna_core::distribution::Distribution;
 use rustuna_core::study::{Study, Direction};
+use rustuna_core::parzen_estimator::ParzenEstimator;
+use rustuna_core::Result;
 use crate::common::{self, ImportanceEvaluator};
 
 

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -1,0 +1,20 @@
+use rustuna_core::trial::PersistedTrial;
+use rustuna_core::distribution::Distribution;
+
+
+fn count_categorical_param_in_grid(
+    param_name: &str,
+    dist: &Distribution,
+    trials: &[PersistedTrial],
+) -> Vec<u32> {
+    let cardinality = match dist {
+        Distribution::Categorical { cardinality } => *cardinality,
+        _ => unreachable!("Invalid distribution type for categorical calculation"),
+    };
+    let mut counts = vec![0u32; cardinality];
+    for t in trials {
+        let v = t.internal_params[param_name];
+        counts[v as usize] += 1;
+    }
+    counts
+}

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -2,6 +2,64 @@ use rustuna_core::trial::PersistedTrial;
 use rustuna_core::distribution::Distribution;
 
 
+
+fn count_numerical_param_in_grid(
+    param_name: &str,
+    dist: &Distribution,
+    trials: &[PersistedTrial],
+    n_steps: usize,
+) -> Vec<u32> {
+    let (low, high, log, n_steps) = match dist {
+        Distribution::Int {
+            low,
+            high,
+            step,
+            log,
+        } => {
+            let n_steps = if *log {
+                let log2_domain_size = ((high - low + 1) as f64).log2().ceil() as usize + 1;
+                n_steps.min(log2_domain_size)
+            } else {
+                n_steps.min(((high - low) / step + 1) as usize)
+            };
+            (*low as f64, *high as f64, *log, n_steps)
+        },
+        Distribution::Float {
+            low,
+            high,
+            step,
+            log,
+        } => {
+            let n_steps = if let Some(step) = step {
+                n_steps.min(((high - low) / step).round() as usize + 1)
+            } else {
+                n_steps
+            };
+            (*low, *high, *log, n_steps)
+        },
+        _ => unreachable!("Invalid distribution type for numerical calculation"),
+    };
+    let (low, high) = if log {
+        (low.ln(), high.ln())
+    } else {
+        (low, high)
+    };
+    let param_values = trials.iter().map(|t| {
+        let v = t.internal_params[param_name];
+        if log { v.ln() } else { v }
+    });
+    let step_size = (high - low) / (n_steps as f64);
+    let mut counts = vec![0u32; n_steps];
+    for v in param_values {
+        let idx = ((v - low) / step_size).floor().max(0.0).min((n_steps - 1) as f64) as usize;
+        counts[idx] += 1;
+    }
+    counts
+}
+
+
+
+
 fn count_categorical_param_in_grid(
     param_name: &str,
     dist: &Distribution,

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -156,3 +156,33 @@ fn count_categorical_param_in_grid(
     }
     counts
 }
+
+fn build_parzen_estimator(
+    param_name: &str,
+    dist: &Distribution,
+    trials: &[PersistedTrial],
+    n_steps: usize,
+    prior_weight: f64,
+) -> ParzenEstimator {
+    let (counts, rounded_dist) = match dist {
+        Distribution::Int {..} | Distribution::Float {..} => {
+            let counts = count_numerical_param_in_grid(param_name, dist, trials, n_steps);
+            let rounded_dist = Distribution::Int {
+                low: 0, high: (counts.len() - 1) as i64, step: 1, log: false
+            };
+            (counts, rounded_dist)
+        }
+        Distribution::Categorical {..} => {
+            let counts = count_categorical_param_in_grid(param_name, dist, trials);
+            (counts, dist.clone())
+        }
+    };
+    let observation = counts.iter().enumerate().filter(|(_, &c)| c > 0).map(|(i, _)| i as f64).collect();
+    let weights = counts.iter().filter(|&&c| c > 0).map(|&c| c as f64).collect::<Vec<_>>();
+    ParzenEstimator::with_scott(
+        &HashMap::from([(param_name.to_string(), observation)]),
+        &HashMap::from([(param_name.to_string(), rounded_dist)]),
+        &weights,
+        prior_weight,
+    )
+}

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -282,3 +282,32 @@ fn build_parzen_estimator_on_grid(
     );
     (pe, counts.len())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustuna_core::Result;
+    use crate::test_utils;
+    use rustuna_core::study::Direction;
+
+
+    #[test]
+    fn test_n_trials_equal_to_min_n_top_trials() -> Result<()> {
+        let evaluator = PedAnovaImportanceEvaluator::default();
+        let study = test_utils::get_study(42, evaluator.min_n_top_trials, false, Direction::Minimize)?;
+        let importances = evaluator.evaluate(&study)?;
+        assert!(importances.values().all(|v| v.abs() <= 1e-12));
+        Ok(())
+    }
+
+    #[test]
+    fn test_direction() -> Result<()> {
+        let study_minimize = test_utils::get_study(42, 20, false, Direction::Minimize)?;
+        let study_maximize = test_utils::get_study(42, 20, false, Direction::Maximize)?;
+        let evaluator = PedAnovaImportanceEvaluator::default();
+        let importances_minimize = evaluator.evaluate(&study_minimize)?;
+        let importances_maximize = evaluator.evaluate(&study_maximize)?;
+        assert_ne!(importances_minimize, importances_maximize);
+        Ok(())
+    }
+

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -296,7 +296,10 @@ mod tests {
         let study =
             test_utils::get_study(42, evaluator.min_n_top_trials, false, Direction::Minimize)?;
         let importances = evaluator.evaluate(&study)?;
-        assert!(importances.values().all(|v| v.abs() <= 1e-12), "{importances:?}");
+        assert!(
+            importances.values().all(|v| v.abs() <= 1e-12),
+            "{importances:?}"
+        );
         Ok(())
     }
 

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -98,6 +98,7 @@ impl ImportanceEvaluator for PedAnovaImportanceEvaluator {
     fn evaluate_with(&self, study: &Study, opts: ImportanceOptions) -> Result<HashMap<String, f64>> {
         let target = common::resolve_target(opts.target);
         let trials = common::get_filtered_trials(study, target)?;
+        common::ensure_target_for_multi_objective(&trials, opts.target)?;
         let dists = common::get_intersection_search_space(&trials);
 
         if trials.len() < self.min_n_top_trials {

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -130,7 +130,7 @@ impl ImportanceEvaluator for PedAnovaImportanceEvaluator {
         common::ensure_target_for_multi_objective(&trials, opts.target)?;
         let dists = common::get_intersection_search_space(&trials);
 
-        if trials.len() < self.min_n_top_trials {
+        if trials.len() <= self.min_n_top_trials {
             return Ok(dists.into_keys().map(|name| (name, 0.0)).collect());
         }
 
@@ -296,7 +296,7 @@ mod tests {
         let study =
             test_utils::get_study(42, evaluator.min_n_top_trials, false, Direction::Minimize)?;
         let importances = evaluator.evaluate(&study)?;
-        assert!(importances.values().all(|v| v.abs() <= 1e-12));
+        assert!(importances.values().all(|v| v.abs() <= 1e-12), "{importances:?}");
         Ok(())
     }
 

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -15,6 +15,19 @@ pub struct PedAnovaImportanceEvaluator {
     min_n_top_trials: usize,
 }
 
+impl Default for PedAnovaImportanceEvaluator {
+    fn default() -> Self {
+        Self {
+            target_quantile: 0.1,
+            region_quantile: 1.0,
+            evaluate_on_local: true,
+            n_steps: 50,
+            prior_weight: 1.0,
+            min_n_top_trials: 2,
+        }
+    }
+}
+
 impl PedAnovaImportanceEvaluator {
     pub fn new(target_quantile: f64, region_quantile: f64, evaluate_on_local: bool) -> Self {
         Self {

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -311,3 +311,36 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn test_target_quantile() -> Result<()> {
+        let study = test_utils::get_study(42, 20, false, Direction::Minimize)?;
+        let evaluator_default = PedAnovaImportanceEvaluator::default();
+        let evaluator = PedAnovaImportanceEvaluator::new(0.3, 1.0, true);
+        let importances_default = evaluator_default.evaluate(&study)?;
+        let importances = evaluator.evaluate(&study)?;
+        assert_ne!(importances_default, importances);
+        Ok(())
+    }
+
+    #[test]
+    fn test_region_quantile_less_than_one() -> Result<()> {
+        let study = test_utils::get_study(42, 20, false, Direction::Minimize)?;
+        let evaluator_default = PedAnovaImportanceEvaluator::default();
+        let evaluator = PedAnovaImportanceEvaluator::new(0.1, 0.5, true);
+        let importances_default = evaluator_default.evaluate(&study)?;
+        let importances = evaluator.evaluate(&study)?;
+        assert_ne!(importances_default, importances);
+        Ok(())
+    }
+
+    #[test]
+    fn test_evaluate_on_local() -> Result<()> {
+        let study = test_utils::get_study(42, 20, false, Direction::Minimize)?;
+        let evaluator_default = PedAnovaImportanceEvaluator::default();
+        let evaluator = PedAnovaImportanceEvaluator::new(0.1, 1.0, false);
+        let importances_default = evaluator_default.evaluate(&study)?;
+        let importances = evaluator.evaluate(&study)?;
+        assert_ne!(importances_default, importances);
+        Ok(())
+    }
+}

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -286,15 +286,15 @@ fn build_parzen_estimator_on_grid(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rustuna_core::Result;
     use crate::test_utils;
     use rustuna_core::study::Direction;
-
+    use rustuna_core::Result;
 
     #[test]
     fn test_n_trials_equal_to_min_n_top_trials() -> Result<()> {
         let evaluator = PedAnovaImportanceEvaluator::default();
-        let study = test_utils::get_study(42, evaluator.min_n_top_trials, false, Direction::Minimize)?;
+        let study =
+            test_utils::get_study(42, evaluator.min_n_top_trials, false, Direction::Minimize)?;
         let importances = evaluator.evaluate(&study)?;
         assert!(importances.values().all(|v| v.abs() <= 1e-12));
         Ok(())

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -1,11 +1,10 @@
-use std::collections::HashMap;
-use rustuna_core::trial::PersistedTrial;
-use rustuna_core::distribution::Distribution;
-use rustuna_core::study::{Study, Direction};
-use rustuna_core::parzen_estimator::ParzenEstimator;
-use rustuna_core::Result;
 use crate::common::{self, ImportanceEvaluator, ImportanceOptions};
-
+use rustuna_core::distribution::Distribution;
+use rustuna_core::parzen_estimator::ParzenEstimator;
+use rustuna_core::study::{Direction, Study};
+use rustuna_core::trial::PersistedTrial;
+use rustuna_core::Result;
+use std::collections::HashMap;
 
 pub struct PedAnovaImportanceEvaluator {
     target_quantile: f64,
@@ -24,7 +23,7 @@ impl PedAnovaImportanceEvaluator {
             evaluate_on_local,
             n_steps: 50,
             prior_weight: 1.0,
-            min_n_top_trials: 2
+            min_n_top_trials: 2,
         }
     }
 
@@ -39,18 +38,27 @@ impl PedAnovaImportanceEvaluator {
             return trials.iter().collect();
         }
         let is_lower_better = study.directions[0] == Direction::Minimize;
-        let objective_values = trials.iter().map(|t| {
-            let v = target(t);
-            if is_lower_better { v } else { -v }
-        }).collect::<Vec<_>>();
+        let objective_values = trials
+            .iter()
+            .map(|t| {
+                let v = target(t);
+                if is_lower_better {
+                    v
+                } else {
+                    -v
+                }
+            })
+            .collect::<Vec<_>>();
         let num_trials = trials.len();
-        let num_top_trials = ((quantile * (num_trials as f64 - 1.0)).floor() as usize).min(num_trials - 1);
+        let num_top_trials =
+            ((quantile * (num_trials as f64 - 1.0)).floor() as usize).min(num_trials - 1);
 
-        let (_, &mut threshold, _) = objective_values.clone().select_nth_unstable_by(
-            num_top_trials,
-            |a, b| a.total_cmp(b),
-        );
-        let top_trials = trials.iter().zip(objective_values.iter())
+        let (_, &mut threshold, _) = objective_values
+            .clone()
+            .select_nth_unstable_by(num_top_trials, |a, b| a.total_cmp(b));
+        let top_trials = trials
+            .iter()
+            .zip(objective_values.iter())
             .filter(|(_, &v)| v <= threshold)
             .map(|(t, _)| t)
             .collect();
@@ -74,7 +82,8 @@ impl PedAnovaImportanceEvaluator {
         let pdf_top = (0..grid_size)
             .map(|i| pe_top.log_pdf(&[(param_name.to_string(), i as f64)].into()))
             .map(|p| p.exp() + 1e-12);
-        let pdf_local: Vec<_> = if self.evaluate_on_local { // The importance of param during the study.
+        let pdf_local: Vec<_> = if self.evaluate_on_local {
+            // The importance of param during the study.
             let (pe_local, _) = build_parzen_estimator_on_grid(
                 param_name,
                 dist,
@@ -84,18 +93,25 @@ impl PedAnovaImportanceEvaluator {
             );
             (0..grid_size)
                 .map(|i| pe_local.log_pdf(&[(param_name.to_string(), i as f64)].into()))
-                .map(|p| p.exp() + 1e-12).collect()
-        } else { // The importance of param in the search space.
+                .map(|p| p.exp() + 1e-12)
+                .collect()
+        } else {
+            // The importance of param in the search space.
             std::iter::repeat_n(1.0 / (grid_size as f64), grid_size).collect()
         };
-        pdf_top.zip(pdf_local)
+        pdf_top
+            .zip(pdf_local)
             .map(|(p_top, p_local)| p_local * (p_top / p_local - 1.0).powi(2))
             .sum()
     }
 }
 
 impl ImportanceEvaluator for PedAnovaImportanceEvaluator {
-    fn evaluate_with(&self, study: &Study, opts: ImportanceOptions) -> Result<HashMap<String, f64>> {
+    fn evaluate_with(
+        &self,
+        study: &Study,
+        opts: ImportanceOptions,
+    ) -> Result<HashMap<String, f64>> {
         let target = common::resolve_target(opts.target);
         let trials = common::get_filtered_trials(study, target)?;
         common::ensure_target_for_multi_objective(&trials, opts.target)?;
@@ -105,23 +121,33 @@ impl ImportanceEvaluator for PedAnovaImportanceEvaluator {
             return Ok(dists.into_keys().map(|name| (name, 0.0)).collect());
         }
 
-        let target_trials = self.get_top_quantile_trials(study, &trials, self.target_quantile, target);
-        let region_trials = self.get_top_quantile_trials(study, &trials, self.region_quantile, target);
+        let target_trials =
+            self.get_top_quantile_trials(study, &trials, self.target_quantile, target);
+        let region_trials =
+            self.get_top_quantile_trials(study, &trials, self.region_quantile, target);
 
         let quantile = target_trials.len() as f64 / region_trials.len() as f64;
 
-        let importances = dists.into_iter().map(|(name, dist)| {
-            let importance = if dist.is_single() {
-                0.0
-            } else {
-                quantile.powi(2) * self.compute_pearson_divergence(&name, &dist, &target_trials, &region_trials)
-            };
-            (name, importance)
-        }).collect();
+        let importances = dists
+            .into_iter()
+            .map(|(name, dist)| {
+                let importance = if dist.is_single() {
+                    0.0
+                } else {
+                    quantile.powi(2)
+                        * self.compute_pearson_divergence(
+                            &name,
+                            &dist,
+                            &target_trials,
+                            &region_trials,
+                        )
+                };
+                (name, importance)
+            })
+            .collect();
         Ok(importances)
     }
 }
-
 
 fn count_numerical_param_in_grid(
     param_name: &str,
@@ -143,7 +169,7 @@ fn count_numerical_param_in_grid(
                 n_steps.min(((high - low) / step + 1) as usize)
             };
             (*low as f64, *high as f64, *log, n_steps)
-        },
+        }
         Distribution::Float {
             low,
             high,
@@ -156,7 +182,7 @@ fn count_numerical_param_in_grid(
                 n_steps
             };
             (*low, *high, *log, n_steps)
-        },
+        }
         _ => unreachable!("Invalid distribution type for numerical calculation"),
     };
     let (low, high) = if log {
@@ -166,19 +192,23 @@ fn count_numerical_param_in_grid(
     };
     let param_values = trials.iter().map(|t| {
         let v = t.internal_params[param_name];
-        if log { v.ln() } else { v }
+        if log {
+            v.ln()
+        } else {
+            v
+        }
     });
     let step_size = (high - low) / (n_steps as f64);
     let mut counts = vec![0u32; n_steps];
     for v in param_values {
-        let idx = ((v - low) / step_size).floor().max(0.0).min((n_steps - 1) as f64) as usize;
+        let idx = ((v - low) / step_size)
+            .floor()
+            .max(0.0)
+            .min((n_steps - 1) as f64) as usize;
         counts[idx] += 1;
     }
     counts
 }
-
-
-
 
 fn count_categorical_param_in_grid(
     param_name: &str,
@@ -205,20 +235,32 @@ fn build_parzen_estimator_on_grid(
     prior_weight: f64,
 ) -> (ParzenEstimator, usize) {
     let (counts, rounded_dist) = match dist {
-        Distribution::Int {..} | Distribution::Float {..} => {
+        Distribution::Int { .. } | Distribution::Float { .. } => {
             let counts = count_numerical_param_in_grid(param_name, dist, trials, n_steps);
             let rounded_dist = Distribution::Int {
-                low: 0, high: (counts.len() - 1) as i64, step: 1, log: false
+                low: 0,
+                high: (counts.len() - 1) as i64,
+                step: 1,
+                log: false,
             };
             (counts, rounded_dist)
         }
-        Distribution::Categorical {..} => {
+        Distribution::Categorical { .. } => {
             let counts = count_categorical_param_in_grid(param_name, dist, trials);
             (counts, dist.clone())
         }
     };
-    let observation = counts.iter().enumerate().filter(|(_, &c)| c > 0).map(|(i, _)| i as f64).collect();
-    let weights = counts.iter().filter(|&&c| c > 0).map(|&c| c as f64).collect::<Vec<_>>();
+    let observation = counts
+        .iter()
+        .enumerate()
+        .filter(|(_, &c)| c > 0)
+        .map(|(i, _)| i as f64)
+        .collect();
+    let weights = counts
+        .iter()
+        .filter(|&&c| c > 0)
+        .map(|&c| c as f64)
+        .collect::<Vec<_>>();
     let pe = ParzenEstimator::with_scott(
         &[(param_name.to_string(), observation)].into(),
         &[(param_name.to_string(), rounded_dist)].into(),

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -54,6 +54,42 @@ impl PedAnovaImportanceEvaluator {
             .collect();
         top_trials
     }
+
+    fn compute_pearson_divergence(
+        &self,
+        param_name: &str,
+        dist: &Distribution,
+        target_trials: &[&PersistedTrial],
+        region_trials: &[&PersistedTrial],
+    ) -> f64 {
+        let (pe_top, grid_size) = build_parzen_estimator_on_grid(
+            param_name,
+            dist,
+            target_trials,
+            self.n_steps,
+            self.prior_weight,
+        );
+        let pdf_top = (0..grid_size)
+            .map(|i| pe_top.log_pdf(&[(param_name.to_string(), i as f64)].into()))
+            .map(|p| p.exp() + 1e-12);
+        let pdf_local: Vec<_> = if self.evaluate_on_local { // The importance of param during the study.
+            let (pe_local, _) = build_parzen_estimator_on_grid(
+                param_name,
+                dist,
+                region_trials,
+                self.n_steps,
+                self.prior_weight,
+            );
+            (0..grid_size)
+                .map(|i| pe_local.log_pdf(&[(param_name.to_string(), i as f64)].into()))
+                .map(|p| p.exp() + 1e-12).collect()
+        } else { // The importance of param in the search space.
+            std::iter::repeat_n(1.0 / (grid_size as f64), grid_size).collect()
+        };
+        pdf_top.zip(pdf_local)
+            .map(|(p_top, p_local)| p_local * (p_top / p_local - 1.0).powi(2))
+            .sum()
+    }
 }
 
 impl ImportanceEvaluator for PedAnovaImportanceEvaluator {

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -51,6 +51,32 @@ impl PedAnovaImportanceEvaluator {
     }
 }
 
+impl ImportanceEvaluator for PedAnovaImportanceEvaluator {
+    fn evaluate_with_target(&self, study: &Study, target: &dyn Fn(&PersistedTrial) -> f64) -> Result<HashMap<String, f64>> {
+        let trials = common::get_filtered_trials(study, target)?;
+        let dists = common::get_intersection_search_space(&trials);
+
+        if trials.len() < self.min_n_top_trials {
+            return Ok(dists.into_iter().map(|(name, _)| (name, 0.0)).collect());
+        }
+
+        let target_trials = self.get_top_quantile_trials(study, &trials, self.target_quantile, target);
+        let region_trials = self.get_top_quantile_trials(study, &trials, self.region_quantile, target);
+
+        let quantile = target_trials.len() as f64 / region_trials.len() as f64;
+
+        let mut importances = dists.into_iter().map(|(name, dist)| {
+            let importance = if dist.is_single() {
+                0.0
+            } else {
+                quantile.powi(2) * self.compute_pearson_divergence(name, &dist, &target_trials, &region_trials)
+            };
+            (name, importance)
+        }).collect::<HashMap<_, _>>();
+        Ok(importances)
+    }
+}
+
 
 fn count_numerical_param_in_grid(
     param_name: &str,

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -1,5 +1,13 @@
 use rustuna_core::trial::PersistedTrial;
 use rustuna_core::distribution::Distribution;
+pub struct PedAnovaImportanceEvaluator {
+    target_quantile: f64,
+    region_quantile: f64,
+    evaluate_on_local: bool,
+    n_steps: usize,
+    prior_weight: f64,
+    min_n_top_trials: usize,
+}
 
 
 

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -4,7 +4,7 @@ use rustuna_core::distribution::Distribution;
 use rustuna_core::study::{Study, Direction};
 use rustuna_core::parzen_estimator::ParzenEstimator;
 use rustuna_core::Result;
-use crate::common::{self, ImportanceEvaluator};
+use crate::common::{self, ImportanceEvaluator, ImportanceOptions};
 
 
 pub struct PedAnovaImportanceEvaluator {
@@ -95,7 +95,8 @@ impl PedAnovaImportanceEvaluator {
 }
 
 impl ImportanceEvaluator for PedAnovaImportanceEvaluator {
-    fn evaluate_with_target(&self, study: &Study, target: &dyn Fn(&PersistedTrial) -> f64) -> Result<HashMap<String, f64>> {
+    fn evaluate_with(&self, study: &Study, opts: ImportanceOptions) -> Result<HashMap<String, f64>> {
+        let target = common::resolve_target(opts.target);
         let trials = common::get_filtered_trials(study, target)?;
         let dists = common::get_intersection_search_space(&trials);
 

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -1,5 +1,10 @@
+use std::collections::HashMap;
 use rustuna_core::trial::PersistedTrial;
 use rustuna_core::distribution::Distribution;
+use rustuna_core::study::{Study, Direction};
+use crate::common::{self, ImportanceEvaluator};
+
+
 pub struct PedAnovaImportanceEvaluator {
     target_quantile: f64,
     region_quantile: f64,

--- a/rustuna_importance/src/test_utils.rs
+++ b/rustuna_importance/src/test_utils.rs
@@ -1,0 +1,42 @@
+use std::sync::{Arc, Mutex};
+use rustuna_core::sampler::RandomSampler;
+use rustuna_core::trial::Trial;
+use rustuna_core::Result;
+use rustuna_core::distribution::Distribution;
+use rustuna_core::study::{self, Direction, Study};
+use rustuna_core::storage::InMemoryStorage;
+
+fn single_objective(mut trial: Trial) -> Result<Vec<f64>> {
+    let x1 = trial.suggest_float("x1", 0.1, 3.0)?;
+    let x2 = trial.suggest("x2", &Distribution::Float {low: 0.1, high: 0.3, step: None, log: true})?;
+    let x3 = trial.suggest("x3", &Distribution::Float {low: 2.0, high:4.0, step: None, log: true})?;
+    Ok(vec![x1 + x2 * x3])
+}
+
+fn multi_objective(mut trial: Trial) -> Result<Vec<f64>> {
+    let x1 = trial.suggest_float("x1", 0.1, 3.0)?;
+    let x2 = trial.suggest("x2", &Distribution::Float {low: 0.1, high: 0.3, step: None, log: true})?;
+    let x3 = trial.suggest("x3", &Distribution::Float {low: 2.0, high:4.0, step: None, log: true})?;
+    Ok(vec![x1, x2 * x3])
+}
+
+pub(crate) fn get_study(seed: u64, n_trials: usize, is_multi_objective: bool, direction: Direction) -> Result<Study> {
+    let storage = InMemoryStorage::new();
+    let directions = if is_multi_objective {
+        vec![direction.clone(), direction]
+    } else {
+        vec![direction]
+    };
+    let mut study = study::create_study("test-study", storage, directions)?;
+    let sampler = Arc::new(Mutex::new(RandomSampler::seed_from_u64(seed)));
+    study.optimize(
+        if is_multi_objective {
+            multi_objective
+        } else {
+            single_objective
+        },
+        sampler,
+        n_trials,
+    )?;
+    Ok(study)
+}

--- a/rustuna_importance/src/test_utils.rs
+++ b/rustuna_importance/src/test_utils.rs
@@ -1,32 +1,85 @@
-use std::sync::{Arc, Mutex};
+use rustuna_core::distribution::Distribution;
 use rustuna_core::sampler::RandomSampler;
+use rustuna_core::storage::InMemoryStorage;
+use rustuna_core::study::{self, Direction, Study};
 use rustuna_core::trial::Trial;
 use rustuna_core::Result;
-use rustuna_core::distribution::Distribution;
-use rustuna_core::study::{self, Direction, Study};
-use rustuna_core::storage::InMemoryStorage;
+use std::sync::{Arc, Mutex};
 
 fn single_objective(mut trial: Trial) -> Result<Vec<f64>> {
     let x1 = trial.suggest_float("x1", 0.1, 3.0)?;
-    let x2 = trial.suggest("x2", &Distribution::Float {low: 0.1, high: 0.3, step: None, log: true})?;
-    let x3 = trial.suggest("x3", &Distribution::Float {low: 0.0, high: 3.0, step: Some(1.0), log: true})?;
+    let x2 = trial.suggest(
+        "x2",
+        &Distribution::Float {
+            low: 0.1,
+            high: 0.3,
+            step: None,
+            log: true,
+        },
+    )?;
+    let x3 = trial.suggest(
+        "x3",
+        &Distribution::Float {
+            low: 0.0,
+            high: 3.0,
+            step: Some(1.0),
+            log: true,
+        },
+    )?;
     let x4 = trial.suggest_int("x4", -3, 3)?;
-    let x5 = trial.suggest("x5", &Distribution::Int {low: -3, high: 3, step: 1, log: true})?;
+    let x5 = trial.suggest(
+        "x5",
+        &Distribution::Int {
+            low: -3,
+            high: 3,
+            step: 1,
+            log: true,
+        },
+    )?;
     let x6 = trial.suggest_categorical("x6", &[1.0, 1.1, 1.2])?;
     Ok(vec![x1.powi(4) + x2 + x3 - x4.pow(2) as f64 - x5 + x6])
 }
 
 fn multi_objective(mut trial: Trial) -> Result<Vec<f64>> {
     let x1 = trial.suggest_float("x1", 0.1, 3.0)?;
-    let x2 = trial.suggest("x2", &Distribution::Float {low: 0.1, high: 0.3, step: None, log: true})?;
-    let x3 = trial.suggest("x3", &Distribution::Float {low: 0.0, high: 3.0, step: Some(1.0), log: true})?;
+    let x2 = trial.suggest(
+        "x2",
+        &Distribution::Float {
+            low: 0.1,
+            high: 0.3,
+            step: None,
+            log: true,
+        },
+    )?;
+    let x3 = trial.suggest(
+        "x3",
+        &Distribution::Float {
+            low: 0.0,
+            high: 3.0,
+            step: Some(1.0),
+            log: true,
+        },
+    )?;
     let x4 = trial.suggest_int("x4", -3, 3)?;
-    let x5 = trial.suggest("x5", &Distribution::Int {low: -3, high: 3, step: 1, log: true})?;
+    let x5 = trial.suggest(
+        "x5",
+        &Distribution::Int {
+            low: -3,
+            high: 3,
+            step: 1,
+            log: true,
+        },
+    )?;
     let x6 = trial.suggest_categorical("x6", &[1.0, 1.1, 1.2])?;
     Ok(vec![x1.powi(4) + x2 + x3, x4.pow(2) as f64 - x5 + x6])
 }
 
-pub(crate) fn get_study(seed: u64, n_trials: usize, is_multi_objective: bool, direction: Direction) -> Result<Study> {
+pub(crate) fn get_study(
+    seed: u64,
+    n_trials: usize,
+    is_multi_objective: bool,
+    direction: Direction,
+) -> Result<Study> {
     let storage = InMemoryStorage::new();
     let directions = if is_multi_objective {
         vec![direction.clone(), direction]

--- a/rustuna_importance/src/test_utils.rs
+++ b/rustuna_importance/src/test_utils.rs
@@ -9,15 +9,21 @@ use rustuna_core::storage::InMemoryStorage;
 fn single_objective(mut trial: Trial) -> Result<Vec<f64>> {
     let x1 = trial.suggest_float("x1", 0.1, 3.0)?;
     let x2 = trial.suggest("x2", &Distribution::Float {low: 0.1, high: 0.3, step: None, log: true})?;
-    let x3 = trial.suggest("x3", &Distribution::Float {low: 2.0, high:4.0, step: None, log: true})?;
-    Ok(vec![x1 + x2 * x3])
+    let x3 = trial.suggest("x3", &Distribution::Float {low: 0.0, high: 3.0, step: Some(1.0), log: true})?;
+    let x4 = trial.suggest_int("x4", -3, 3)?;
+    let x5 = trial.suggest("x5", &Distribution::Int {low: -3, high: 3, step: 1, log: true})?;
+    let x6 = trial.suggest_categorical("x6", &[1.0, 1.1, 1.2])?;
+    Ok(vec![x1.powi(4) + x2 + x3 - x4.pow(2) as f64 - x5 + x6])
 }
 
 fn multi_objective(mut trial: Trial) -> Result<Vec<f64>> {
     let x1 = trial.suggest_float("x1", 0.1, 3.0)?;
     let x2 = trial.suggest("x2", &Distribution::Float {low: 0.1, high: 0.3, step: None, log: true})?;
-    let x3 = trial.suggest("x3", &Distribution::Float {low: 2.0, high:4.0, step: None, log: true})?;
-    Ok(vec![x1, x2 * x3])
+    let x3 = trial.suggest("x3", &Distribution::Float {low: 0.0, high: 3.0, step: Some(1.0), log: true})?;
+    let x4 = trial.suggest_int("x4", -3, 3)?;
+    let x5 = trial.suggest("x5", &Distribution::Int {low: -3, high: 3, step: 1, log: true})?;
+    let x6 = trial.suggest_categorical("x6", &[1.0, 1.1, 1.2])?;
+    Ok(vec![x1.powi(4) + x2 + x3, x4.pow(2) as f64 - x5 + x6])
 }
 
 pub(crate) fn get_study(seed: u64, n_trials: usize, is_multi_objective: bool, direction: Direction) -> Result<Study> {


### PR DESCRIPTION
## Motivation & Description of the changes
- Add `PedAnovaImportanceEvaluator`


> [!NOTE]
> Currently, the `params` argument is not supported. We plan to add support it when we implement condPED-ANOVA:
> - https://arxiv.org/abs/2601.20800


> [!NOTE]
> To keep this PR minimal, I did not modify `fanova.rs` in this PR. We can address it in a follow-up PR.