### PR TITLE
Add sampler field to `rustuna_core::Study`

### DIFF
--- a/rustuna_core/src/sampler.rs
+++ b/rustuna_core/src/sampler.rs
@@ -162,8 +162,6 @@ impl Sampler for RandomSampler {
 mod tests {
     use super::*;
 
-    use std::sync::Mutex;
-
     use crate::storage::InMemoryStorage;
     use crate::study::create_study;
     use crate::trial::Trial;
@@ -205,9 +203,13 @@ mod tests {
     #[test]
     fn test_joint_sampling_empty() -> Result<()> {
         let joint_params = HashMap::new();
-        let sampler = Arc::new(Mutex::new(DummyJointSampler { joint_params }));
-        let study = create_study("dummy", InMemoryStorage::new(), vec![Direction::Minimize])?;
-        study.optimize(objective, sampler, 2)?;
+        let study = create_study(
+            "dummy",
+            InMemoryStorage::new(),
+            DummyJointSampler { joint_params },
+            vec![Direction::Minimize],
+        )?;
+        study.optimize(objective, 2)?;
         Ok(())
     }
 
@@ -216,9 +218,13 @@ mod tests {
         let mut joint_params = HashMap::new();
         joint_params.insert(String::from("x"), 0.5);
 
-        let sampler = Arc::new(Mutex::new(DummyJointSampler { joint_params }));
-        let study = create_study("dummy", InMemoryStorage::new(), vec![Direction::Minimize])?;
-        study.optimize(objective, sampler, 2)?;
+        let study = create_study(
+            "dummy",
+            InMemoryStorage::new(),
+            DummyJointSampler { joint_params },
+            vec![Direction::Minimize],
+        )?;
+        study.optimize(objective, 2)?;
 
         let trials = study.get_trials()?;
         assert_eq!(trials.len(), 2);
@@ -233,9 +239,13 @@ mod tests {
         joint_params.insert(String::from("x"), 1.0);
         joint_params.insert(String::from("y"), 1.0);
 
-        let sampler = Arc::new(Mutex::new(DummyJointSampler { joint_params }));
-        let study = create_study("dummy", InMemoryStorage::new(), vec![Direction::Minimize])?;
-        study.optimize(objective, sampler, 2)?;
+        let study = create_study(
+            "dummy",
+            InMemoryStorage::new(),
+            DummyJointSampler { joint_params },
+            vec![Direction::Minimize],
+        )?;
+        study.optimize(objective, 2)?;
 
         let trials = study.get_trials()?;
         assert_eq!(trials.len(), 2);

--- a/rustuna_core/src/study.rs
+++ b/rustuna_core/src/study.rs
@@ -9,24 +9,30 @@ use crate::trial::{PersistedTrial, Trial, TrialStateValues};
 use crate::trial_queue::{InMemoryTrialQueue, TrialQueue};
 use crate::{Error, ErrorKind, Result};
 
-pub fn create_study<S: Storage + Send + Sync + 'static>(
+pub fn create_study<S: Storage + Send + Sync + 'static, T: Sampler + Send + 'static>(
     study_name: &str,
     mut storage: S,
+    sampler: T,
     directions: Vec<Direction>,
 ) -> Result<Study> {
     let study_id = storage.create_new_study(study_name, directions.clone())?.id;
     let storage = Arc::new(RwLock::new(storage));
+    let sampler: Arc<Mutex<dyn Sampler>> = Arc::new(Mutex::new(sampler));
+    let queue = Arc::new(RwLock::new(InMemoryTrialQueue::new()));
     Ok(Study::new(
         study_id,
         study_name.to_string(),
         directions,
         storage,
+        sampler,
+        queue,
     ))
 }
 
 pub fn create_study_with_arc(
     study_name: &str,
     storage: Arc<RwLock<dyn Storage>>,
+    sampler: Arc<Mutex<dyn Sampler>>,
     directions: Vec<Direction>,
 ) -> Result<Study> {
     let mut guard = storage
@@ -34,11 +40,14 @@ pub fn create_study_with_arc(
         .map_err(|_e| Error::new(ErrorKind::Unexpected))?;
     let study_id = guard.create_new_study(study_name, directions.clone())?.id;
     drop(guard);
+    let queue = Arc::new(RwLock::new(InMemoryTrialQueue::new()));
     Ok(Study::new(
         study_id,
         study_name.to_string(),
         directions,
         storage,
+        sampler,
+        queue,
     ))
 }
 
@@ -48,6 +57,7 @@ pub struct Study {
     pub name: String,
     pub directions: Vec<Direction>,
     pub storage: Arc<RwLock<dyn Storage>>,
+    pub sampler: Arc<Mutex<dyn Sampler>>,
     pub queue: Arc<RwLock<dyn TrialQueue>>,
 }
 impl Study {
@@ -56,22 +66,7 @@ impl Study {
         name: String,
         directions: Vec<Direction>,
         storage: Arc<RwLock<dyn Storage>>,
-    ) -> Self {
-        let queue = Arc::new(RwLock::new(InMemoryTrialQueue::new()));
-        Study {
-            id,
-            name,
-            directions,
-            storage,
-            queue,
-        }
-    }
-
-    pub fn with_queue(
-        id: u32,
-        name: String,
-        directions: Vec<Direction>,
-        storage: Arc<RwLock<dyn Storage>>,
+        sampler: Arc<Mutex<dyn Sampler>>,
         queue: Arc<RwLock<dyn TrialQueue>>,
     ) -> Self {
         Study {
@@ -79,11 +74,16 @@ impl Study {
             name,
             directions,
             storage,
+            sampler,
             queue,
         }
     }
 
-    pub fn from_id(id: u32, storage: Arc<RwLock<dyn Storage>>) -> Result<Self> {
+    pub fn from_id(
+        id: u32,
+        storage: Arc<RwLock<dyn Storage>>,
+        sampler: Arc<Mutex<dyn Sampler>>,
+    ) -> Result<Self> {
         let mut guard = storage.write().map_err(|e| {
             Error::with_reason(
                 ErrorKind::Unexpected,
@@ -94,10 +94,15 @@ impl Study {
         let name = study.name.clone();
         let directions = study.directions.clone();
         drop(guard);
-        Ok(Study::new(id, name, directions, storage))
+        let queue = Arc::new(RwLock::new(InMemoryTrialQueue::new()));
+        Ok(Study::new(id, name, directions, storage, sampler, queue))
     }
 
-    pub fn from_name(name: String, storage: Arc<RwLock<dyn Storage>>) -> Result<Self> {
+    pub fn from_name(
+        name: String,
+        storage: Arc<RwLock<dyn Storage>>,
+        sampler: Arc<Mutex<dyn Sampler>>,
+    ) -> Result<Self> {
         let mut guard = storage.write().map_err(|e| {
             Error::with_reason(
                 ErrorKind::Unexpected,
@@ -112,10 +117,13 @@ impl Study {
         let study_id = study.id;
         let directions = study.directions.clone();
         drop(guard);
-        Ok(Study::new(study_id, name, directions, storage))
+        let queue = Arc::new(RwLock::new(InMemoryTrialQueue::new()));
+        Ok(Study::new(
+            study_id, name, directions, storage, sampler, queue,
+        ))
     }
 
-    pub fn ask(&self, sampler: Arc<Mutex<dyn Sampler>>) -> Result<Trial> {
+    pub fn ask(&self) -> Result<Trial> {
         let queued_trial_id = {
             let mut queue_guard = self.queue.write().map_err(|e| {
                 Error::with_reason(
@@ -186,6 +194,7 @@ impl Study {
                 )
             };
 
+        let sampler = Arc::clone(&self.sampler);
         let mut guard = sampler
             .lock()
             .map_err(|_| Error::new(ErrorKind::Unexpected))?;
@@ -216,6 +225,8 @@ impl Study {
             HashMap::new()
         };
 
+        drop(guard);
+
         let trial = Trial::new(
             trial_id,
             self.id,
@@ -224,7 +235,7 @@ impl Study {
             datetime_complete,
             self.directions.clone(),
             Arc::clone(&self.storage),
-            sampler.clone(),
+            Arc::clone(&self.sampler),
             joint_params,
             fixed_params,
         );
@@ -241,19 +252,12 @@ impl Study {
         Ok(())
     }
 
-    pub fn optimize<F>(
-        &self,
-        mut objective: F,
-        // TODO(c-bata): Avoid to wrap Sampler by Arc and Mutex.
-        // Sampler does not need to be shared across threads.
-        sampler: Arc<Mutex<dyn Sampler>>,
-        n_trials: usize,
-    ) -> Result<()>
+    pub fn optimize<F>(&self, mut objective: F, n_trials: usize) -> Result<()>
     where
         F: FnMut(Trial) -> Result<Vec<f64>>,
     {
         for _ in 0..n_trials {
-            let trial = self.ask(sampler.clone())?;
+            let trial = self.ask()?;
             let trial_number = trial.number;
 
             // Call an objective function.
@@ -516,9 +520,8 @@ mod tests {
     #[test]
     fn test_optimize() -> Result<()> {
         let storage = InMemoryStorage::new();
-        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let study = create_study("dummy", storage, directions)?;
+        let study = create_study("dummy", storage, RandomSampler::new(), directions)?;
 
         study.optimize(
             |mut t| {
@@ -529,7 +532,6 @@ mod tests {
                 let value = (x - 3.0).powi(2) + (y - 5.0).powi(2) + (z as f64);
                 Ok(vec![value])
             },
-            sampler,
             100,
         )?;
         assert!(get_best_trial(&study).is_ok());
@@ -540,12 +542,11 @@ mod tests {
     fn test_optimize_parallel() -> Result<()> {
         let storage = InMemoryStorage::new();
         let directions = vec![Direction::Minimize];
-        let study = create_study("dummy-study", storage, directions)?;
+        let study = create_study("dummy-study", storage, RandomSampler::new(), directions)?;
 
         thread::scope(|s| {
-            for i in 0..4 {
+            for _i in 0..4 {
                 let study = study.clone();
-                let sampler = Arc::new(Mutex::new(RandomSampler::seed_from_u64(i)));
                 let choices = vec![String::from("foo"), String::from("bar")];
                 s.spawn(move || {
                     study
@@ -558,7 +559,6 @@ mod tests {
                                 let value = (x - 3.0).powi(2) + (y - 5.0).powi(2) + (z as f64);
                                 Ok(vec![value])
                             },
-                            sampler,
                             100,
                         )
                         .expect("Optimization failed");
@@ -573,11 +573,10 @@ mod tests {
     #[test]
     fn test_user_attr() -> Result<()> {
         let storage = InMemoryStorage::new();
-        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let study = create_study("dummy", storage, directions)?;
+        let study = create_study("dummy", storage, RandomSampler::new(), directions)?;
 
-        let mut trial = study.ask(sampler)?;
+        let mut trial = study.ask()?;
         trial.set_user_attr("key", String::from("bar"))?;
         let user_attr = trial
             .get_user_attr("key")
@@ -589,9 +588,8 @@ mod tests {
     #[test]
     fn test_get_best_trial() -> Result<()> {
         let storage = InMemoryStorage::new();
-        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let study = create_study("dummy", storage, directions)?;
+        let study = create_study("dummy", storage, RandomSampler::new(), directions)?;
 
         study.optimize(
             |mut t| {
@@ -602,7 +600,6 @@ mod tests {
                 let value = (x - 3.0).powi(2) + (y - 5.0).powi(2) + (z as f64);
                 Ok(vec![value])
             },
-            sampler,
             100,
         )?;
 
@@ -614,9 +611,8 @@ mod tests {
     #[test]
     fn test_get_pareto_front_trials() -> Result<()> {
         let storage = InMemoryStorage::new();
-        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize, Direction::Maximize];
-        let study = create_study("dummy", storage, directions)?;
+        let study = create_study("dummy", storage, RandomSampler::new(), directions)?;
 
         study.optimize(
             |mut t| {
@@ -628,7 +624,6 @@ mod tests {
                 let value1 = (x - 3.0).powi(2) + (y - 5.0).powi(2) + (z as f64) * 2.0;
                 Ok(vec![value0, value1])
             },
-            sampler,
             100,
         )?;
 
@@ -650,16 +645,14 @@ mod tests {
     #[test]
     fn test_dynamic_search_space() -> Result<()> {
         let storage = InMemoryStorage::new();
-        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let study = create_study("dummy", storage, directions)?;
+        let study = create_study("dummy", storage, RandomSampler::new(), directions)?;
 
         study.optimize(
             |mut t| {
                 t.suggest_float("x", 0.0, 10.0)?;
                 Ok(vec![0.0])
             },
-            sampler.clone(),
             5,
         )?;
         study.optimize(
@@ -667,7 +660,6 @@ mod tests {
                 t.suggest_float("x", 1.0, 10.0)?;
                 Ok(vec![0.0])
             },
-            sampler.clone(),
             5,
         )?;
         Ok(())
@@ -676,16 +668,14 @@ mod tests {
     #[test]
     fn test_invalid_dynamic_search_space() -> Result<()> {
         let storage = InMemoryStorage::new();
-        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let study = create_study("dummy", storage, directions)?;
+        let study = create_study("dummy", storage, RandomSampler::new(), directions)?;
 
         study.optimize(
             |mut t| {
                 t.suggest_float("x", 0.0, 10.0)?;
                 Ok(vec![0.0])
             },
-            sampler.clone(),
             5,
         )?;
         let error = study
@@ -694,7 +684,6 @@ mod tests {
                     t.suggest_int("x", 0, 10)?;
                     Ok(vec![0.0])
                 },
-                sampler.clone(),
                 5,
             )
             .unwrap_err();
@@ -706,7 +695,7 @@ mod tests {
     fn test_add_trial_preserves_template_fields() -> Result<()> {
         let storage = InMemoryStorage::new();
         let directions = vec![Direction::Minimize];
-        let study = create_study("dummy-add-trial", storage, directions)?;
+        let study = create_study("dummy-add-trial", storage, RandomSampler::new(), directions)?;
 
         let mut trial = PersistedTrial::new(999, 888, 777);
         trial.state_values = TrialStateValues::Complete(vec![1.23]);

--- a/rustuna_core/src/trial.rs
+++ b/rustuna_core/src/trial.rs
@@ -348,13 +348,13 @@ mod tests {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let study = create_study_with_arc("dummy", storage.clone(), directions)?;
+        let study = create_study_with_arc("dummy", storage.clone(), sampler, directions)?;
 
         let mut params = HashMap::new();
         params.insert("x".to_string(), CategoryLabel::Float(5.0));
         study.enqueue_trial(params, None)?;
 
-        let mut trial = study.ask(sampler.clone())?;
+        let mut trial = study.ask()?;
         let value = trial.suggest_float("x", 0.0, 10.0)?;
         assert_eq!(value, 5.0);
         Ok(())
@@ -365,13 +365,13 @@ mod tests {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let study = create_study_with_arc("dummy", storage.clone(), directions)?;
+        let study = create_study_with_arc("dummy", storage.clone(), sampler, directions)?;
 
         let mut params = HashMap::new();
         params.insert("x".to_string(), CategoryLabel::Int(7));
         study.enqueue_trial(params, None)?;
 
-        let mut trial = study.ask(sampler.clone())?;
+        let mut trial = study.ask()?;
         let value = trial.suggest_int("x", 0, 10)?;
         assert_eq!(value, 7);
         Ok(())
@@ -382,13 +382,13 @@ mod tests {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let study = create_study_with_arc("dummy", storage.clone(), directions)?;
+        let study = create_study_with_arc("dummy", storage.clone(), sampler, directions)?;
 
         let mut params = HashMap::new();
         params.insert("x".to_string(), CategoryLabel::Float(100.0));
         study.enqueue_trial(params, None)?;
 
-        let mut trial = study.ask(sampler.clone())?;
+        let mut trial = study.ask()?;
         let value = trial.suggest_float("x", 0.0, 10.0)?;
         assert!((0.0..=10.0).contains(&value));
         Ok(())
@@ -399,18 +399,18 @@ mod tests {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let study = create_study_with_arc("dummy", storage.clone(), directions)?;
+        let study = create_study_with_arc("dummy", storage.clone(), sampler, directions)?;
 
         let mut params = HashMap::new();
         params.insert("x".to_string(), CategoryLabel::Float(5.0));
         study.enqueue_trial(params, None)?;
 
         // First ask should use enqueued trial
-        let mut trial1 = study.ask(sampler.clone())?;
+        let mut trial1 = study.ask()?;
         assert_eq!(trial1.suggest_float("x", 0.0, 10.0)?, 5.0);
 
         // Second ask should create a new trial (sampled)
-        let mut trial2 = study.ask(sampler.clone())?;
+        let mut trial2 = study.ask()?;
         let value = trial2.suggest_float("x", 0.0, 10.0)?;
         assert!((0.0..=10.0).contains(&value));
 
@@ -422,13 +422,13 @@ mod tests {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let study = create_study_with_arc("dummy", storage.clone(), directions)?;
+        let study = create_study_with_arc("dummy", storage.clone(), sampler, directions)?;
 
         let mut params = HashMap::new();
         params.insert("x".to_string(), CategoryLabel::Float(5.0));
         study.enqueue_trial(params, None)?;
 
-        let mut trial = study.ask(sampler.clone())?;
+        let mut trial = study.ask()?;
         assert_eq!(trial.suggest_float("x", 0.0, 10.0)?, 5.0);
         // "y" is not in fixed_params, so it should be sampled
         let y = trial.suggest_float("y", 0.0, 10.0)?;
@@ -442,10 +442,10 @@ mod tests {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
         let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let study = create_study_with_arc("dummy", storage.clone(), directions)?;
+        let study = create_study_with_arc("dummy", storage.clone(), sampler, directions)?;
 
         // Set user attributes
-        let mut trial = study.ask(sampler.clone())?;
+        let mut trial = study.ask()?;
         trial.set_user_attr("key", "user".to_string())?;
 
         // Set system attributes

--- a/rustuna_importance/examples/ped_anova.rs
+++ b/rustuna_importance/examples/ped_anova.rs
@@ -1,5 +1,3 @@
-use std::sync::{Arc, Mutex};
-
 use rustuna_core::sampler::RandomSampler;
 use rustuna_core::storage::InMemoryStorage;
 use rustuna_core::study::{create_study, Direction};
@@ -9,9 +7,12 @@ use rustuna_importance::{self, PedAnovaImportanceEvaluator};
 fn main() -> Result<()> {
     let storage = InMemoryStorage::new();
     let directions = vec![Direction::Minimize];
-    let study = create_study("simple-quadratic", storage, directions)?;
-
-    let sampler = Arc::new(Mutex::new(RandomSampler::new()));
+    let study = create_study(
+        "simple-quadratic",
+        storage,
+        RandomSampler::new(),
+        directions,
+    )?;
     study.optimize(
         |mut t| {
             let x = t.suggest_float("x", 0.0, 10.0)?;
@@ -20,7 +21,6 @@ fn main() -> Result<()> {
             println!("{:2} x: {}, y: {}, value: {}", t.number, x, y, value);
             Ok(vec![value])
         },
-        sampler,
         50,
     )?;
     let evaluator = PedAnovaImportanceEvaluator::new(0.1, 1.0, true);

--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -165,8 +165,6 @@ mod tests {
     use rustuna_core::trial::PersistedTrial;
     use rustuna_core::{ErrorKind, Result};
     use std::collections::HashSet;
-    use std::sync::{Arc, Mutex};
-
     #[test]
     fn test_error_multi_objective_wo_target() -> Result<()> {
         let evaluators = vec![PedAnovaImportanceEvaluator::default()];
@@ -287,6 +285,7 @@ mod tests {
         let study = study::create_study(
             "empty-study",
             InMemoryStorage::new(),
+            RandomSampler::new(),
             vec![Direction::Minimize],
         )?;
         for evaluator in evaluators {
@@ -301,6 +300,7 @@ mod tests {
         let study = study::create_study(
             "empty-search-space",
             InMemoryStorage::new(),
+            RandomSampler::new(),
             vec![Direction::Minimize],
         )?;
         study.optimize(
@@ -317,7 +317,6 @@ mod tests {
                 )?;
                 Ok(vec![x1 + x2])
             },
-            Arc::new(Mutex::new(RandomSampler::new())),
             5,
         )?;
         let evaluators = vec![PedAnovaImportanceEvaluator::default()];

--- a/rustuna_importance/src/fanova.rs
+++ b/rustuna_importance/src/fanova.rs
@@ -74,8 +74,6 @@ pub fn get_param_importance(study: &Study) -> Result<Vec<Vec<f64>>> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
-
     use rustuna_core::sampler::RandomSampler;
     use rustuna_core::storage::InMemoryStorage;
     use rustuna_core::study::{create_study, Direction};
@@ -85,9 +83,8 @@ mod tests {
     #[test]
     fn fanova() {
         let storage = InMemoryStorage::new();
-        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         let directions = vec![Direction::Minimize];
-        let study = create_study("dummy", storage, directions).unwrap();
+        let study = create_study("dummy", storage, RandomSampler::new(), directions).unwrap();
 
         study
             .optimize(
@@ -99,7 +96,6 @@ mod tests {
                     let value = (x - 3.0).powi(2) + (y - 5.0).powi(2) + (z as f64);
                     Ok(vec![value])
                 },
-                sampler,
                 100,
             )
             .unwrap();

--- a/rustuna_importance/src/test_utils.rs
+++ b/rustuna_importance/src/test_utils.rs
@@ -4,8 +4,6 @@ use rustuna_core::storage::InMemoryStorage;
 use rustuna_core::study::{self, Direction, Study};
 use rustuna_core::trial::Trial;
 use rustuna_core::Result;
-use std::sync::{Arc, Mutex};
-
 fn single_objective(mut trial: Trial) -> Result<Vec<f64>> {
     let x1 = trial.suggest_float("x1", 0.1, 3.0)?;
     let x2 = trial.suggest(
@@ -86,15 +84,18 @@ pub(crate) fn get_study(
     } else {
         vec![direction]
     };
-    let study = study::create_study("test-study", storage, directions)?;
-    let sampler = Arc::new(Mutex::new(RandomSampler::seed_from_u64(seed)));
+    let study = study::create_study(
+        "test-study",
+        storage,
+        RandomSampler::seed_from_u64(seed),
+        directions,
+    )?;
     study.optimize(
         if is_multi_objective {
             multi_objective
         } else {
             single_objective
         },
-        sampler,
         n_trials,
     )?;
     Ok(study)

--- a/rustuna_js/src/study.rs
+++ b/rustuna_js/src/study.rs
@@ -1,5 +1,3 @@
-use std::sync::{Arc, Mutex};
-
 use js_sys::Function;
 use rustuna_core::sampler::RandomSampler;
 use rustuna_core::storage::InMemoryStorage;
@@ -16,7 +14,6 @@ pub struct JsStudy(Study);
 #[wasm_bindgen(js_class=Study)]
 impl JsStudy {
     pub fn optimize(&self, objective: &Function, n_trials: usize) -> JsResult<()> {
-        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
         self.0
             .optimize(
                 |t| {
@@ -31,7 +28,6 @@ impl JsStudy {
                     }?;
                     Ok(vec![val])
                 },
-                sampler,
                 n_trials,
             )
             .map_err(|err| JsError::new(&format!("{err:?}")))
@@ -69,7 +65,7 @@ impl From<Study> for JsStudy {
 pub fn js_create_study(study_name: String) -> JsResult<JsStudy> {
     let storage = InMemoryStorage::new();
     let directions = vec![Direction::Minimize];
-    let study = create_study(&study_name, storage, directions);
+    let study = create_study(&study_name, storage, RandomSampler::new(), directions);
     match study {
         Ok(study) => Ok(study.into()),
         Err(err) => Err(JsError::new(&format!("{err:?}"))),

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -171,43 +171,7 @@ pub fn py_create_study(
         }
     };
     let directions = convert_directions(direction, directions)?;
-    let study = match create_study_with_arc(&study_name, storage_arc.clone(), directions) {
-        Ok(study) => study,
-        Err(err) => {
-            if !load_if_exists || !matches!(err.kind, ErrorKind::DuplicatedStudy) {
-                return Err(err_to_exceptions(err));
-            }
-            let mut guard = storage_arc
-                .write()
-                .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
-            let (study_id, directions) = guard
-                .get_studies()
-                .map_err(err_to_exceptions)?
-                .iter()
-                .find(|s| s.name == study_name)
-                .map(|s| (s.id, s.directions.clone()))
-                .ok_or(PyRuntimeError::new_err(format!(
-                    "Study {study_name} not found"
-                )))?;
-            drop(guard);
-            Study::new(
-                study_id,
-                study_name.clone(),
-                directions,
-                storage_arc.clone(),
-            )
-        }
-    };
-    let (trial_queue_arc, trial_queue_pyobj) =
-        Python::attach(|py| into_trial_queue_pyobj(py, trial_queue))?;
-    let study = Study::with_queue(
-        study.id,
-        study.name,
-        study.directions,
-        study.storage,
-        trial_queue_arc,
-    );
-    let is_multi_objective = study.directions.len() > 1;
+    let is_multi_objective = directions.len() > 1;
     let (sampler_arc, sampler_pyobj): (Arc<Mutex<dyn Sampler>>, Py<PyAny>) = match sampler {
         Some(sampler_obj) => Python::attach(|py| {
             let sampler_pyobj = sampler_obj.clone_ref(py);
@@ -239,9 +203,52 @@ pub fn py_create_study(
             (arc, sampler_pyobj)
         }
     };
+    let (trial_queue_arc, trial_queue_pyobj) =
+        Python::attach(|py| into_trial_queue_pyobj(py, trial_queue))?;
+    let study = match create_study_with_arc(
+        &study_name,
+        storage_arc.clone(),
+        sampler_arc.clone(),
+        directions,
+    ) {
+        Ok(study) => study,
+        Err(err) => {
+            if !load_if_exists || !matches!(err.kind, ErrorKind::DuplicatedStudy) {
+                return Err(err_to_exceptions(err));
+            }
+            let mut guard = storage_arc
+                .write()
+                .map_err(|_| PyRuntimeError::new_err("Failed to acquire the storage guard"))?;
+            let (study_id, directions) = guard
+                .get_studies()
+                .map_err(err_to_exceptions)?
+                .iter()
+                .find(|s| s.name == study_name)
+                .map(|s| (s.id, s.directions.clone()))
+                .ok_or(PyRuntimeError::new_err(format!(
+                    "Study {study_name} not found"
+                )))?;
+            drop(guard);
+            Study::new(
+                study_id,
+                study_name.clone(),
+                directions,
+                storage_arc.clone(),
+                sampler_arc.clone(),
+                trial_queue_arc.clone(),
+            )
+        }
+    };
+    let study = Study::new(
+        study.id,
+        study.name,
+        study.directions,
+        study.storage,
+        study.sampler,
+        trial_queue_arc,
+    );
     Ok(PyStudy {
         study,
-        sampler: sampler_arc,
         storage_pyobj,
         sampler_pyobj,
         trial_queue_pyobj,
@@ -289,7 +296,6 @@ pub fn py_load_study(
     let is_multi_objective = directions.len() > 1;
     let (trial_queue_arc, trial_queue_pyobj) =
         Python::attach(|py| into_trial_queue_pyobj(py, trial_queue))?;
-    let study = Study::with_queue(study_id, study_name, directions, storage, trial_queue_arc);
     let (sampler_arc, sampler_pyobj): (Arc<Mutex<dyn Sampler>>, Py<PyAny>) = match sampler {
         Some(sampler_obj) => Python::attach(|py| {
             let sampler_pyobj = sampler_obj.clone_ref(py);
@@ -321,9 +327,16 @@ pub fn py_load_study(
             (arc, sampler_pyobj)
         }
     };
+    let study = Study::new(
+        study_id,
+        study_name,
+        directions,
+        storage,
+        sampler_arc.clone(),
+        trial_queue_arc,
+    );
     Ok(PyStudy {
         study,
-        sampler: sampler_arc,
         storage_pyobj,
         sampler_pyobj,
         trial_queue_pyobj,
@@ -334,7 +347,6 @@ pub fn py_load_study(
 #[pyo3(module = "rustuna")]
 pub struct PyStudy {
     pub study: Study,
-    sampler: Arc<Mutex<dyn Sampler>>,
     storage_pyobj: Py<PyAny>,
     sampler_pyobj: Py<PyAny>,
     trial_queue_pyobj: Py<PyAny>,
@@ -367,10 +379,16 @@ impl PyStudy {
         let trial_queue_pyobj = Python::attach(|py| -> PyResult<Py<PyAny>> {
             Ok(Py::new(py, trial_queue)?.into_any())
         })?;
-        let study = Study::with_queue(study_id, name, directions, storage.storage, trial_queue_arc);
+        let study = Study::new(
+            study_id,
+            name,
+            directions,
+            storage.storage,
+            sampler.sampler.clone(),
+            trial_queue_arc,
+        );
         Ok(PyStudy {
             study,
-            sampler: sampler.sampler,
             storage_pyobj,
             sampler_pyobj,
             trial_queue_pyobj,
@@ -386,10 +404,9 @@ impl PyStudy {
     ) -> PyResult<()> {
         let catch = Python::attach(|py| normalize_catch(py, catch.as_ref().map(|c| c.bind(py))))?;
         for _ in 0..n_trials {
-            let sampler = self.sampler.clone();
             let rs_trial = self
                 .study
-                .ask(sampler)
+                .ask()
                 .map_err(|e| PyRuntimeError::new_err(format!("Failed to ask a trial {e:?}.")))?;
             let trial_number = rs_trial.number;
 
@@ -429,7 +446,7 @@ impl PyStudy {
     pub fn ask(&self) -> PyResult<PyTrial> {
         let trial = self
             .study
-            .ask(self.sampler.clone())
+            .ask()
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to ask a trial: {:?}", e.kind)))?;
         let trial = Python::attach(|py| PyTrial::new(trial, self.storage_pyobj.clone_ref(py)));
         Ok(trial)

--- a/rustuna_samplers/benches/nsgaii.rs
+++ b/rustuna_samplers/benches/nsgaii.rs
@@ -4,7 +4,6 @@ extern crate test;
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
     use test::Bencher;
 
     use rustuna_core::storage::InMemoryStorage;
@@ -16,8 +15,8 @@ mod tests {
         b.iter(|| {
             let directions = vec![Direction::Minimize, Direction::Minimize];
             let storage = InMemoryStorage::new();
-            let sampler = Arc::new(Mutex::new(NSGAIISampler::default()));
-            let study = create_study("dummy", storage, directions).unwrap();
+            let study =
+                create_study("dummy", storage, NSGAIISampler::default(), directions).unwrap();
             study
                 .optimize(
                     |mut t| {
@@ -28,7 +27,6 @@ mod tests {
                         let v1 = (x - 5.0).powi(2) + (y - 5.0).powi(2);
                         Ok(vec![v0, v1])
                     },
-                    sampler,
                     200,
                 )
                 .unwrap();

--- a/rustuna_samplers/benches/tpe.rs
+++ b/rustuna_samplers/benches/tpe.rs
@@ -4,7 +4,6 @@ extern crate test;
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
     use test::Bencher;
 
     use rustuna_core::storage::InMemoryStorage;
@@ -16,8 +15,7 @@ mod tests {
         b.iter(|| {
             let directions = vec![Direction::Minimize];
             let storage = InMemoryStorage::new();
-            let sampler = Arc::new(Mutex::new(TpeSampler::new()));
-            let study = create_study("dummy", storage, directions).unwrap();
+            let study = create_study("dummy", storage, TpeSampler::new(), directions).unwrap();
             study
                 .optimize(
                     |mut t| {
@@ -28,7 +26,6 @@ mod tests {
                         let value = (x - 3.0).powi(2) + (y - 5.0).powi(2) + (z as f64);
                         Ok(vec![value])
                     },
-                    sampler,
                     100,
                 )
                 .unwrap();

--- a/rustuna_samplers/examples/quadratic.rs
+++ b/rustuna_samplers/examples/quadratic.rs
@@ -1,8 +1,6 @@
 // How to run this example:
 // $ cargo run --example quadratic
 
-use std::sync::{Arc, Mutex};
-
 use rustuna_core::storage::InMemoryStorage;
 use rustuna_core::study::get_best_trial;
 use rustuna_core::study::{create_study, Direction};
@@ -12,9 +10,8 @@ use rustuna_samplers::tpe::TpeSampler;
 fn main() -> Result<()> {
     let storage = InMemoryStorage::new();
     let directions = vec![Direction::Minimize];
-    let study = create_study("simple-quadratic", storage, directions)?;
+    let study = create_study("simple-quadratic", storage, TpeSampler::new(), directions)?;
 
-    let sampler = Arc::new(Mutex::new(TpeSampler::new()));
     study.optimize(
         |mut t| {
             let x = t.suggest_float("x", 0.0, 10.0)?;
@@ -23,7 +20,6 @@ fn main() -> Result<()> {
             println!("{:2} x: {}, y: {}, value: {}", t.number, x, y, value);
             Ok(vec![value])
         },
-        sampler,
         50,
     )?;
 

--- a/rustuna_samplers/src/nsgaii.rs
+++ b/rustuna_samplers/src/nsgaii.rs
@@ -410,15 +410,17 @@ mod tests {
     use super::*;
     use rustuna_core::storage::InMemoryStorage;
     use rustuna_core::study::{create_study, Direction};
-    use std::sync::{Arc, Mutex};
-
     #[test]
     fn test_optimize() {
         let storage = InMemoryStorage::new();
         let directions = vec![Direction::Minimize, Direction::Minimize];
-        let study = create_study("simple-quadratic", storage, directions).unwrap();
-
-        let sampler = Arc::new(Mutex::new(NSGAIISampler::new(2, None, 1.0, 1.0)));
+        let study = create_study(
+            "simple-quadratic",
+            storage,
+            NSGAIISampler::new(2, None, 1.0, 1.0),
+            directions,
+        )
+        .unwrap();
         let n_trials = 10;
         study
             .optimize(
@@ -429,7 +431,6 @@ mod tests {
                     let value1 = (x - 5.0).powi(2) + (y - 3.0).powi(2);
                     Ok(vec![value0, value1])
                 },
-                sampler,
                 n_trials,
             )
             .unwrap();

--- a/rustuna_samplers/src/tpe/sampler.rs
+++ b/rustuna_samplers/src/tpe/sampler.rs
@@ -453,15 +453,12 @@ mod tests {
     use rustuna_core::storage::InMemoryStorage;
     use rustuna_core::study::{create_study, Direction};
     use rustuna_core::study::{get_best_trial, get_pareto_front};
-    use std::sync::{Arc, Mutex};
-
     #[test]
     fn test_optimize() {
         let storage = InMemoryStorage::new();
         let directions = vec![Direction::Minimize];
-        let study = create_study("simple-quadratic", storage, directions).unwrap();
-
-        let sampler = Arc::new(Mutex::new(TpeSampler::new()));
+        let study =
+            create_study("simple-quadratic", storage, TpeSampler::new(), directions).unwrap();
         study
             .optimize(
                 |mut t| {
@@ -475,7 +472,6 @@ mod tests {
                     );
                     Ok(vec![value])
                 },
-                sampler,
                 50,
             )
             .unwrap();
@@ -487,9 +483,8 @@ mod tests {
     fn test_optimize_conditional() {
         let storage = InMemoryStorage::new();
         let directions = vec![Direction::Minimize];
-        let study = create_study("simple-quadratic", storage, directions).unwrap();
-
-        let sampler = Arc::new(Mutex::new(TpeSampler::new()));
+        let study =
+            create_study("simple-quadratic", storage, TpeSampler::new(), directions).unwrap();
         study
             .optimize(
                 |mut t| {
@@ -509,7 +504,6 @@ mod tests {
                     }
                     Ok(vec![value])
                 },
-                sampler,
                 50,
             )
             .unwrap();
@@ -521,9 +515,13 @@ mod tests {
     fn test_multi_objective() {
         let storage = InMemoryStorage::new();
         let directions = vec![Direction::Minimize, Direction::Minimize];
-        let study = create_study("simple-bi-objective", storage, directions).unwrap();
-
-        let sampler = Arc::new(Mutex::new(TpeSampler::new()));
+        let study = create_study(
+            "simple-bi-objective",
+            storage,
+            TpeSampler::new(),
+            directions,
+        )
+        .unwrap();
         study
             .optimize(
                 |mut t| {
@@ -536,7 +534,6 @@ mod tests {
                     println!("{:2} x: {}, y: {}, values: {:?}", t.number, x, y, values);
                     Ok(values)
                 },
-                sampler,
                 50,
             )
             .unwrap();

--- a/rustuna_storages/src/sqlite3.rs
+++ b/rustuna_storages/src/sqlite3.rs
@@ -1775,7 +1775,6 @@ mod tests {
     use crate::cache::CachedStorage;
     use rustuna_core::sampler::RandomSampler;
     use rustuna_core::study::{create_study, Direction};
-    use std::sync::Arc;
     use tempfile::tempdir;
 
     fn init_storage() -> Result<SQLite3Storage> {
@@ -2221,8 +2220,12 @@ mod tests {
         storage.create_database()?;
         let storage = CachedStorage::new(Box::new(storage));
 
-        let study = create_study("simple-quadratic", storage, vec![Direction::Minimize])?;
-        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
+        let study = create_study(
+            "simple-quadratic",
+            storage,
+            RandomSampler::new(),
+            vec![Direction::Minimize],
+        )?;
         study.optimize(
             |mut t| {
                 let x = t.suggest_float("x", 0.0, 10.0)?;
@@ -2231,7 +2234,6 @@ mod tests {
                 println!("{:2} x: {}, y: {}, value: {}", t.number, x, y, value);
                 Ok(vec![value])
             },
-            sampler,
             100,
         )?;
         assert_eq!(study.get_trials()?.len(), 100);


### PR DESCRIPTION
To introduce `after_trial()` method in Sampler trait, this PR suggests adding `sampler` field to a `rustuna_core::Study`.