### PR TITLE
Run clippy on all targets

### DIFF
--- a/.github/workflows/checks_rust.yml
+++ b/.github/workflows/checks_rust.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt, clippy
-      - run: cargo clippy --lib --tests -- -D warnings
+      - run: cargo clippy --workspace --lib --bins --tests --examples --all-features -- -D warnings
       - name: Rustfmt Check
         uses: actions-rust-lang/rustfmt@v1
   rust_test:

--- a/rustuna_samplers/src/tpe/multi_objective.rs
+++ b/rustuna_samplers/src/tpe/multi_objective.rs
@@ -120,7 +120,7 @@ where
 
     assert!(m > 0, "reference_point must be non-empty");
     for (k, &v) in reference_point.iter().enumerate() {
-        assert!(!v.is_nan(), "reference_point[{}] is NaN", k);
+        assert!(!v.is_nan(), "reference_point[{k}] is NaN");
     }
 
     for (i, r) in loss_vals.iter().enumerate() {
@@ -394,9 +394,7 @@ mod tests {
         let expected_hv = 3.5;
         assert!(
             (hv - expected_hv).abs() < 1e-6,
-            "hv: {}, expected: {}",
-            hv,
-            expected_hv
+            "hv: {hv}, expected: {expected_hv}"
         );
     }
 

--- a/rustuna_storages/tests/journal.rs
+++ b/rustuna_storages/tests/journal.rs
@@ -14,7 +14,7 @@ fn run_optuna_python_script(python: &str, journal_path: &str, script: &str) -> R
         .map_err(|e| {
             Error::with_reason(
                 ErrorKind::Unexpected,
-                format!("Failed to execute Python: {}", e),
+                format!("Failed to execute Python: {e}"),
             )
         })?;
     if output.status.success() {
@@ -39,7 +39,7 @@ fn load_studies_from_optuna_journal() -> Result<()> {
     let dir = tempfile::tempdir().map_err(|e| {
         Error::with_reason(
             ErrorKind::Unexpected,
-            format!("Failed to create temp dir: {}", e),
+            format!("Failed to create temp dir: {e}"),
         )
     })?;
     let journal_path = dir.path().join("optuna.journal");
@@ -88,7 +88,7 @@ fn load_trial_from_optuna_journal() -> Result<()> {
     let dir = tempfile::tempdir().map_err(|e| {
         Error::with_reason(
             ErrorKind::Unexpected,
-            format!("Failed to create temp dir: {}", e),
+            format!("Failed to create temp dir: {e}"),
         )
     })?;
     let journal_path = dir.path().join("optuna.journal");
@@ -161,7 +161,7 @@ fn get_trials_from_optuna_journal() -> Result<()> {
     let dir = tempfile::tempdir().map_err(|e| {
         Error::with_reason(
             ErrorKind::Unexpected,
-            format!("Failed to create temp dir: {}", e),
+            format!("Failed to create temp dir: {e}"),
         )
     })?;
     let journal_path = dir.path().join("optuna.journal");


### PR DESCRIPTION
- Change the Rust CI clippy command from `--lib --tests` to `--all-targets`
- Make CI catch issues that were only fixed by `cargo clippy --fix`