### PR TITLE
Add `states` argument in `StorageProtocol.get_trials()`

### DIFF
--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -625,7 +625,9 @@ class StorageProtocol(Protocol):
     ) -> None: ...
     def get_studies(self) -> list[PersistedStudy]: ...
     def get_study(self, study_id: int) -> PersistedStudy: ...
-    def get_trials(self, study_id: int) -> list[PersistedTrial]: ...
+    def get_trials(
+        self, study_id: int, *, states: list[TrialState] | None = None
+    ) -> list[PersistedTrial]: ...
     def get_trial(self, trial_id: int) -> PersistedTrial: ...
     def get_cached_trial(self, trial_id: int) -> PersistedTrial: ...
     def get_study_user_attr(self, study_id: int, key: str) -> str: ...
@@ -788,11 +790,14 @@ class Storage:
         Returns:
             The study.
         """
-    def get_trials(self, study_id: int) -> list[PersistedTrial]:
+    def get_trials(
+        self, study_id: int, *, states: list[TrialState] | None = None
+    ) -> list[PersistedTrial]:
         """Get all trials in a study.
 
         Args:
             study_id: ID of the study.
+            states: Optional trial states to filter by.
 
         Returns:
             List of all trials in the study.

--- a/rustuna_pyo3/rustuna/converter/_storage.py
+++ b/rustuna_pyo3/rustuna/converter/_storage.py
@@ -102,8 +102,16 @@ class ToRustunaStorage:
                 return to_persisted_study(s)
         raise KeyError(f"Study {study_id} not found")
 
-    def get_trials(self, study_id: int) -> list[rustuna.PersistedTrial]:
-        frozen_trials = self._storage.get_all_trials(study_id)
+    def get_trials(
+        self,
+        study_id: int,
+        *,
+        states: list[rustuna.TrialState] | None = None,
+    ) -> list[rustuna.PersistedTrial]:
+        optuna_states = None
+        if states is not None:
+            optuna_states = tuple(to_optuna_state(state) for state in states)
+        frozen_trials = self._storage.get_all_trials(study_id, states=optuna_states)
 
         persisted_trials: list[rustuna.PersistedTrial] = []
         with self._lock:
@@ -342,7 +350,6 @@ class ToOptunaStorage(BaseStorage):
         deepcopy: bool = True,
         states: Container[TrialState] | None = None,
     ) -> list[FrozenTrial]:
-        rustuna_trials = self._storage.get_trials(study_id)
         rustuna_states: list[rustuna.TrialState] | None = None
         if states is not None:
             assert isinstance(states, Iterable), (
@@ -352,10 +359,9 @@ class ToOptunaStorage(BaseStorage):
             if not states_list:
                 return []
             rustuna_states = [to_rustuna_state(s) for s in states_list]
+        rustuna_trials = self._storage.get_trials(study_id, states=rustuna_states)
         trials: list[FrozenTrial] = []
         for t in rustuna_trials:
-            if rustuna_states is not None and t.state not in rustuna_states:
-                continue
             cached = self._trial_cache.get(t._trial_id)
             if cached is not None:
                 trials.append(cached)

--- a/rustuna_pyo3/src/storage.rs
+++ b/rustuna_pyo3/src/storage.rs
@@ -254,13 +254,22 @@ impl PyStorage {
         Ok(study.clone().into())
     }
 
-    fn get_trials(&mut self, study_id: u32) -> PyResult<Vec<PyPersistedTrial>> {
+    #[pyo3(signature = (study_id, *, states = None))]
+    fn get_trials(
+        &mut self,
+        study_id: u32,
+        states: Option<Vec<PyTrialState>>,
+    ) -> PyResult<Vec<PyPersistedTrial>> {
         let mut guard = self.storage.write().map_err(|e| {
             PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
         })?;
         let trials = guard.get_trials(study_id).map_err(err_to_exceptions)?;
         let py_trials: Vec<PyPersistedTrial> = trials
             .iter()
+            .filter(|trial| match &states {
+                Some(states) => states.contains(&PyTrialState::from(trial.state_values.clone())),
+                None => true,
+            })
             .map(|t| PyPersistedTrial::from_storage(self.storage.clone(), t))
             .collect();
         Ok(py_trials)

--- a/rustuna_pyo3/tests/storage_tests/test_storage.py
+++ b/rustuna_pyo3/tests/storage_tests/test_storage.py
@@ -127,3 +127,35 @@ def test_trial_get_user_attr_method(storage: StorageProtocol) -> None:
     assert persisted.get_user_attr("key", decoder=int) == 1
     assert persisted.get_user_attr("not_found") is None
     assert persisted.get_user_attr("not_found", default=1) == 1
+
+
+def test_get_trials_with_states_filter(storage: StorageProtocol) -> None:
+    study = rustuna.create_study(storage=storage)
+
+    completed = study.ask()
+    running = study.ask()
+    failed = study.ask()
+
+    study.tell(completed.number, 1.0)
+    study.tell(failed.number, state=rustuna.TrialState.FAIL)
+
+    completed_trials = storage.get_trials(
+        study._study_id, states=[rustuna.TrialState.COMPLETE]
+    )
+    assert len(completed_trials) == 1
+    assert completed_trials[0].number == completed.number
+
+    running_trials = storage.get_trials(
+        study._study_id, states=[rustuna.TrialState.RUNNING]
+    )
+    assert len(running_trials) == 1
+    assert running_trials[0].number == running.number
+
+    finished_trials = storage.get_trials(
+        study._study_id,
+        states=[rustuna.TrialState.COMPLETE, rustuna.TrialState.FAIL],
+    )
+    assert {trial.number for trial in finished_trials} == {
+        completed.number,
+        failed.number,
+    }


### PR DESCRIPTION
Add `states` argument in `StorageProtocol.get_trials()` to reduce the unnecessary clone.