### PR TITLE
Add `name` property in TrialState

### DIFF
--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -40,6 +40,17 @@ impl From<TrialStateValues> for PyTrialState {
 }
 #[pymethods]
 impl PyTrialState {
+    #[getter]
+    pub fn name(&self) -> &'static str {
+        match self {
+            PyTrialState::RUNNING => "RUNNING",
+            PyTrialState::COMPLETE => "COMPLETE",
+            PyTrialState::PRUNED => "PRUNED",
+            PyTrialState::WAITING => "WAITING",
+            PyTrialState::FAIL => "FAIL",
+        }
+    }
+
     pub fn is_finished(&self) -> bool {
         matches!(
             self,


### PR DESCRIPTION
Add `name` property in TrialState, so that Rustuna's TrialState can be used with the same API with Optuna's TrialState.