### PR TITLE
 Make Study operations take `&self` instead of `&mut self`

### DIFF
--- a/rustuna_core/src/sampler.rs
+++ b/rustuna_core/src/sampler.rs
@@ -206,7 +206,7 @@ mod tests {
     fn test_joint_sampling_empty() -> Result<()> {
         let joint_params = HashMap::new();
         let sampler = Arc::new(Mutex::new(DummyJointSampler { joint_params }));
-        let mut study = create_study("dummy", InMemoryStorage::new(), vec![Direction::Minimize])?;
+        let study = create_study("dummy", InMemoryStorage::new(), vec![Direction::Minimize])?;
         study.optimize(objective, sampler, 2)?;
         Ok(())
     }
@@ -217,7 +217,7 @@ mod tests {
         joint_params.insert(String::from("x"), 0.5);
 
         let sampler = Arc::new(Mutex::new(DummyJointSampler { joint_params }));
-        let mut study = create_study("dummy", InMemoryStorage::new(), vec![Direction::Minimize])?;
+        let study = create_study("dummy", InMemoryStorage::new(), vec![Direction::Minimize])?;
         study.optimize(objective, sampler, 2)?;
 
         let trials = study.get_trials()?;
@@ -234,7 +234,7 @@ mod tests {
         joint_params.insert(String::from("y"), 1.0);
 
         let sampler = Arc::new(Mutex::new(DummyJointSampler { joint_params }));
-        let mut study = create_study("dummy", InMemoryStorage::new(), vec![Direction::Minimize])?;
+        let study = create_study("dummy", InMemoryStorage::new(), vec![Direction::Minimize])?;
         study.optimize(objective, sampler, 2)?;
 
         let trials = study.get_trials()?;

--- a/rustuna_core/src/study.rs
+++ b/rustuna_core/src/study.rs
@@ -115,7 +115,7 @@ impl Study {
         Ok(Study::new(study_id, name, directions, storage))
     }
 
-    pub fn ask(&mut self, sampler: Arc<Mutex<dyn Sampler>>) -> Result<Trial> {
+    pub fn ask(&self, sampler: Arc<Mutex<dyn Sampler>>) -> Result<Trial> {
         let queued_trial_id = {
             let mut queue_guard = self.queue.write().map_err(|e| {
                 Error::with_reason(
@@ -231,7 +231,7 @@ impl Study {
         Ok(trial)
     }
 
-    pub fn tell(&mut self, trial_number: u32, state_values: TrialStateValues) -> Result<()> {
+    pub fn tell(&self, trial_number: u32, state_values: TrialStateValues) -> Result<()> {
         let mut guard = self
             .storage
             .write()
@@ -242,7 +242,7 @@ impl Study {
     }
 
     pub fn optimize<F>(
-        self: &mut Study,
+        &self,
         mut objective: F,
         // TODO(c-bata): Avoid to wrap Sampler by Arc and Mutex.
         // Sampler does not need to be shared across threads.
@@ -297,7 +297,7 @@ impl Study {
         }
     }
 
-    pub fn set_user_attr(&mut self, attrs: HashMap<String, String>) -> Result<()> {
+    pub fn set_user_attr(&self, attrs: HashMap<String, String>) -> Result<()> {
         let mut guard = self
             .storage
             .write()
@@ -310,7 +310,7 @@ impl Study {
         Ok(())
     }
 
-    pub fn add_trial(&mut self, trial: PersistedTrial) -> Result<()> {
+    pub fn add_trial(&self, trial: PersistedTrial) -> Result<()> {
         trial.validate()?;
         if let TrialStateValues::Complete(ref values) = trial.state_values {
             if values.len() != self.directions.len() {
@@ -335,7 +335,7 @@ impl Study {
     }
 
     pub fn enqueue_trial(
-        &mut self,
+        &self,
         params: HashMap<String, CategoryLabel>,
         user_attrs: Option<Attrs>,
     ) -> Result<()> {
@@ -365,6 +365,7 @@ impl Study {
             )
         })?;
         queue_guard.push(trial_id)?;
+
         Ok(())
     }
 }
@@ -517,7 +518,7 @@ mod tests {
         let storage = InMemoryStorage::new();
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let mut study = create_study("dummy", storage, directions)?;
+        let study = create_study("dummy", storage, directions)?;
 
         study.optimize(
             |mut t| {
@@ -543,7 +544,7 @@ mod tests {
 
         thread::scope(|s| {
             for i in 0..4 {
-                let mut study = study.clone();
+                let study = study.clone();
                 let sampler = Arc::new(Mutex::new(RandomSampler::seed_from_u64(i)));
                 let choices = vec![String::from("foo"), String::from("bar")];
                 s.spawn(move || {
@@ -574,7 +575,7 @@ mod tests {
         let storage = InMemoryStorage::new();
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let mut study = create_study("dummy", storage, directions)?;
+        let study = create_study("dummy", storage, directions)?;
 
         let mut trial = study.ask(sampler)?;
         trial.set_user_attr("key", String::from("bar"))?;
@@ -590,7 +591,7 @@ mod tests {
         let storage = InMemoryStorage::new();
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let mut study = create_study("dummy", storage, directions)?;
+        let study = create_study("dummy", storage, directions)?;
 
         study.optimize(
             |mut t| {
@@ -615,7 +616,7 @@ mod tests {
         let storage = InMemoryStorage::new();
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize, Direction::Maximize];
-        let mut study = create_study("dummy", storage, directions)?;
+        let study = create_study("dummy", storage, directions)?;
 
         study.optimize(
             |mut t| {
@@ -651,7 +652,7 @@ mod tests {
         let storage = InMemoryStorage::new();
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let mut study = create_study("dummy", storage, directions)?;
+        let study = create_study("dummy", storage, directions)?;
 
         study.optimize(
             |mut t| {
@@ -677,7 +678,7 @@ mod tests {
         let storage = InMemoryStorage::new();
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let mut study = create_study("dummy", storage, directions)?;
+        let study = create_study("dummy", storage, directions)?;
 
         study.optimize(
             |mut t| {
@@ -705,7 +706,7 @@ mod tests {
     fn test_add_trial_preserves_template_fields() -> Result<()> {
         let storage = InMemoryStorage::new();
         let directions = vec![Direction::Minimize];
-        let mut study = create_study("dummy-add-trial", storage, directions)?;
+        let study = create_study("dummy-add-trial", storage, directions)?;
 
         let mut trial = PersistedTrial::new(999, 888, 777);
         trial.state_values = TrialStateValues::Complete(vec![1.23]);

--- a/rustuna_core/src/trial.rs
+++ b/rustuna_core/src/trial.rs
@@ -348,7 +348,7 @@ mod tests {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let mut study = create_study_with_arc("dummy", storage.clone(), directions)?;
+        let study = create_study_with_arc("dummy", storage.clone(), directions)?;
 
         let mut params = HashMap::new();
         params.insert("x".to_string(), CategoryLabel::Float(5.0));
@@ -365,7 +365,7 @@ mod tests {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let mut study = create_study_with_arc("dummy", storage.clone(), directions)?;
+        let study = create_study_with_arc("dummy", storage.clone(), directions)?;
 
         let mut params = HashMap::new();
         params.insert("x".to_string(), CategoryLabel::Int(7));
@@ -382,7 +382,7 @@ mod tests {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let mut study = create_study_with_arc("dummy", storage.clone(), directions)?;
+        let study = create_study_with_arc("dummy", storage.clone(), directions)?;
 
         let mut params = HashMap::new();
         params.insert("x".to_string(), CategoryLabel::Float(100.0));
@@ -399,7 +399,7 @@ mod tests {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let mut study = create_study_with_arc("dummy", storage.clone(), directions)?;
+        let study = create_study_with_arc("dummy", storage.clone(), directions)?;
 
         let mut params = HashMap::new();
         params.insert("x".to_string(), CategoryLabel::Float(5.0));
@@ -422,7 +422,7 @@ mod tests {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let mut study = create_study_with_arc("dummy", storage.clone(), directions)?;
+        let study = create_study_with_arc("dummy", storage.clone(), directions)?;
 
         let mut params = HashMap::new();
         params.insert("x".to_string(), CategoryLabel::Float(5.0));
@@ -442,7 +442,7 @@ mod tests {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let mut study = create_study_with_arc("dummy", storage.clone(), directions)?;
+        let study = create_study_with_arc("dummy", storage.clone(), directions)?;
 
         // Set user attributes
         let mut trial = study.ask(sampler.clone())?;

--- a/rustuna_importance/examples/ped_anova.rs
+++ b/rustuna_importance/examples/ped_anova.rs
@@ -9,7 +9,7 @@ use rustuna_importance::{self, PedAnovaImportanceEvaluator};
 fn main() -> Result<()> {
     let storage = InMemoryStorage::new();
     let directions = vec![Direction::Minimize];
-    let mut study = create_study("simple-quadratic", storage, directions)?;
+    let study = create_study("simple-quadratic", storage, directions)?;
 
     let sampler = Arc::new(Mutex::new(RandomSampler::new()));
     study.optimize(

--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -298,7 +298,7 @@ mod tests {
 
     #[test]
     fn test_get_param_importances_single_search_space() -> Result<()> {
-        let mut study = study::create_study(
+        let study = study::create_study(
             "empty-search-space",
             InMemoryStorage::new(),
             vec![Direction::Minimize],

--- a/rustuna_importance/src/fanova.rs
+++ b/rustuna_importance/src/fanova.rs
@@ -87,7 +87,7 @@ mod tests {
         let storage = InMemoryStorage::new();
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let mut study = create_study("dummy", storage, directions).unwrap();
+        let study = create_study("dummy", storage, directions).unwrap();
 
         study
             .optimize(

--- a/rustuna_importance/src/test_utils.rs
+++ b/rustuna_importance/src/test_utils.rs
@@ -86,7 +86,7 @@ pub(crate) fn get_study(
     } else {
         vec![direction]
     };
-    let mut study = study::create_study("test-study", storage, directions)?;
+    let study = study::create_study("test-study", storage, directions)?;
     let sampler = Arc::new(Mutex::new(RandomSampler::seed_from_u64(seed)));
     study.optimize(
         if is_multi_objective {

--- a/rustuna_js/src/study.rs
+++ b/rustuna_js/src/study.rs
@@ -15,7 +15,7 @@ type JsResult<T> = Result<T, JsError>;
 pub struct JsStudy(Study);
 #[wasm_bindgen(js_class=Study)]
 impl JsStudy {
-    pub fn optimize(&mut self, objective: &Function, n_trials: usize) -> JsResult<()> {
+    pub fn optimize(&self, objective: &Function, n_trials: usize) -> JsResult<()> {
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         self.0
             .optimize(
@@ -38,7 +38,7 @@ impl JsStudy {
     }
 
     #[wasm_bindgen(getter)]
-    pub fn best_trial(&mut self) -> JsResult<JsPersistedTrial> {
+    pub fn best_trial(&self) -> JsResult<JsPersistedTrial> {
         let number = get_best_trial(&self.0).map_err(|e| JsError::new(&format!("{e:?}")))?;
         let (trials, study_attrs) = {
             let mut guard = self.0.storage.write().map_err(|e| {

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -364,7 +364,7 @@ impl PyStudy {
 
     #[pyo3(signature = (objective, n_trials, catch = None))]
     pub fn optimize(
-        &mut self,
+        &self,
         objective: Py<PyAny>,
         n_trials: usize,
         catch: Option<Py<PyAny>>,
@@ -411,7 +411,7 @@ impl PyStudy {
         Ok(())
     }
 
-    pub fn ask(&mut self) -> PyResult<PyTrial> {
+    pub fn ask(&self) -> PyResult<PyTrial> {
         let trial = self
             .study
             .ask(self.sampler.clone())
@@ -422,7 +422,7 @@ impl PyStudy {
 
     #[pyo3(signature = (number, values = None, state = None))]
     pub fn tell(
-        &mut self,
+        &self,
         number: u32,
         values: Option<Py<PyAny>>,
         state: Option<PyTrialState>,
@@ -492,7 +492,7 @@ impl PyStudy {
 
     #[pyo3(signature = (params, user_attrs = None))]
     pub fn enqueue_trial(
-        &mut self,
+        &self,
         params: &Bound<'_, PyDict>,
         user_attrs: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<()> {
@@ -506,7 +506,7 @@ impl PyStudy {
         Ok(())
     }
 
-    pub fn add_trial(&mut self, trial: &Bound<'_, PyPersistedTrial>) -> PyResult<()> {
+    pub fn add_trial(&self, trial: &Bound<'_, PyPersistedTrial>) -> PyResult<()> {
         // Extract the underlying PersistedTrial
         let persisted_trial = trial.borrow().with_trial(|t| Ok(t.clone()))?;
 
@@ -519,7 +519,7 @@ impl PyStudy {
     }
 
     #[pyo3(signature = (key, value))]
-    pub fn set_user_attr(&mut self, key: String, value: String) -> PyResult<()> {
+    pub fn set_user_attr(&self, key: String, value: String) -> PyResult<()> {
         let mut attrs = rustuna_core::attr::Attrs::new();
         attrs.insert(AttrKey::User(key.into()), value);
         let mut guard = self

--- a/rustuna_samplers/benches/nsgaii.rs
+++ b/rustuna_samplers/benches/nsgaii.rs
@@ -17,7 +17,7 @@ mod tests {
             let directions = vec![Direction::Minimize, Direction::Minimize];
             let storage = InMemoryStorage::new();
             let sampler = Arc::new(Mutex::new(NSGAIISampler::default()));
-            let mut study = create_study("dummy", storage, directions).unwrap();
+            let study = create_study("dummy", storage, directions).unwrap();
             study
                 .optimize(
                     |mut t| {

--- a/rustuna_samplers/benches/tpe.rs
+++ b/rustuna_samplers/benches/tpe.rs
@@ -17,7 +17,7 @@ mod tests {
             let directions = vec![Direction::Minimize];
             let storage = InMemoryStorage::new();
             let sampler = Arc::new(Mutex::new(TpeSampler::new()));
-            let mut study = create_study("dummy", storage, directions).unwrap();
+            let study = create_study("dummy", storage, directions).unwrap();
             study
                 .optimize(
                     |mut t| {

--- a/rustuna_samplers/examples/quadratic.rs
+++ b/rustuna_samplers/examples/quadratic.rs
@@ -12,7 +12,7 @@ use rustuna_samplers::tpe::TpeSampler;
 fn main() -> Result<()> {
     let storage = InMemoryStorage::new();
     let directions = vec![Direction::Minimize];
-    let mut study = create_study("simple-quadratic", storage, directions)?;
+    let study = create_study("simple-quadratic", storage, directions)?;
 
     let sampler = Arc::new(Mutex::new(TpeSampler::new()));
     study.optimize(

--- a/rustuna_samplers/src/nsgaii.rs
+++ b/rustuna_samplers/src/nsgaii.rs
@@ -416,7 +416,7 @@ mod tests {
     fn test_optimize() {
         let storage = InMemoryStorage::new();
         let directions = vec![Direction::Minimize, Direction::Minimize];
-        let mut study = create_study("simple-quadratic", storage, directions).unwrap();
+        let study = create_study("simple-quadratic", storage, directions).unwrap();
 
         let sampler = Arc::new(Mutex::new(NSGAIISampler::new(2, None, 1.0, 1.0)));
         let n_trials = 10;

--- a/rustuna_samplers/src/tpe/sampler.rs
+++ b/rustuna_samplers/src/tpe/sampler.rs
@@ -459,7 +459,7 @@ mod tests {
     fn test_optimize() {
         let storage = InMemoryStorage::new();
         let directions = vec![Direction::Minimize];
-        let mut study = create_study("simple-quadratic", storage, directions).unwrap();
+        let study = create_study("simple-quadratic", storage, directions).unwrap();
 
         let sampler = Arc::new(Mutex::new(TpeSampler::new()));
         study
@@ -487,7 +487,7 @@ mod tests {
     fn test_optimize_conditional() {
         let storage = InMemoryStorage::new();
         let directions = vec![Direction::Minimize];
-        let mut study = create_study("simple-quadratic", storage, directions).unwrap();
+        let study = create_study("simple-quadratic", storage, directions).unwrap();
 
         let sampler = Arc::new(Mutex::new(TpeSampler::new()));
         study
@@ -521,7 +521,7 @@ mod tests {
     fn test_multi_objective() {
         let storage = InMemoryStorage::new();
         let directions = vec![Direction::Minimize, Direction::Minimize];
-        let mut study = create_study("simple-bi-objective", storage, directions).unwrap();
+        let study = create_study("simple-bi-objective", storage, directions).unwrap();
 
         let sampler = Arc::new(Mutex::new(TpeSampler::new()));
         study

--- a/rustuna_storages/src/sqlite3.rs
+++ b/rustuna_storages/src/sqlite3.rs
@@ -2169,7 +2169,7 @@ mod tests {
         storage.create_database()?;
         let storage = CachedStorage::new(Box::new(storage));
 
-        let mut study = create_study("simple-quadratic", storage, vec![Direction::Minimize])?;
+        let study = create_study("simple-quadratic", storage, vec![Direction::Minimize])?;
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         study.optimize(
             |mut t| {


### PR DESCRIPTION
This PR updates `Study` APIs to take `&self` instead of `&mut self` where exclusive access is not required.

- Relax Study method receivers from `&mut self` to `&self`
- Use shared references for Study operations across core and bindings