### PR TITLE
Add `set_user_attrs` method for bulk inserts

### DIFF
--- a/rustuna_core/src/trial.rs
+++ b/rustuna_core/src/trial.rs
@@ -228,6 +228,26 @@ impl Trial {
         self.cached_trial.attrs.insert(key, value);
         Ok(())
     }
+
+    pub fn set_user_attrs(&mut self, user_attrs: HashMap<String, String>) -> Result<()> {
+        let mut attrs = Attrs::with_capacity(user_attrs.len());
+        for (key, value) in &user_attrs {
+            attrs.insert(AttrKey::User(key.as_str().into()), value.clone());
+        }
+        let mut guard = self
+            .storage
+            .write()
+            .map_err(|_| Error::new(ErrorKind::StorageError))?;
+        guard.set_trial_attrs(self.id, attrs, false)?;
+        drop(guard);
+
+        for (key, value) in user_attrs {
+            self.cached_trial
+                .attrs
+                .insert(AttrKey::User(key.into()), value);
+        }
+        Ok(())
+    }
 }
 
 /// PersistedTrial is a struct that represents a trial that has been persisted to storage.

--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -176,9 +176,21 @@ class Trial:
     def set_user_attr(self, key: str, value: str) -> None:
         """Set a user attribute to the trial.
 
+        .. note::
+            Unlike Optuna, Rustuna accepts only str values for user attributes.
+
         Args:
             key: A key string of the attribute.
             value: A value of the attribute. The value should be JSON serializable.
+        """
+    def set_user_attrs(self, attrs: dict[str, str]) -> None:
+        """Set user attributes to the trial.
+
+        .. note::
+            Unlike Optuna, Rustuna accepts only str values for user attributes.
+
+        Args:
+            attrs: A dictionary object.
         """
 
 class AttrsDictView(Mapping[str, str]):
@@ -410,7 +422,7 @@ class Study:
         key: str,
         value: str,
     ) -> None:
-        """Set user attributes to the study.
+        """Set a user attribute to the study.
 
         .. note::
             Unlike Optuna, Rustuna accepts only str values for user attributes.
@@ -424,13 +436,34 @@ class Study:
 
                 import rustuna
 
-                def objective(trial):
-                    x = trial.suggest_float("x", 0, 1)
-                    y = trial.suggest_float("y", 0, 1)
-                    return x**2 + y**2
-
                 study = rustuna.create_study()
                 study.set_user_attr("objective function", "quadratic function")
+
+                assert study.user_attrs == {
+                    "objective function": "quadratic function",
+                }
+        """
+    def set_user_attrs(
+        self,
+        attrs: dict[str, str],
+    ) -> None:
+        """Set user attributes to the study.
+
+        .. note::
+            Unlike Optuna, Rustuna accepts only str values for user attributes.
+
+        Args:
+            attrs: A dictionary object.
+
+        Example:
+            .. code-block:: python
+
+                import rustuna
+
+                study = rustuna.create_study()
+                study.set_user_attrs({
+                    "objective function", "quadratic function"
+                })
 
                 assert study.user_attrs == {
                     "objective function": "quadratic function",

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -517,16 +517,26 @@ impl PyStudy {
     pub fn set_user_attr(&self, key: String, value: String) -> PyResult<()> {
         let mut attrs = rustuna_core::attr::Attrs::new();
         attrs.insert(AttrKey::User(key.into()), value);
-        let mut guard = self
-            .study
-            .storage
-            .write()
-            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
+        let mut guard = self.study.storage.write().map_err(|e| {
+            PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
+        })?;
         guard
             .set_study_attrs(self.study.id, attrs, false)
-            .map_err(|e| {
-                PyRuntimeError::new_err(format!("Failed to set user attrs: {:?}", e.kind))
-            })?;
+            .map_err(err_to_exceptions)?;
+        Ok(())
+    }
+
+    fn set_user_attrs(&mut self, attrs: Py<PyAny>) -> PyResult<()> {
+        let user_attrs = Python::attach(|py| {
+            let attrs = attrs.bind(py);
+            pyobj_to_attrs_with_kind(attrs, AttrKind::User)
+        })?;
+        let mut guard = self.study.storage.write().map_err(|e| {
+            PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
+        })?;
+        guard
+            .set_study_attrs(self.study.id, user_attrs, false)
+            .map_err(err_to_exceptions)?;
         Ok(())
     }
 

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -169,13 +169,30 @@ impl PyTrial {
     }
     #[pyo3(signature = (key, value))]
     pub fn set_user_attr(&mut self, key: &str, value: String) -> PyResult<()> {
-        let mut cache = self.cached_user_attrs.write().map_err(|_| {
-            PyRuntimeError::new_err("Failed to acquire write lock for cached_user_attrs")
-        })?;
         self.trial.set_user_attr(key, value.clone()).map_err(|e| {
             PyRuntimeError::new_err(format!("Failed to set user attr: {:?}", e.kind))
         })?;
+
+        let mut cache = self.cached_user_attrs.write().map_err(|_| {
+            PyRuntimeError::new_err("Failed to acquire write lock for cached_user_attrs")
+        })?;
         cache.insert(key.to_string(), value);
+        Ok(())
+    }
+
+    fn set_user_attrs(&mut self, attrs: Py<PyAny>) -> PyResult<()> {
+        let user_attrs: HashMap<String, String> = Python::attach(|py| attrs.bind(py).extract())?;
+
+        self.trial.set_user_attrs(user_attrs.clone()).map_err(|e| {
+            PyRuntimeError::new_err(format!("Failed to set user attrs: {:?}", e.kind))
+        })?;
+
+        let mut cache = self.cached_user_attrs.write().map_err(|e| {
+            PyRuntimeError::new_err(format!(
+                "Failed to acquire write lock for cached_user_attrs: {e:?}"
+            ))
+        })?;
+        cache.extend(user_attrs);
         Ok(())
     }
 

--- a/rustuna_pyo3/tests/test_rustuna.py
+++ b/rustuna_pyo3/tests/test_rustuna.py
@@ -52,8 +52,10 @@ def test_optimize():
         assert -5.0 <= x <= 5.0
         assert 0 <= y <= 10
         assert z in ["foo", "bar"]
-        trial.set_user_attr("key", "value")
-        assert trial.user_attrs == {"key": "value"}
+        trial.set_user_attr("key1", "value1")
+        assert trial.user_attrs == {"key1": "value1"}
+        trial.set_user_attrs({"key1": "updated", "key2": "value2"})
+        assert trial.user_attrs == {"key1": "updated", "key2": "value2"}
         return x * 2 + y
 
     study.optimize(objective, n_trials=10)
@@ -168,8 +170,10 @@ def test_study():
 
     assert study.study_name == "example"
 
-    study.set_user_attr("key", "value")
-    assert study.user_attrs == {"key": "value"}
+    study.set_user_attr("key1", "value1")
+    assert study.user_attrs == {"key1": "value1"}
+    study.set_user_attrs({"key1": "updated", "key2": "value2"})
+    assert study.user_attrs == {"key1": "updated", "key2": "value2"}
 
     assert len(study._storage.get_studies()) == 1
 


### PR DESCRIPTION
Rustuna's storage api supports bulk inserts for study/trial attributes, but Study and Trial classes do not provide the methods for that. This PR adds `set_user_attrs(attrs: dict[str, str]) -> None`, so that users can create multiple attributes efficiently.