### PR TITLE
Remove `storage.get_tria_attr` method

### DIFF
--- a/rustuna_core/src/storage.rs
+++ b/rustuna_core/src/storage.rs
@@ -39,7 +39,6 @@ pub trait Storage: Send + Sync {
     fn get_studies(&mut self) -> Result<&Vec<PersistedStudy>>;
     fn get_study(&mut self, study_id: u32) -> Result<&PersistedStudy>;
     fn get_study_attr(&mut self, study_id: u32, key: AttrKey) -> Result<String>;
-    fn get_trial_attr(&mut self, trial_id: u32, key: AttrKey) -> Result<String>;
     fn get_trials(&mut self, study_id: u32) -> Result<&Vec<PersistedTrial>>;
     fn get_trial(&mut self, trial_id: u32) -> Result<&PersistedTrial>;
     // Design Note:
@@ -341,15 +340,6 @@ impl Storage for InMemoryStorage {
             .ok_or(Error::new(ErrorKind::AttrNotFound))
     }
 
-    fn get_trial_attr(&mut self, trial_id: u32, key: AttrKey) -> Result<String> {
-        let trial = self.get_trial(trial_id)?;
-        trial
-            .attrs
-            .get(&key)
-            .cloned()
-            .ok_or(Error::new(ErrorKind::AttrNotFound))
-    }
-
     fn get_trials(&mut self, study_id: u32) -> Result<&Vec<PersistedTrial>> {
         get_trials_by_study_id(&self.trials, study_id)
     }
@@ -567,23 +557,6 @@ mod tests {
     }
 
     #[test]
-    fn get_trial_attr_returns_stored_value() -> Result<()> {
-        let mut storage = InMemoryStorage::new();
-        let study_id = storage
-            .create_new_study("study", vec![Direction::Minimize])?
-            .id;
-        let trial_id = storage.create_new_trial(study_id)?.id;
-        let key = AttrKey::User("owner".into());
-        let mut attrs = Attrs::new();
-        attrs.insert(key.clone(), "bob".to_string());
-        storage.set_trial_attrs(trial_id, attrs, false)?;
-
-        let value = storage.get_trial_attr(trial_id, key)?;
-        assert_eq!(value, "bob");
-        Ok(())
-    }
-
-    #[test]
     fn get_study_attr_returns_error_for_missing_key() -> Result<()> {
         let mut storage = InMemoryStorage::new();
         let study_id = storage
@@ -592,21 +565,6 @@ mod tests {
 
         let err = storage
             .get_study_attr(study_id, AttrKey::User("missing".into()))
-            .unwrap_err();
-        assert!(matches!(err.kind, ErrorKind::AttrNotFound));
-        Ok(())
-    }
-
-    #[test]
-    fn get_trial_attr_returns_error_for_missing_key() -> Result<()> {
-        let mut storage = InMemoryStorage::new();
-        let study_id = storage
-            .create_new_study("study", vec![Direction::Minimize])?
-            .id;
-        let trial_id = storage.create_new_trial(study_id)?.id;
-
-        let err = storage
-            .get_trial_attr(trial_id, AttrKey::User("missing".into()))
             .unwrap_err();
         assert!(matches!(err.kind, ErrorKind::AttrNotFound));
         Ok(())

--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -727,26 +727,6 @@ class StorageProtocol(Protocol):
         Returns:
             The attribute value as a string.
         """
-    def get_trial_user_attr(self, trial_id: int, key: str) -> str:
-        """Get a single user attribute of a trial.
-
-        Args:
-            trial_id: ID of the trial.
-            key: Attribute key.
-
-        Returns:
-            The attribute value as a string.
-        """
-    def get_trial_system_attr(self, trial_id: int, key: str) -> str:
-        """Get a single system attribute of a trial.
-
-        Args:
-            trial_id: ID of the trial.
-            key: Attribute key.
-
-        Returns:
-            The attribute value as a string.
-        """
     def get_trial_id_from_study_id_trial_number(
         self, study_id: int, trial_number: int
     ) -> int:
@@ -910,8 +890,6 @@ class Storage:
     ) -> int: ...
     def get_study_user_attr(self, study_id: int, key: str) -> str: ...
     def get_study_system_attr(self, study_id: int, key: str) -> str: ...
-    def get_trial_user_attr(self, trial_id: int, key: str) -> str: ...
-    def get_trial_system_attr(self, trial_id: int, key: str) -> str: ...
     def set_study_system_attrs(self, study_id: int, attrs: dict[str, str]) -> None: ...
     def set_study_user_attrs(self, study_id: int, attrs: dict[str, str]) -> None: ...
     def set_trial_system_attrs(self, trial_id: int, attrs: dict[str, str]) -> None: ...

--- a/rustuna_pyo3/rustuna/converter/_storage.py
+++ b/rustuna_pyo3/rustuna/converter/_storage.py
@@ -169,16 +169,6 @@ class ToRustunaStorage:
         value = self._storage.get_study_system_attrs(study_id)[key]
         return json.dumps(value) if not isinstance(value, str) else value
 
-    def get_trial_user_attr(self, trial_id: int, key: str) -> str:
-        trial = self._storage.get_trial(trial_id)
-        value = trial.user_attrs[key]
-        return json.dumps(value) if not isinstance(value, str) else value
-
-    def get_trial_system_attr(self, trial_id: int, key: str) -> str:
-        trial = self._storage.get_trial(trial_id)
-        value = trial.system_attrs[key]
-        return json.dumps(value) if not isinstance(value, str) else value
-
     def set_category_labels(
         self,
         study_id: int,

--- a/rustuna_pyo3/src/pyobject_storage.rs
+++ b/rustuna_pyo3/src/pyobject_storage.rs
@@ -545,11 +545,6 @@ impl Storage for PyObjectStorage {
         self.cache.get_study_attr(study_id, key)
     }
 
-    fn get_trial_attr(&mut self, trial_id: u32, key: AttrKey) -> rustuna_core::Result<String> {
-        self.sync_all_trials()?;
-        self.cache.get_trial_attr(trial_id, key)
-    }
-
     fn get_cached_trial(
         &self,
         trial_id: u32,

--- a/rustuna_pyo3/src/storage.rs
+++ b/rustuna_pyo3/src/storage.rs
@@ -319,24 +319,6 @@ impl PyStorage {
             .map_err(err_to_exceptions)
     }
 
-    fn get_trial_user_attr(&mut self, trial_id: u32, key: String) -> PyResult<String> {
-        let mut guard = self.storage.write().map_err(|e| {
-            PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
-        })?;
-        guard
-            .get_trial_attr(trial_id, AttrKey::User(key.into()))
-            .map_err(err_to_exceptions)
-    }
-
-    fn get_trial_system_attr(&mut self, trial_id: u32, key: String) -> PyResult<String> {
-        let mut guard = self.storage.write().map_err(|e| {
-            PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
-        })?;
-        guard
-            .get_trial_attr(trial_id, AttrKey::System(key.into()))
-            .map_err(err_to_exceptions)
-    }
-
     fn get_trial_id_from_study_id_trial_number(
         &mut self,
         study_id: u32,

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -678,10 +678,16 @@ impl PyPersistedTrial {
             PyPersistedTrialSource::StorageBacked {
                 storage, trial_id, ..
             } => {
-                let mut guard = storage.write().map_err(|e| {
+                let guard = storage.read().map_err(|e| {
                     PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
                 })?;
-                guard.get_trial_attr(*trial_id, AttrKey::User(key.into()))
+                guard.get_cached_trial(*trial_id).and_then(|trial| {
+                    trial
+                        .attrs
+                        .get(&AttrKey::User(key.into()))
+                        .cloned()
+                        .ok_or(rustuna_core::Error::new(ErrorKind::AttrNotFound))
+                })
             }
         };
         match result {

--- a/rustuna_pyo3/tests/storage_tests/test_storage.py
+++ b/rustuna_pyo3/tests/storage_tests/test_storage.py
@@ -89,40 +89,6 @@ def test_study_get_user_attr_method(storage: StorageProtocol) -> None:
     assert study.get_user_attr("not_found", default=1) == 1
 
 
-def test_get_trial_attr_methods(storage: StorageProtocol) -> None:
-    study = storage.create_new_study(
-        "example study", [rustuna.study.StudyDirection.MINIMIZE]
-    )
-    trial = storage.create_new_trial(study.id)
-    storage.set_trial_user_attrs(
-        trial._trial_id,
-        {
-            "trial_user_attr": "trial_user_attr",
-        },
-    )
-    storage.set_trial_system_attrs(
-        trial._trial_id,
-        {
-            "trial_system_attr": "trial_system_attr",
-        },
-    )
-    assert (
-        storage.get_trial_user_attr(trial._trial_id, "trial_user_attr")
-        == "trial_user_attr"
-    )
-    assert (
-        storage.get_trial_system_attr(trial._trial_id, "trial_system_attr")
-        == "trial_system_attr"
-    )
-    storage.set_trial_user_attrs(
-        trial._trial_id,
-        {
-            "trial_user_attr": "updated",
-        },
-    )
-    assert storage.get_trial_user_attr(trial._trial_id, "trial_user_attr") == "updated"
-
-
 def test_trial_get_user_attr_method(storage: StorageProtocol) -> None:
     study = rustuna.create_study(storage=storage)
     trial = study.ask()

--- a/rustuna_storages/src/cache.rs
+++ b/rustuna_storages/src/cache.rs
@@ -45,7 +45,6 @@ pub trait CachedStorageBackend: Send + Sync {
     fn get_study(&mut self, study_id: u32) -> Result<PersistedStudy>;
     fn get_trial(&mut self, trial_id: u32) -> Result<PersistedTrial>;
     fn get_study_attr(&mut self, study_id: u32, key: AttrKey) -> Result<String>;
-    fn get_trial_attr(&mut self, trial_id: u32, key: AttrKey) -> Result<String>;
     fn set_study_attrs(
         &mut self,
         study_id: u32,
@@ -409,18 +408,6 @@ impl rustuna_core::storage::Storage for CachedStorage {
         self.backend.get_study_attr(study_id, key)
     }
 
-    fn get_trial_attr(&mut self, trial_id: u32, key: AttrKey) -> Result<String> {
-        if self.trial_id_to_study_number.contains_key(&trial_id) {
-            self.get_cached_trial(trial_id)?
-                .attrs
-                .get(&key)
-                .cloned()
-                .ok_or_else(|| Error::new(ErrorKind::AttrNotFound))
-        } else {
-            self.backend.get_trial_attr(trial_id, key)
-        }
-    }
-
     fn get_cached_trial(&self, trial_id: u32) -> Result<&PersistedTrial> {
         let (study_id, trial_number) = self
             .trial_id_to_study_number
@@ -673,10 +660,6 @@ mod tests {
 
         fn get_study_attr(&mut self, study_id: u32, key: AttrKey) -> Result<String> {
             self.inner.get_study_attr(study_id, key)
-        }
-
-        fn get_trial_attr(&mut self, trial_id: u32, key: AttrKey) -> Result<String> {
-            self.inner.get_trial_attr(trial_id, key)
         }
 
         fn set_study_attrs(

--- a/rustuna_storages/src/journal/storage.rs
+++ b/rustuna_storages/src/journal/storage.rs
@@ -470,15 +470,6 @@ impl Storage for JournalStorage {
             .ok_or(Error::new(ErrorKind::AttrNotFound))
     }
 
-    fn get_trial_attr(&mut self, trial_id: u32, key: AttrKey) -> Result<String> {
-        let trial = self.get_trial(trial_id)?;
-        trial
-            .attrs
-            .get(&key)
-            .cloned()
-            .ok_or(Error::new(ErrorKind::AttrNotFound))
-    }
-
     fn get_cached_trial(&self, trial_id: u32) -> Result<&PersistedTrial> {
         let (study_id, trial_number) = self
             .replay

--- a/rustuna_storages/src/sqlite3.rs
+++ b/rustuna_storages/src/sqlite3.rs
@@ -839,32 +839,6 @@ impl CachedStorageBackend for SQLite3Storage {
             .ok_or(Error::new(ErrorKind::AttrNotFound))
     }
 
-    fn get_trial_attr(
-        &mut self,
-        trial_id: u32,
-        key: rustuna_core::attr::AttrKey,
-    ) -> rustuna_core::Result<String> {
-        let guard = self
-            .conn
-            .lock()
-            .map_err(|_| Error::new(ErrorKind::StorageError))?;
-        let (table, key_str) = match &key {
-            AttrKey::User(k) => ("trial_user_attributes", k.as_str()),
-            AttrKey::System(k) => ("trial_system_attributes", k.as_str()),
-        };
-        let sql = format!("SELECT value_json FROM {table} WHERE trial_id = ? AND key = ?");
-        guard
-            .query_row(&sql, params![trial_id, key_str], |row| row.get(0))
-            .optional()
-            .map_err(|e| {
-                Error::with_reason(
-                    ErrorKind::StorageError,
-                    format!("Database query failed: {e}"),
-                )
-            })?
-            .ok_or(Error::new(ErrorKind::AttrNotFound))
-    }
-
     fn set_study_attrs(
         &mut self,
         study_id: u32,


### PR DESCRIPTION
`get_trial_attr` was originally introduced as a possible fast path for reading a single trial attribute without going through full trial access. In practice, this optimization does not provide a meaningful benefit in Rustuna's current
  storage design, because all built-in storage implementations already keep `PersistedTrial` objects cached in memory.