### PR TITLE
Follow-up #78: fix mkdocs.yml

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
       - rustuna.Distribution: api/distribution.md
 
 markdown_extensions:
+  - attr_list
   - admonition
   - pymdownx.arithmatex:
       generic: true
@@ -62,4 +63,3 @@ markdown_extensions:
 extra_javascript:
   - javascripts/mathjax.js
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
-  - attr_list


### PR DESCRIPTION
Follow up #78 

Move `attr_list` to `markdown_extensions` section.