### PR TITLE
Remove `StorageInternalError` from `ErrorKind`

### DIFF
--- a/rustuna_core/src/error.rs
+++ b/rustuna_core/src/error.rs
@@ -54,7 +54,6 @@ pub enum ErrorKind {
     AttrOverwriteNotAllowed,
     InvalidObjectiveValues,
     TrialAlreadyFinished,
-    StorageInternalError,
     UnsupportedSearchSpace,
     UnsupportedMultiObjective,
     NoCompletedTrial,

--- a/rustuna_pyo3/src/exception.rs
+++ b/rustuna_pyo3/src/exception.rs
@@ -14,7 +14,7 @@ pub fn err_to_exceptions(e: rustuna_core::Error) -> PyErr {
         rustuna_core::ErrorKind::TrialAlreadyFinished => {
             exceptions::UpdateFinishedTrialError::new_err("Trial already finished")
         }
-        rustuna_core::ErrorKind::StorageInternalError => {
+        rustuna_core::ErrorKind::StorageError => {
             exceptions::StorageInternalError::new_err("storage internal error")
         }
         rustuna_core::ErrorKind::DuplicatedStudy => {


### PR DESCRIPTION
`StorageInternalError` kind was introduced since Optuna provides `StorageInternalError` class.
https://github.com/optuna/optuna/blob/8d98bf30960414194cf3330d84dd240dd97bf768/optuna/exceptions.py#L66-L72

However, Rustuna's ErrorKind enum also provide `StorageError` kind, which is used for the same purpose. So, this PR removes `StorageInternalError struct.