### PR TITLE
Update installation section of the Getting started page

### DIFF
--- a/docs/docs/tutorial/getting-started.md
+++ b/docs/docs/tutorial/getting-started.md
@@ -4,7 +4,7 @@ This guide will help you get started with Rustuna.
 
 ## Installation
 
-Rustuna supports Python 3.9 or newer. You can install Rustuna via pip:
+Rustuna supports Python 3.9 or newer. You can install Rustuna via pip. Unlike Optuna, Rustuna doesn't have runtime dependencies, not even on NumPy. This not only eliminates concerns of version conflicts for users but also significantly speeds up imports.
 
 ```sh
 $ pip install rustuna


### PR DESCRIPTION
Update the installation section of the Getting Started page to emphasize that Rustuna has no Python runtime dependencies.