### PR TITLE
Follow-up #86: Fix docstring and stub for `PersistedTrial` class

### DIFF
--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -227,11 +227,9 @@ class TrialState(enum.IntEnum):
 class PersistedTrial:
     """Status and results of a Trial.
 
-    This object has the same methods as :class:`Trial`, but is not associated with,
-    nor has any references to a :class:`Study`.
-
     Attributes:
         number: Unique and consecutive number of Trial for each Study.
+        study_id: An associated study's id.
         state: TrialState of the Trial.
         values: Sequence of objective values of the Trial.
         value: An objective value of the Trial (only available when single objective optimization).
@@ -258,8 +256,6 @@ class PersistedTrial:
         datetime_start: datetime.datetime | None = None,
         datetime_complete: datetime.datetime | None = None,
     ) -> None: ...
-    @property
-    def id(self) -> int: ...
     @property
     def _trial_id(self) -> int: ...
     @property

--- a/rustuna_pyo3/rustuna/converter/_storage.py
+++ b/rustuna_pyo3/rustuna/converter/_storage.py
@@ -255,7 +255,7 @@ class ToOptunaStorage(BaseStorage):
                     )
             persisted_trial_template = to_persisted_trial(template_trial, study_id)
         trial = self._storage.create_new_trial(study_id, persisted_trial_template)
-        return trial.id
+        return trial._trial_id
 
     def set_trial_param(
         self,
@@ -338,13 +338,13 @@ class ToOptunaStorage(BaseStorage):
         for t in rustuna_trials:
             if rustuna_states is not None and t.state not in rustuna_states:
                 continue
-            cached = self._trial_cache.get(t.id)
+            cached = self._trial_cache.get(t._trial_id)
             if cached is not None:
                 trials.append(cached)
             else:
                 frozen = FrozenTrialLike(t)
                 if t.state.is_finished():
-                    self._trial_cache[t.id] = frozen
+                    self._trial_cache[t._trial_id] = frozen
                 trials.append(frozen)
         if deepcopy:
             return copy.deepcopy(trials)

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -388,17 +388,12 @@ impl PyPersistedTrial {
         Ok(PyPersistedTrial::new(trial, study_attrs))
     }
 
-    #[getter]
+    #[getter(_trial_id)]
     fn id(&self) -> PyResult<u32> {
         match &self.source {
             PyPersistedTrialSource::Owned(trial) => Ok(trial.id),
             PyPersistedTrialSource::StorageBacked { trial_id, .. } => Ok(*trial_id),
         }
-    }
-
-    #[getter]
-    fn _trial_id(&self) -> PyResult<u32> {
-        self.id()
     }
 
     #[getter]


### PR DESCRIPTION
This PR includes:

* remove `id` field, which was renamed to `_trial_id` in #86.
* update the docstring of `PersistedTrial` class.
