### PR TITLE
Align study and trial accessors with Optuna-style names

### DIFF
--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -113,7 +113,7 @@ class Trial:
     instantiation of this object.
     """
 
-    id: int
+    _trial_id: int
     number: int
     study_id: int
 
@@ -443,10 +443,10 @@ class Study:
     ) -> list[PersistedTrial]:
         """Return trials in the study filtered by states if specified."""
     @property
-    def id(self) -> int:
+    def _study_id(self) -> int:
         """Return the study ID."""
     @property
-    def name(self) -> str:
+    def study_name(self) -> str:
         """Return the study name."""
     @property
     def directions(self) -> list[StudyDirection]:
@@ -465,7 +465,7 @@ class Study:
     def best_trials(self) -> list[PersistedTrial]:
         """Return the Pareto front trials in the multi-objective study."""
     @property
-    def storage(self) -> StorageProtocol:
+    def _storage(self) -> StorageProtocol:
         """Return the storage object."""
     @property
     def sampler(self) -> SamplerProtocol:

--- a/rustuna_pyo3/rustuna/converter/_storage.py
+++ b/rustuna_pyo3/rustuna/converter/_storage.py
@@ -57,17 +57,12 @@ class ToRustunaStorage:
         )
 
     def create_new_trial(
-        self,
-        study_id: int,
-        template_trial: rustuna.PersistedTrial | None = None,
+        self, study_id: int, template_trial: rustuna.PersistedTrial | None = None
     ) -> rustuna.PersistedTrial:
-        if template_trial is None:
-            trial_id = self._storage.create_new_trial(study_id)
-        else:
-            frozen_trial = to_frozen_trial(template_trial)
-            trial_id = self._storage.create_new_trial(
-                study_id, template_trial=frozen_trial
-            )
+        template_frozen = to_frozen_trial(template_trial) if template_trial else None
+        trial_id = self._storage.create_new_trial(
+            study_id, template_trial=template_frozen
+        )
         trial = self._storage.get_trial(trial_id)
         with self._lock:
             self._trial_id_to_study_id[trial_id] = study_id

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -616,17 +616,17 @@ impl PyStudy {
         Ok(user_attrs)
     }
 
-    #[getter]
+    #[getter(_study_id)]
     pub fn id(&self) -> u32 {
         self.study.id
     }
 
-    #[getter]
+    #[getter(study_name)]
     pub fn name(&self) -> &str {
         &self.study.name
     }
 
-    #[getter]
+    #[getter(_storage)]
     pub fn storage<'py>(&self, py: Python<'py>) -> Py<PyAny> {
         self.storage_pyobj.clone_ref(py)
     }

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -77,7 +77,7 @@ impl PyTrial {
 }
 #[pymethods]
 impl PyTrial {
-    #[getter]
+    #[getter(_trial_id)]
     pub fn id(&self) -> PyResult<u32> {
         Ok(self.trial.id)
     }

--- a/rustuna_pyo3/tests/storage_tests/test_journal_storage.py
+++ b/rustuna_pyo3/tests/storage_tests/test_journal_storage.py
@@ -18,7 +18,7 @@ def test_reading_trials_after_late_user_attr_write_keeps_trials_readable() -> No
 
         trial = study.ask()
         storage.set_trial_user_attrs(
-            trial.id,
+            trial._trial_id,
             {
                 "x": "1",
                 "y": "2",
@@ -28,7 +28,7 @@ def test_reading_trials_after_late_user_attr_write_keeps_trials_readable() -> No
 
         with pytest.raises(rustuna.exceptions.UpdateFinishedTrialError):
             storage.set_trial_user_attrs(
-                trial.id,
+                trial._trial_id,
                 {
                     "x": "1",
                     "y": "2",

--- a/rustuna_pyo3/tests/storage_tests/test_schema_compatibility.py
+++ b/rustuna_pyo3/tests/storage_tests/test_schema_compatibility.py
@@ -124,8 +124,8 @@ def test_rustuna_api_resume_with_compat_storage(
         # TODO: Uncomment following line to align Rustuna Study to Optuna behavior.
         # assert len(first_study.trials) == len(second_study.trials) == 20
         assert (
-            len(first_storage.get_trials(study_id=first_study.id))
-            == len(second_storage.get_trials(study_id=first_study.id))
+            len(first_storage.get_trials(study_id=first_study._study_id))
+            == len(second_storage.get_trials(study_id=first_study._study_id))
             == 20
         )
 

--- a/rustuna_pyo3/tests/test_rustuna.py
+++ b/rustuna_pyo3/tests/test_rustuna.py
@@ -9,15 +9,15 @@ def test_load_study_with_trial_queue():
 
     template = rustuna.PersistedTrial(
         trial_id=0,
-        study_id=created.id,
+        study_id=created._study_id,
         number=0,
         state=rustuna.TrialState.WAITING,
         system_attrs={"fixed_params:x": "f:0x4014000000000000"},
     )
-    trial = storage.create_new_trial(created.id, template)
+    trial = storage.create_new_trial(created._study_id, template)
 
     queue = rustuna.TrialQueue.in_memory()
-    queue.push(trial.id)
+    queue.push(trial._trial_id)
 
     loaded = rustuna.load_study(
         study_name="queued-study",
@@ -166,12 +166,12 @@ def test_optimize_multi_objective():
 def test_study():
     study = rustuna.create_study(study_name="example")
 
-    assert study.name == "example"
+    assert study.study_name == "example"
 
     study.set_user_attr("key", "value")
     assert study.user_attrs == {"key": "value"}
 
-    assert len(study.storage.get_studies()) == 1
+    assert len(study._storage.get_studies()) == 1
 
 
 def test_create_study_load_if_exists_true():
@@ -188,7 +188,7 @@ def test_create_study_load_if_exists_true():
         load_if_exists=True,
     )
 
-    assert first.id == second.id
+    assert first._study_id == second._study_id
     assert second.directions == [rustuna.StudyDirection.MINIMIZE]
 
 
@@ -212,7 +212,7 @@ def test_copy_study():
         study_name="copy-source",
         directions=["maximize", "minimize"],
     )
-    from_study.storage.set_study_system_attrs(from_study.id, {"sys": "value"})
+    from_study._storage.set_study_system_attrs(from_study._study_id, {"sys": "value"})
     from_study.set_user_attr("user", "value")
     from_study.optimize(
         lambda trial: (
@@ -229,12 +229,12 @@ def test_copy_study():
     )
     to_study = rustuna.load_study(study_name="copy-source", storage=to_storage)
 
-    assert to_study.name == from_study.name
+    assert to_study.study_name == from_study.study_name
     assert to_study.directions == from_study.directions
     assert to_study.user_attrs == from_study.user_attrs
     assert (
-        to_study.storage.get_study(to_study.id).system_attrs
-        == from_study.storage.get_study(from_study.id).system_attrs
+        to_study._storage.get_study(to_study._study_id).system_attrs
+        == from_study._storage.get_study(from_study._study_id).system_attrs
     )
     assert len(to_study.trials) == len(from_study.trials)
 
@@ -355,9 +355,9 @@ def test_sample():
         study = rustuna.create_study(sampler=sampler, storage=storage)
         trial = study.ask()
         ctx = rustuna.SamplerContext(
-            study_id=study.id,
+            study_id=study._study_id,
             trial_number=trial.number,
-            trial_id=trial.id,
+            trial_id=trial._trial_id,
             directions=study.directions,
         )
         value = sampler.sample_independent(


### PR DESCRIPTION
To prioritize the compatibility with Optuna, this PR updates accessors of Study and Trial classes.