### PR TITLE
Add support for `rustuna.create_trial()`

### DIFF
--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -244,12 +244,14 @@ class PersistedTrial:
 
     def __init__(
         self,
+        *,
         trial_id: int,
         study_id: int,
         number: int,
         state: TrialState,
+        value: float | None = None,
         values: list[float] | None = None,
-        internal_params: dict[str, float] | None = None,
+        params: dict[str, CategoricalChoiceType] | None = None,
         distributions: dict[str, Distribution] | None = None,
         user_attrs: dict[str, str] | None = None,
         system_attrs: dict[str, str] | None = None,
@@ -315,6 +317,35 @@ class PersistedTrial:
 
 # Study
 ObjectiveFuncType = Callable[[Trial], float | tuple[float, ...]]
+
+def create_trial(
+    *,
+    state: TrialState = TrialState.COMPLETE,
+    value: float | None = None,
+    values: Sequence[float] | None = None,
+    params: dict[str, Any] | None = None,
+    distributions: dict[str, Distribution] | None = None,
+    user_attrs: dict[str, str] | None = None,
+    system_attrs: dict[str, str] | None = None,
+) -> PersistedTrial:
+    """Create a low-level PersistedTrial object.
+
+    This is intended to mirror Optuna's ``create_trial`` helper for preparing
+    trials that will later be passed to ``Study.add_trial``.
+
+    Args:
+        state: Trial state.
+        value: Trial objective value. Must not be specified together with ``values``.
+        values: Sequence of trial objective values. Must not be specified together
+            with ``value``.
+        params: Dictionary with suggested parameter values in external representation.
+        distributions: Dictionary with parameter distributions.
+        user_attrs: Dictionary with user attributes.
+        system_attrs: Dictionary with system attributes.
+
+    Returns:
+        A PersistedTrial object.
+    """
 
 def create_study(
     *,

--- a/rustuna_pyo3/rustuna/converter/_trial.py
+++ b/rustuna_pyo3/rustuna/converter/_trial.py
@@ -85,14 +85,10 @@ def to_persisted_trial(
             trial.intermediate_values
         )
 
-    internal_params: dict[str, float] = {}
     distributions: dict[str, rustuna.Distribution] = {}
     for param_name in trial.distributions:
         optuna_distribution = trial.distributions[param_name]
         distributions[param_name] = to_rustuna_distribution(optuna_distribution)
-        internal_params[param_name] = optuna_distribution.to_internal_repr(
-            trial.params[param_name]
-        )
 
     return rustuna.PersistedTrial(
         trial_id=max(trial._trial_id, 0),
@@ -100,7 +96,7 @@ def to_persisted_trial(
         number=max(trial.number, 0),
         state=to_rustuna_state(trial.state),
         values=trial.values,
-        internal_params=internal_params,
+        params=trial.params,
         distributions=distributions,
         user_attrs={k: json.dumps(v) for k, v in trial.user_attrs.items()},
         system_attrs={k: json.dumps(v) for k, v in optuna_system_attrs.items()},

--- a/rustuna_pyo3/src/lib.rs
+++ b/rustuna_pyo3/src/lib.rs
@@ -22,6 +22,7 @@ fn rustuna(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<trial::PyTrial>()?;
     m.add_class::<trial::PyPersistedTrial>()?;
     m.add_class::<trial::PyTrialState>()?;
+    m.add_function(wrap_pyfunction!(trial::py_create_trial, m)?)?;
     // study
     m.add_function(wrap_pyfunction!(study::py_create_study, m)?)?;
     m.add_function(wrap_pyfunction!(study::py_load_study, m)?)?;

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -1,11 +1,13 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-use chrono::NaiveDateTime;
+use chrono::{Local, NaiveDateTime};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};
-use rustuna_core::attr::{get_category_labels, AttrKey, Attrs, CategoryLabel};
+use rustuna_core::attr::{
+    category_labels_to_attrs, get_category_labels, AttrKey, Attrs, CategoryLabel,
+};
 use rustuna_core::distribution::Distribution;
 use rustuna_core::storage::Storage;
 use rustuna_core::trial::{PersistedTrial, Trial, TrialStateValues};
@@ -16,6 +18,157 @@ use crate::distribution::{
     category_label_to_pyobject, py_to_external_repr, pyobject_to_category_label, PyDistribution,
 };
 use crate::exception::err_to_exceptions;
+
+fn state_values_from_py(
+    state: &PyTrialState,
+    value: Option<f64>,
+    values: Option<Vec<f64>>,
+) -> PyResult<TrialStateValues> {
+    if value.is_some() && values.is_some() {
+        return Err(PyValueError::new_err(
+            "value and values must not be specified at the same time",
+        ));
+    }
+
+    let values = match (value, values) {
+        (Some(value), None) => Some(vec![value]),
+        (None, values) => values,
+        (Some(_), Some(_)) => unreachable!(),
+    };
+
+    match state {
+        PyTrialState::RUNNING => Ok(TrialStateValues::Running),
+        PyTrialState::COMPLETE => Ok(TrialStateValues::Complete(values.ok_or(
+            PyValueError::new_err("value or values must be specified when state is COMPLETE"),
+        )?)),
+        PyTrialState::PRUNED => Ok(TrialStateValues::Pruned),
+        PyTrialState::FAIL => Ok(TrialStateValues::Fail),
+        PyTrialState::WAITING => Ok(TrialStateValues::Waiting),
+    }
+}
+
+fn internal_param_from_py(obj: &Bound<'_, PyAny>, distribution: &PyDistribution) -> PyResult<f64> {
+    match &distribution.distribution {
+        Distribution::Float { .. } => obj.extract::<f64>(),
+        Distribution::Int { .. } => obj.extract::<i64>().map(|v| v as f64),
+        Distribution::Categorical { .. } => {
+            let label = pyobject_to_category_label(obj)?;
+            let labels = distribution
+                .category_labels
+                .as_ref()
+                .ok_or(PyValueError::new_err(
+                    "categorical distributions must include choices",
+                ))?;
+            labels
+                .iter()
+                .position(|candidate| candidate == &label)
+                .map(|index| index as f64)
+                .ok_or(PyValueError::new_err(
+                    "parameter value is not contained in the categorical distribution",
+                ))
+        }
+    }
+    .map_err(|e| PyValueError::new_err(format!("Failed to convert parameter value: {e}")))
+}
+
+fn build_trial_attrs(
+    user_attrs: HashMap<String, String>,
+    system_attrs: HashMap<String, String>,
+) -> Attrs {
+    let mut trial_attrs = Attrs::with_capacity(user_attrs.len() + system_attrs.len());
+    for (key, value) in user_attrs {
+        trial_attrs.insert(AttrKey::User(key.into()), value);
+    }
+    for (key, value) in system_attrs {
+        trial_attrs.insert(AttrKey::System(key.into()), value);
+    }
+    trial_attrs
+}
+
+fn build_params(
+    params: Option<&Bound<'_, PyDict>>,
+    distributions: &HashMap<String, PyDistribution>,
+) -> PyResult<HashMap<String, f64>> {
+    params
+        .map(|params| -> PyResult<HashMap<String, f64>> {
+            let mut internal_params = HashMap::with_capacity(params.len());
+            for (key, value) in params.iter() {
+                let name = key.extract::<String>()?;
+                let distribution =
+                    distributions
+                        .get(&name)
+                        .ok_or(PyValueError::new_err(format!(
+                            "Parameter '{name}' is not found in distributions."
+                        )))?;
+                let internal_value = internal_param_from_py(&value, distribution)?;
+                internal_params.insert(name, internal_value);
+            }
+            Ok(internal_params)
+        })
+        .transpose()
+        .map(|opt| opt.unwrap_or_default())
+}
+
+fn study_attrs_from_distributions(distributions: &HashMap<String, PyDistribution>) -> Attrs {
+    let mut attrs = Attrs::new();
+    for (name, distribution) in distributions {
+        if let Some(labels) = &distribution.category_labels {
+            attrs.extend(category_labels_to_attrs(name, labels));
+        }
+    }
+    attrs
+}
+
+#[pyfunction]
+#[pyo3(
+    name = "create_trial",
+    signature = (
+        *,
+        state = PyTrialState::COMPLETE,
+        value = None,
+        values = None,
+        params = None,
+        distributions = None,
+        user_attrs = None,
+        system_attrs = None,
+    )
+)]
+pub fn py_create_trial(
+    state: PyTrialState,
+    value: Option<f64>,
+    values: Option<Vec<f64>>,
+    params: Option<&Bound<'_, PyDict>>,
+    distributions: Option<HashMap<String, PyDistribution>>,
+    user_attrs: Option<HashMap<String, String>>,
+    system_attrs: Option<HashMap<String, String>>,
+) -> PyResult<PyPersistedTrial> {
+    let mut trial = PersistedTrial::new(0, 0, 0);
+    trial.state_values = state_values_from_py(&state, value, values)?;
+
+    let distributions = distributions.unwrap_or_default();
+    let study_attrs = study_attrs_from_distributions(&distributions);
+    trial.internal_params = build_params(params, &distributions)?;
+    trial.distributions = distributions
+        .into_iter()
+        .map(|(name, distribution)| (name, distribution.distribution))
+        .collect();
+    trial.attrs = build_trial_attrs(
+        user_attrs.unwrap_or_default(),
+        system_attrs.unwrap_or_default(),
+    );
+
+    let now = Local::now().naive_local().to_string();
+    if matches!(state, PyTrialState::WAITING) {
+        trial.datetime_start = None;
+        trial.datetime_complete = None;
+    } else {
+        trial.datetime_start = Some(now.clone());
+        trial.datetime_complete = if state.is_finished() { Some(now) } else { None };
+    }
+
+    trial.validate().map_err(err_to_exceptions)?;
+    Ok(PyPersistedTrial::new(trial, study_attrs))
+}
 
 #[derive(Clone, Debug, PartialEq)]
 #[pyclass(name = "TrialState", eq, eq_int)]
@@ -330,62 +483,40 @@ impl PyPersistedTrial {
 #[pymethods]
 impl PyPersistedTrial {
     #[new]
-    #[pyo3(signature = (trial_id, study_id, number, state, values=None, internal_params=None, distributions=None, user_attrs=None, system_attrs=None, datetime_start=None, datetime_complete=None))]
+    #[pyo3(signature = (*, trial_id, study_id, number, state, value=None, values=None, params=None, distributions=None, user_attrs=None, system_attrs=None, datetime_start=None, datetime_complete=None))]
     #[allow(clippy::too_many_arguments)]
     pub fn py_new(
         trial_id: u32,
         study_id: u32,
         number: u32,
         state: PyTrialState,
+        value: Option<f64>,
         values: Option<Vec<f64>>,
-        internal_params: Option<HashMap<String, f64>>,
+        params: Option<&Bound<'_, PyDict>>,
         distributions: Option<HashMap<String, PyDistribution>>,
         user_attrs: Option<HashMap<String, String>>,
         system_attrs: Option<HashMap<String, String>>,
         datetime_start: Option<NaiveDateTime>,
         datetime_complete: Option<NaiveDateTime>,
     ) -> PyResult<Self> {
-        if matches!(state, PyTrialState::COMPLETE) && values.is_none() {
-            Err(PyValueError::new_err(
-                "values must be specified when state is COMPLETE",
-            ))?;
-        }
         let mut trial = PersistedTrial::new(trial_id, study_id, number);
-        trial.state_values = match state {
-            PyTrialState::RUNNING => TrialStateValues::Running,
-            PyTrialState::COMPLETE => TrialStateValues::Complete(values.ok_or(
-                PyValueError::new_err("values must be specified when state is COMPLETE"),
-            )?),
-            PyTrialState::PRUNED => TrialStateValues::Pruned,
-            PyTrialState::FAIL => TrialStateValues::Fail,
-            PyTrialState::WAITING => TrialStateValues::Waiting,
-        };
+        trial.state_values = state_values_from_py(&state, value, values)?;
 
-        trial.internal_params = internal_params.unwrap_or_default();
-        trial.distributions = HashMap::with_capacity(match &distributions {
-            Some(d) => d.len(),
-            None => 0,
-        });
-        for (name, dist) in distributions.unwrap_or_default() {
-            trial.distributions.insert(name, dist.distribution);
-        }
-
-        let user_attrs = user_attrs.unwrap_or_default();
-        let system_attrs = system_attrs.unwrap_or_default();
-        let n_user_attrs = user_attrs.len();
-        let n_system_attrs = user_attrs.len();
-        let mut trial_attrs = Attrs::with_capacity(n_user_attrs + n_system_attrs);
-        for (key, value) in user_attrs {
-            trial_attrs.insert(AttrKey::User(key.into()), value);
-        }
-        for (key, value) in system_attrs {
-            trial_attrs.insert(AttrKey::System(key.into()), value);
-        }
-        trial.attrs = trial_attrs;
+        let distributions = distributions.unwrap_or_default();
+        let study_attrs = study_attrs_from_distributions(&distributions);
+        trial.internal_params = build_params(params, &distributions)?;
+        trial.distributions = distributions
+            .into_iter()
+            .map(|(name, dist)| (name, dist.distribution))
+            .collect();
+        trial.attrs = build_trial_attrs(
+            user_attrs.unwrap_or_default(),
+            system_attrs.unwrap_or_default(),
+        );
         trial.datetime_start = datetime_start.map(|dt| dt.to_string());
         trial.datetime_complete = datetime_complete.map(|dt| dt.to_string());
 
-        let study_attrs = Attrs::new();
+        trial.validate().map_err(err_to_exceptions)?;
         Ok(PyPersistedTrial::new(trial, study_attrs))
     }
 

--- a/rustuna_pyo3/tests/test_rustuna.py
+++ b/rustuna_pyo3/tests/test_rustuna.py
@@ -367,7 +367,9 @@ def test_persisted_trial():
 
     pytest.raises(
         ValueError,
-        lambda: rustuna.PersistedTrial(2, 1, 2, state=rustuna.TrialState.COMPLETE),
+        lambda: rustuna.PersistedTrial(
+            trial_id=2, study_id=1, number=2, state=rustuna.TrialState.COMPLETE
+        ),
     )
 
 

--- a/rustuna_pyo3/tests/test_trial.py
+++ b/rustuna_pyo3/tests/test_trial.py
@@ -1,0 +1,103 @@
+import pytest
+
+import rustuna
+
+
+def test_create_trial() -> None:
+    trial = rustuna.create_trial(
+        params={"x": 1.5, "y": "foo"},
+        distributions={
+            "x": rustuna.Distribution.float(0.0, 10.0),
+            "y": rustuna.Distribution.categorical(["foo", "bar"]),
+        },
+        value=5.0,
+        user_attrs={"user": "attr"},
+        system_attrs={"system": "attr"},
+    )
+
+    assert trial._trial_id == 0
+    assert trial.study_id == 0
+    assert trial.number == 0
+    assert trial.state == rustuna.TrialState.COMPLETE
+    assert trial.values == [5.0]
+    assert trial.params == {"x": 1.5, "y": "foo"}
+    assert trial.user_attrs["user"] == "attr"
+    assert trial.system_attrs["system"] == "attr"
+    assert trial.datetime_start is not None
+    assert trial.datetime_complete is not None
+
+    study = rustuna.create_study()
+    study.add_trial(trial)
+    persisted = study.trials[0]
+    assert persisted.number == 0
+    assert persisted.value == 5.0
+
+
+def test_create_trial_distributions() -> None:
+    trial = rustuna.create_trial(
+        params={"lr": 0.01, "n_layers": 3, "activation": "relu"},
+        distributions={
+            "lr": rustuna.Distribution.float(1e-5, 1e-1),
+            "n_layers": rustuna.Distribution.int(1, 5),
+            "activation": rustuna.Distribution.categorical(["relu", "tanh", "sigmoid"]),
+        },
+        value=0.95,
+    )
+    assert trial.state == rustuna.TrialState.COMPLETE
+    assert trial.params["lr"] == pytest.approx(0.01)
+    assert trial.params["n_layers"] == 3
+    assert trial.params["activation"] == "relu"
+    assert trial.internal_params["lr"] == pytest.approx(0.01)
+    assert trial.internal_params["n_layers"] == 3.0
+    assert trial.internal_params["activation"] == 0.0  # index of "relu"
+
+
+def test_create_trial_unknown_param_raises() -> None:
+    with pytest.raises(Exception):
+        rustuna.create_trial(
+            params={"x": 1.0, "unknown": 99.0},
+            distributions={"x": rustuna.Distribution.float(0.0, 10.0)},
+            value=1.0,
+        )
+
+
+def test_persisted_trial_new_distributions() -> None:
+    trial = rustuna.PersistedTrial(
+        trial_id=10,
+        study_id=1,
+        number=5,
+        state=rustuna.TrialState.COMPLETE,
+        params={"lr": 0.001, "n_layers": 2, "activation": "tanh"},
+        distributions={
+            "lr": rustuna.Distribution.float(1e-5, 1e-1),
+            "n_layers": rustuna.Distribution.int(1, 5),
+            "activation": rustuna.Distribution.categorical(["relu", "tanh", "sigmoid"]),
+        },
+        values=[0.9, 0.8],
+        user_attrs={"note": "test"},
+        system_attrs={"sys": "val"},
+    )
+    assert trial._trial_id == 10
+    assert trial.study_id == 1
+    assert trial.number == 5
+    assert trial.values == [0.9, 0.8]
+    assert trial.params["lr"] == pytest.approx(0.001)
+    assert trial.params["n_layers"] == 2
+    assert trial.params["activation"] == "tanh"
+    assert trial.internal_params["lr"] == pytest.approx(0.001)
+    assert trial.internal_params["n_layers"] == 2.0
+    assert trial.internal_params["activation"] == 1.0  # index of "tanh"
+    assert trial.user_attrs["note"] == "test"
+    assert trial.system_attrs["sys"] == "val"
+
+
+def test_persisted_trial_new_value_and_values_error() -> None:
+    with pytest.raises(Exception):
+        rustuna.PersistedTrial(
+            trial_id=0,
+            study_id=0,
+            number=0,
+            state=rustuna.TrialState.COMPLETE,
+            value=1.0,
+            values=[1.0],
+        )


### PR DESCRIPTION
To improve the Optuna compatibility, this PR suggests introducing `rustuna.create_trial()`.