### PR TITLE
Remove unsendable from AttrsDictView

### DIFF
--- a/rustuna_pyo3/src/attrs.rs
+++ b/rustuna_pyo3/src/attrs.rs
@@ -81,7 +81,7 @@ enum AttrsDictViewSource {
     },
 }
 
-#[pyclass(name = "AttrsDictView", unsendable)]
+#[pyclass(name = "AttrsDictView")]
 pub struct AttrsDictView {
     source: AttrsDictViewSource,
     kind: AttrKind,


### PR DESCRIPTION
The `unsendable` flag is already not required.