### PR TITLE
Add `after_trial` hook to samplers

### DIFF
--- a/rustuna_core/src/sampler.rs
+++ b/rustuna_core/src/sampler.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, RwLock};
 use crate::distribution::Distribution;
 use crate::storage::Storage;
 use crate::study::Direction;
+use crate::trial::TrialStateValues;
 use crate::Result;
 
 #[derive(Debug, Clone)]
@@ -31,6 +32,14 @@ pub trait Sampler: Send {
         storage: Arc<RwLock<dyn Storage>>,
         search_space: &HashMap<String, Distribution>,
     ) -> Result<HashMap<String, f64>>;
+    fn after_trial(
+        &mut self,
+        _ctx: &Context,
+        _storage: Arc<RwLock<dyn Storage>>,
+        _state_values: &TrialStateValues,
+    ) -> Result<()> {
+        Ok(())
+    }
 }
 
 pub struct RandomSampler {
@@ -156,6 +165,15 @@ impl Sampler for RandomSampler {
     ) -> Result<HashMap<String, f64>> {
         unreachable!()
     }
+
+    fn after_trial(
+        &mut self,
+        _ctx: &Context,
+        _storage: Arc<RwLock<dyn Storage>>,
+        _state_values: &TrialStateValues,
+    ) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -191,6 +209,15 @@ mod tests {
             _search_space: &HashMap<String, Distribution>,
         ) -> Result<HashMap<String, f64>> {
             Ok(self.joint_params.clone())
+        }
+
+        fn after_trial(
+            &mut self,
+            _ctx: &Context,
+            _storage: Arc<RwLock<dyn Storage>>,
+            _state_values: &TrialStateValues,
+        ) -> Result<()> {
+            Ok(())
         }
     }
 

--- a/rustuna_core/src/study.rs
+++ b/rustuna_core/src/study.rs
@@ -35,9 +35,12 @@ pub fn create_study_with_arc(
     sampler: Arc<Mutex<dyn Sampler>>,
     directions: Vec<Direction>,
 ) -> Result<Study> {
-    let mut guard = storage
-        .write()
-        .map_err(|_e| Error::new(ErrorKind::Unexpected))?;
+    let mut guard = storage.write().map_err(|e| {
+        Error::with_reason(
+            ErrorKind::Unexpected,
+            format!("Failed to acquire a storage guard: {e}"),
+        )
+    })?;
     let study_id = guard.create_new_study(study_name, directions.clone())?.id;
     drop(guard);
     let queue = Arc::new(RwLock::new(InMemoryTrialQueue::new()));
@@ -173,7 +176,14 @@ impl Study {
                                 format!("Failed to acquire queue guard for recovery: {queue_err}"),
                             )
                         })?;
-                        let _ = queue_guard.push(trial_id);
+                        if let Err(queue_err) = queue_guard.push(trial_id) {
+                            return Err(Error::with_reason(
+                                ErrorKind::Unexpected,
+                                format!(
+                                    "Failed to restore queued trial {trial_id} after ask error: {queue_err}; original error: {e}"
+                                ),
+                            ));
+                        }
                         return Err(e);
                     }
                 }
@@ -195,14 +205,22 @@ impl Study {
             };
 
         let sampler = Arc::clone(&self.sampler);
-        let mut guard = sampler
-            .lock()
-            .map_err(|_| Error::new(ErrorKind::Unexpected))?;
+        let mut guard = sampler.lock().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::Unexpected,
+                format!("Failed to acquire a sampler guard: {e}"),
+            )
+        })?;
         let joint_params: HashMap<String, (Distribution, f64)> = if guard.support_joint_sampling() {
             let joint_search_space = self
                 .storage
                 .write()
-                .map_err(|_| Error::new(ErrorKind::Unexpected))?
+                .map_err(|e| {
+                    Error::with_reason(
+                        ErrorKind::Unexpected,
+                        format!("Failed to acquire a storage guard: {e}"),
+                    )
+                })?
                 .get_joint_search_space(self.id)?;
 
             let ctx = SamplerContext {
@@ -243,10 +261,12 @@ impl Study {
     }
 
     pub fn tell(&self, trial_number: u32, state_values: TrialStateValues) -> Result<()> {
-        let mut storage_guard = self
-            .storage
-            .write()
-            .map_err(|_| Error::new(ErrorKind::Unexpected))?;
+        let mut storage_guard = self.storage.write().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::Unexpected,
+                format!("Failed to acquire a storage guard: {e}"),
+            )
+        })?;
         let trial_id =
             storage_guard.get_trial_id_from_study_id_trial_number(self.id, trial_number)?;
         drop(storage_guard);
@@ -258,17 +278,21 @@ impl Study {
             trial_id,
         };
         let after_trial_result = {
-            let mut sampler_guard = self
-                .sampler
-                .lock()
-                .map_err(|_| Error::new(ErrorKind::Unexpected))?;
+            let mut sampler_guard = self.sampler.lock().map_err(|e| {
+                Error::with_reason(
+                    ErrorKind::Unexpected,
+                    format!("Failed to acquire a sampler guard: {e}"),
+                )
+            })?;
             sampler_guard.after_trial(&ctx, self.storage.clone(), &state_values)
         };
 
-        let mut storage_guard = self
-            .storage
-            .write()
-            .map_err(|_| Error::new(ErrorKind::Unexpected))?;
+        let mut storage_guard = self.storage.write().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::Unexpected,
+                format!("Failed to acquire a storage guard: {e}"),
+            )
+        })?;
         storage_guard.set_trial_state_values(trial_id, state_values)?;
         drop(storage_guard);
 
@@ -303,19 +327,23 @@ impl Study {
     }
 
     pub fn get_trials(&self) -> Result<Vec<PersistedTrial>> {
-        let mut guard = self
-            .storage
-            .write()
-            .map_err(|_| Error::new(ErrorKind::StorageError))?;
+        let mut guard = self.storage.write().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::StorageError,
+                format!("Failed to acquire a storage guard: {e}"),
+            )
+        })?;
         let trials = guard.get_trials(self.id)?;
         Ok(trials.clone())
     }
 
     pub fn get_user_attr(&self, key: String) -> Result<Option<String>> {
-        let mut guard = self
-            .storage
-            .write()
-            .map_err(|_| Error::new(ErrorKind::Unexpected))?;
+        let mut guard = self.storage.write().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::Unexpected,
+                format!("Failed to acquire a storage guard: {e}"),
+            )
+        })?;
         let study = guard.get_study(self.id)?;
 
         let key = AttrKey::User(key.into());
@@ -326,10 +354,12 @@ impl Study {
     }
 
     pub fn set_user_attr(&self, attrs: HashMap<String, String>) -> Result<()> {
-        let mut guard = self
-            .storage
-            .write()
-            .map_err(|_| Error::new(ErrorKind::Unexpected))?;
+        let mut guard = self.storage.write().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::Unexpected,
+                format!("Failed to acquire a storage guard: {e}"),
+            )
+        })?;
         let mut a = Attrs::new();
         for (key, value) in attrs {
             a.insert(AttrKey::User(key.into()), value);
@@ -438,10 +468,12 @@ impl PersistedStudy {
 }
 
 pub fn get_best_trial(study: &Study) -> Result<u32> {
-    let mut guard = study
-        .storage
-        .write()
-        .map_err(|_| Error::new(ErrorKind::StorageError))?;
+    let mut guard = study.storage.write().map_err(|e| {
+        Error::with_reason(
+            ErrorKind::StorageError,
+            format!("Failed to acquire a storage guard: {e}"),
+        )
+    })?;
     let trials = guard.get_trials(study.id)?;
 
     let best_trial = trials
@@ -472,10 +504,12 @@ pub fn get_best_trial(study: &Study) -> Result<u32> {
 
 // TODO(HideakiImamura): Support the faster algorithm for `len(directions) == 2`.
 pub fn get_pareto_front(study: &Study) -> Result<Vec<u32>> {
-    let mut guard = study
-        .storage
-        .write()
-        .map_err(|_| Error::new(ErrorKind::StorageError))?;
+    let mut guard = study.storage.write().map_err(|e| {
+        Error::with_reason(
+            ErrorKind::StorageError,
+            format!("Failed to acquire a storage guard: {e}"),
+        )
+    })?;
     let trials = guard
         .get_trials(study.id)?
         .iter()
@@ -578,16 +612,24 @@ mod tests {
             storage: Arc<RwLock<dyn Storage>>,
             state_values: &TrialStateValues,
         ) -> Result<()> {
-            let mut storage_guard = storage
-                .write()
-                .map_err(|_| Error::new(ErrorKind::Unexpected))?;
+            let mut storage_guard = storage.write().map_err(|e| {
+                Error::with_reason(
+                    ErrorKind::Unexpected,
+                    format!("Failed to acquire a storage guard: {e}"),
+                )
+            })?;
             let trial = storage_guard.get_trial(ctx.trial_id)?;
             assert_eq!(trial.state_values, TrialStateValues::Running);
             drop(storage_guard);
 
             self.calls
                 .lock()
-                .map_err(|_| Error::new(ErrorKind::Unexpected))?
+                .map_err(|e| {
+                    Error::with_reason(
+                        ErrorKind::Unexpected,
+                        format!("Failed to acquire a calls guard: {e}"),
+                    )
+                })?
                 .push((ctx.clone(), state_values.clone()));
 
             if self.fail_after_trial {
@@ -837,9 +879,12 @@ mod tests {
         let trial = study.ask()?;
         study.tell(trial.number, TrialStateValues::Complete(vec![1.5]))?;
 
-        let calls_guard = calls
-            .lock()
-            .map_err(|_| Error::new(ErrorKind::Unexpected))?;
+        let calls_guard = calls.lock().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::Unexpected,
+                format!("Failed to acquire a calls guard: {e}"),
+            )
+        })?;
         assert_eq!(calls_guard.len(), 1);
         let (ctx, state_values) = &calls_guard[0];
         assert_eq!(ctx.study_id, study.id);
@@ -848,9 +893,12 @@ mod tests {
         assert_eq!(state_values, &TrialStateValues::Complete(vec![1.5]));
         drop(calls_guard);
 
-        let mut storage_guard = storage
-            .write()
-            .map_err(|_| Error::new(ErrorKind::Unexpected))?;
+        let mut storage_guard = storage.write().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::Unexpected,
+                format!("Failed to acquire a storage guard: {e}"),
+            )
+        })?;
         let persisted_trial = storage_guard.get_trial(trial.id)?;
         assert_eq!(
             persisted_trial.state_values,
@@ -881,9 +929,12 @@ mod tests {
             .expect_err("tell must propagate after_trial error");
         assert!(matches!(err.kind, ErrorKind::SamplerError));
 
-        let mut storage_guard = storage
-            .write()
-            .map_err(|_| Error::new(ErrorKind::Unexpected))?;
+        let mut storage_guard = storage.write().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::Unexpected,
+                format!("Failed to acquire a storage guard: {e}"),
+            )
+        })?;
         let persisted_trial = storage_guard.get_trial(trial.id)?;
         assert_eq!(
             persisted_trial.state_values,

--- a/rustuna_core/src/study.rs
+++ b/rustuna_core/src/study.rs
@@ -243,12 +243,36 @@ impl Study {
     }
 
     pub fn tell(&self, trial_number: u32, state_values: TrialStateValues) -> Result<()> {
-        let mut guard = self
+        let mut storage_guard = self
             .storage
             .write()
             .map_err(|_| Error::new(ErrorKind::Unexpected))?;
-        let trial_id = guard.get_trial_id_from_study_id_trial_number(self.id, trial_number)?;
-        guard.set_trial_state_values(trial_id, state_values)?;
+        let trial_id =
+            storage_guard.get_trial_id_from_study_id_trial_number(self.id, trial_number)?;
+        drop(storage_guard);
+
+        let ctx = SamplerContext {
+            study_id: self.id,
+            directions: self.directions.clone(),
+            trial_number,
+            trial_id,
+        };
+        let after_trial_result = {
+            let mut sampler_guard = self
+                .sampler
+                .lock()
+                .map_err(|_| Error::new(ErrorKind::Unexpected))?;
+            sampler_guard.after_trial(&ctx, self.storage.clone(), &state_values)
+        };
+
+        let mut storage_guard = self
+            .storage
+            .write()
+            .map_err(|_| Error::new(ErrorKind::Unexpected))?;
+        storage_guard.set_trial_state_values(trial_id, state_values)?;
+        drop(storage_guard);
+
+        after_trial_result?;
         Ok(())
     }
 
@@ -510,12 +534,71 @@ mod tests {
     use super::*;
     use crate::attr::AttrKey;
     use crate::distribution::Distribution;
+    use crate::sampler::{Context as SamplerContext, Sampler};
     use std::thread;
 
     use crate::sampler::RandomSampler;
     use crate::storage::InMemoryStorage;
     use crate::study::create_study;
+    use crate::study::create_study_with_arc;
     use crate::study::get_best_trial;
+
+    struct RecordingSampler {
+        calls: Arc<Mutex<Vec<(SamplerContext, TrialStateValues)>>>,
+        fail_after_trial: bool,
+    }
+
+    impl Sampler for RecordingSampler {
+        fn sample_independent(
+            &mut self,
+            _ctx: &SamplerContext,
+            _storage: Arc<RwLock<dyn Storage>>,
+            _name: &str,
+            _distribution: &Distribution,
+        ) -> Result<f64> {
+            Ok(0.0)
+        }
+
+        fn support_joint_sampling(&self) -> bool {
+            false
+        }
+
+        fn sample_joint(
+            &mut self,
+            _ctx: &SamplerContext,
+            _storage: Arc<RwLock<dyn Storage>>,
+            _search_space: &HashMap<String, Distribution>,
+        ) -> Result<HashMap<String, f64>> {
+            unreachable!()
+        }
+
+        fn after_trial(
+            &mut self,
+            ctx: &SamplerContext,
+            storage: Arc<RwLock<dyn Storage>>,
+            state_values: &TrialStateValues,
+        ) -> Result<()> {
+            let mut storage_guard = storage
+                .write()
+                .map_err(|_| Error::new(ErrorKind::Unexpected))?;
+            let trial = storage_guard.get_trial(ctx.trial_id)?;
+            assert_eq!(trial.state_values, TrialStateValues::Running);
+            drop(storage_guard);
+
+            self.calls
+                .lock()
+                .map_err(|_| Error::new(ErrorKind::Unexpected))?
+                .push((ctx.clone(), state_values.clone()));
+
+            if self.fail_after_trial {
+                return Err(Error::with_reason(
+                    ErrorKind::SamplerError,
+                    "after_trial failed",
+                ));
+            }
+            Ok(())
+        }
+    }
 
     #[test]
     fn test_optimize() -> Result<()> {
@@ -732,6 +815,79 @@ mod tests {
         assert_eq!(
             trials[0].attrs.get(&AttrKey::User("memo".into())),
             Some(&"\"imported\"".to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_tell_calls_after_trial_before_storage_update() -> Result<()> {
+        let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let sampler = Arc::new(Mutex::new(RecordingSampler {
+            calls: calls.clone(),
+            fail_after_trial: false,
+        }));
+        let study = create_study_with_arc(
+            "dummy-after-trial",
+            storage.clone(),
+            sampler,
+            vec![Direction::Minimize],
+        )?;
+
+        let trial = study.ask()?;
+        study.tell(trial.number, TrialStateValues::Complete(vec![1.5]))?;
+
+        let calls_guard = calls
+            .lock()
+            .map_err(|_| Error::new(ErrorKind::Unexpected))?;
+        assert_eq!(calls_guard.len(), 1);
+        let (ctx, state_values) = &calls_guard[0];
+        assert_eq!(ctx.study_id, study.id);
+        assert_eq!(ctx.trial_id, trial.id);
+        assert_eq!(ctx.trial_number, trial.number);
+        assert_eq!(state_values, &TrialStateValues::Complete(vec![1.5]));
+        drop(calls_guard);
+
+        let mut storage_guard = storage
+            .write()
+            .map_err(|_| Error::new(ErrorKind::Unexpected))?;
+        let persisted_trial = storage_guard.get_trial(trial.id)?;
+        assert_eq!(
+            persisted_trial.state_values,
+            TrialStateValues::Complete(vec![1.5])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_tell_persists_trial_even_if_after_trial_fails() -> Result<()> {
+        let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let sampler = Arc::new(Mutex::new(RecordingSampler {
+            calls,
+            fail_after_trial: true,
+        }));
+        let study = create_study_with_arc(
+            "dummy-after-trial-failure",
+            storage.clone(),
+            sampler,
+            vec![Direction::Minimize],
+        )?;
+
+        let trial = study.ask()?;
+        // Optuna persists the final state in a finally block even if after_trial raises.
+        let err = study
+            .tell(trial.number, TrialStateValues::Complete(vec![2.5]))
+            .expect_err("tell must propagate after_trial error");
+        assert!(matches!(err.kind, ErrorKind::SamplerError));
+
+        let mut storage_guard = storage
+            .write()
+            .map_err(|_| Error::new(ErrorKind::Unexpected))?;
+        let persisted_trial = storage_guard.get_trial(trial.id)?;
+        assert_eq!(
+            persisted_trial.state_values,
+            TrialStateValues::Complete(vec![2.5])
         );
         Ok(())
     }

--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -995,6 +995,13 @@ class SamplerProtocol(Protocol):
         name: str,
         distribution: Distribution,
     ) -> float: ...
+    def after_trial(
+        self,
+        ctx: SamplerContext,
+        storage: StorageProtocol,
+        state: TrialState,
+        values: list[float] | None = None,
+    ) -> None: ...
 
 class Sampler:
     """Factory class for creating sampler instances."""
@@ -1084,6 +1091,22 @@ class Sampler:
 
         Returns:
             Suggested parameter value (Optuna's internal representation).
+        """
+
+    def after_trial(
+        self,
+        ctx: SamplerContext,
+        storage: StorageProtocol,
+        state: TrialState,
+        values: list[float] | None = None,
+    ) -> None:
+        """Run sampler post-processing after a trial finishes.
+
+        Args:
+            ctx: Sampler context.
+            storage: Storage object.
+            state: Final trial state.
+            values: Final objective values. ``None`` unless the trial completed.
         """
 
 # Trial Queue

--- a/rustuna_pyo3/rustuna/converter/_sampler.py
+++ b/rustuna_pyo3/rustuna/converter/_sampler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from optuna.distributions import BaseDistribution
@@ -7,7 +8,7 @@ from optuna.samplers import BaseSampler
 from optuna.search_space import IntersectionSearchSpace
 from optuna.storages import BaseStorage
 from optuna.study import Study
-from optuna.trial import FrozenTrial
+from optuna.trial import FrozenTrial, TrialState
 
 import rustuna
 from rustuna.converter import (
@@ -16,6 +17,7 @@ from rustuna.converter import (
     to_rustuna_distributions,
 )
 from rustuna.converter._storage import ToRustunaStorage
+from rustuna.converter._trial import to_rustuna_state
 
 if TYPE_CHECKING:
     from rustuna import SamplerProtocol, StorageProtocol
@@ -98,3 +100,28 @@ class ToOptunaSampler(BaseSampler):
             search_space[name] = distribution
 
         return search_space
+
+    def after_trial(
+        self,
+        study: Study,
+        trial: FrozenTrial,
+        state: TrialState,
+        values: Sequence[float] | None,
+    ) -> None:
+        after_trial = getattr(self._sampler, "after_trial", None)
+        if after_trial is None:
+            return
+
+        ctx = rustuna.SamplerContext(
+            study_id=study._study_id,
+            trial_number=trial.number,
+            trial_id=trial._trial_id,
+            directions=to_rustuna_directions(study._directions),
+        )
+        storage = self._get_storage(study._storage)
+        after_trial(
+            ctx,
+            storage,
+            to_rustuna_state(state),
+            list(values) if values is not None else None,
+        )

--- a/rustuna_pyo3/src/sampler.rs
+++ b/rustuna_pyo3/src/sampler.rs
@@ -8,6 +8,7 @@ use pyo3::{prelude::*, types::PyType};
 
 use rustuna_core::sampler::{Context as SamplerContext, RandomSampler, Sampler};
 use rustuna_core::storage::Storage;
+use rustuna_core::trial::TrialStateValues;
 use rustuna_samplers::tpe::{TpeConfig, TpeSampler};
 
 use crate::distribution::PyDistribution;
@@ -323,5 +324,14 @@ impl Sampler for PyObjectSampler {
             })?;
             Ok(py_result)
         })
+    }
+
+    fn after_trial(
+        &mut self,
+        _ctx: &SamplerContext,
+        _storage: Arc<std::sync::RwLock<dyn Storage>>,
+        _state_values: &TrialStateValues,
+    ) -> rustuna_core::Result<()> {
+        Ok(())
     }
 }

--- a/rustuna_pyo3/src/sampler.rs
+++ b/rustuna_pyo3/src/sampler.rs
@@ -15,6 +15,7 @@ use crate::distribution::PyDistribution;
 use crate::pyobject_storage::PyPyObjectStorage;
 use crate::storage::PyStorage;
 use crate::study::PyDirection;
+use crate::trial::PyTrialState;
 
 #[derive(Clone)]
 #[pyclass(name = "Sampler")]
@@ -136,6 +137,31 @@ impl PySampler {
                     .collect(),
             )
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to sample joint: {e:?}")))
+    }
+
+    #[pyo3(signature = (ctx, storage, state, values = None))]
+    fn after_trial(
+        &self,
+        ctx: &PySamplerContext,
+        storage: Py<PyAny>,
+        state: PyTrialState,
+        values: Option<Vec<f64>>,
+    ) -> PyResult<()> {
+        let arc_storage = extract_storage(storage)?;
+        let state_values = match state {
+            PyTrialState::RUNNING => TrialStateValues::Running,
+            PyTrialState::COMPLETE => TrialStateValues::Complete(values.ok_or(
+                PyRuntimeError::new_err("values must be specified when state is COMPLETE"),
+            )?),
+            PyTrialState::PRUNED => TrialStateValues::Pruned,
+            PyTrialState::WAITING => TrialStateValues::Waiting,
+            PyTrialState::FAIL => TrialStateValues::Fail,
+        };
+        self.sampler
+            .lock()
+            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the sampler guard"))?
+            .after_trial(&ctx.context, arc_storage, &state_values)
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to call after_trial: {e:?}")))
     }
 }
 
@@ -328,10 +354,41 @@ impl Sampler for PyObjectSampler {
 
     fn after_trial(
         &mut self,
-        _ctx: &SamplerContext,
-        _storage: Arc<std::sync::RwLock<dyn Storage>>,
-        _state_values: &TrialStateValues,
+        ctx: &SamplerContext,
+        storage: Arc<std::sync::RwLock<dyn Storage>>,
+        state_values: &TrialStateValues,
     ) -> rustuna_core::Result<()> {
-        Ok(())
+        let py_state = PyTrialState::from(state_values.clone());
+        let py_values = match state_values {
+            TrialStateValues::Complete(values) => Some(values.clone()),
+            _ => None,
+        };
+
+        Python::attach(|py| {
+            if !self.obj.bind(py).hasattr("after_trial").map_err(|e| {
+                rustuna_core::Error::with_reason(
+                    rustuna_core::ErrorKind::SamplerError,
+                    e.to_string(),
+                )
+            })? {
+                return Ok(());
+            }
+
+            let py_ctx = PySamplerContext::from(ctx.clone());
+            let py_storage = PyStorage {
+                storage: storage.clone(),
+                optuna_compatible: None,
+                kind: "unset",
+            };
+            self.obj
+                .call_method1(py, "after_trial", (py_ctx, py_storage, py_state, py_values))
+                .map_err(|e| {
+                    rustuna_core::Error::with_reason(
+                        rustuna_core::ErrorKind::SamplerError,
+                        e.to_string(),
+                    )
+                })?;
+            Ok(())
+        })
     }
 }

--- a/rustuna_pyo3/tests/test_optuna_samplers.py
+++ b/rustuna_pyo3/tests/test_optuna_samplers.py
@@ -1,5 +1,9 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
 from typing import Callable
 
+import optuna
 import pytest
 from optuna.samplers import BaseSampler
 from optuna.testing.pytest_samplers import (
@@ -20,3 +24,93 @@ class TestTpeSampler(
         return lambda: ToOptunaSampler(
             rustuna.Sampler.tpe(n_startup_trials=0, multivariate=True)
         )
+
+
+class RecordingSampler:
+    @property
+    def support_joint_sampling(self) -> bool:
+        return False
+
+    def __init__(self) -> None:
+        self.after_trial_calls: list[
+            tuple[int, int, rustuna.TrialState, list[float] | None]
+        ] = []
+
+    def sample_joint(
+        self,
+        ctx: rustuna.SamplerContext,
+        storage: rustuna.StorageProtocol,
+        search_space: dict[str, rustuna.Distribution],
+    ) -> dict[str, float]:
+        raise AssertionError("sample_joint must not be called")
+
+    def sample_independent(
+        self,
+        ctx: rustuna.SamplerContext,
+        storage: rustuna.StorageProtocol,
+        name: str,
+        distribution: rustuna.Distribution,
+    ) -> float:
+        distribution_dict = distribution.to_dict()
+        if distribution_dict["type"] == "FloatDistribution":
+            return distribution_dict["low"]
+        if distribution_dict["type"] == "IntDistribution":
+            return distribution_dict["low"]
+        if distribution_dict["type"] == "CategoricalDistribution":
+            return 0.0
+        raise AssertionError("Unreachable code")
+
+    def after_trial(
+        self,
+        ctx: rustuna.SamplerContext,
+        storage: rustuna.StorageProtocol,
+        state: rustuna.TrialState,
+        values: Sequence[float] | None = None,
+    ) -> None:
+        self.after_trial_calls.append(
+            (
+                ctx.study_id,
+                ctx.trial_number,
+                state,
+                list(values) if values is not None else None,
+            )
+        )
+
+
+class FailingAfterTrialSampler(RecordingSampler):
+    def after_trial(
+        self,
+        ctx: rustuna.SamplerContext,
+        storage: rustuna.StorageProtocol,
+        state: rustuna.TrialState,
+        values: Sequence[float] | None = None,
+    ) -> None:
+        raise RuntimeError("after_trial failed")
+
+
+def test_to_optuna_sampler_after_trial_is_called() -> None:
+    sampler = RecordingSampler()
+    study = optuna.create_study(sampler=ToOptunaSampler(sampler), direction="minimize")
+
+    study.optimize(lambda trial: trial.suggest_float("x", -1.0, 1.0), n_trials=2)
+
+    assert len(sampler.after_trial_calls) == 2
+    for study_id, trial_number, state, values in sampler.after_trial_calls:
+        assert study_id == study._study_id
+        assert trial_number >= 0
+        assert state == rustuna.TrialState.COMPLETE
+        assert values is not None
+        assert len(values) == 1
+
+
+def test_to_optuna_sampler_after_trial_failure_still_persists_trial() -> None:
+    sampler = FailingAfterTrialSampler()
+    study = optuna.create_study(sampler=ToOptunaSampler(sampler), direction="minimize")
+    trial = study.ask()
+
+    with pytest.raises(RuntimeError, match="after_trial failed"):
+        study.tell(trial, 1.0)
+
+    persisted = study.trials[0]
+    assert persisted.state == optuna.trial.TrialState.COMPLETE
+    assert persisted.values == [1.0]

--- a/rustuna_pyo3/tests/test_samplers.py
+++ b/rustuna_pyo3/tests/test_samplers.py
@@ -16,7 +16,7 @@ class DummyIndependentSampler:
     def sample_joint(
         self,
         ctx: rustuna.SamplerContext,
-        storage: rustuna.Storage,
+        storage: rustuna.StorageProtocol,
         search_space: dict[str, rustuna.Distribution],
     ) -> dict[str, float]:
         assert False, "Unreachable code"
@@ -24,7 +24,7 @@ class DummyIndependentSampler:
     def sample_independent(
         self,
         ctx: rustuna.SamplerContext,
-        storage: rustuna.Storage,
+        storage: rustuna.StorageProtocol,
         name: str,
         distribution: rustuna.Distribution,
     ) -> float:
@@ -36,6 +36,15 @@ class DummyIndependentSampler:
         elif dic["type"] == "CategoricalDistribution":
             return 0
         assert False, "Unreachable code"
+
+    def after_trial(
+        self,
+        ctx: rustuna.SamplerContext,
+        storage: rustuna.StorageProtocol,
+        state: rustuna.TrialState,
+        values: list[float] | None = None,
+    ) -> None:
+        return None
 
 
 class DummyJointSampler:
@@ -49,7 +58,7 @@ class DummyJointSampler:
     def sample_joint(
         self,
         ctx: rustuna.SamplerContext,
-        storage: rustuna.Storage,
+        storage: rustuna.StorageProtocol,
         search_space: dict[str, rustuna.Distribution],
     ) -> dict[str, float]:
         params = {}
@@ -68,7 +77,7 @@ class DummyJointSampler:
     def sample_independent(
         self,
         ctx: rustuna.SamplerContext,
-        storage: rustuna.Storage,
+        storage: rustuna.StorageProtocol,
         name: str,
         distribution: rustuna.Distribution,
     ) -> float:
@@ -81,6 +90,42 @@ class DummyJointSampler:
             return 0
         assert False, "Unreachable code"
 
+    def after_trial(
+        self,
+        ctx: rustuna.SamplerContext,
+        storage: rustuna.StorageProtocol,
+        state: rustuna.TrialState,
+        values: list[float] | None = None,
+    ) -> None:
+        return None
+
+
+class RecordingSampler(DummyIndependentSampler):
+    def __init__(self) -> None:
+        self.after_trial_calls: list[
+            tuple[int, int, rustuna.TrialState, list[float] | None]
+        ] = []
+
+    def after_trial(
+        self,
+        ctx: rustuna.SamplerContext,
+        storage: rustuna.StorageProtocol,
+        state: rustuna.TrialState,
+        values: list[float] | None = None,
+    ) -> None:
+        self.after_trial_calls.append((ctx.study_id, ctx.trial_number, state, values))
+
+
+class FailingAfterTrialSampler(DummyIndependentSampler):
+    def after_trial(
+        self,
+        ctx: rustuna.SamplerContext,
+        storage: rustuna.StorageProtocol,
+        state: rustuna.TrialState,
+        values: list[float] | None = None,
+    ) -> None:
+        raise RuntimeError("after_trial failed")
+
 
 @pytest.mark.parametrize("sampler", [DummyIndependentSampler(), DummyJointSampler()])
 def test_custom_sampler(sampler: rustuna.SamplerProtocol) -> None:
@@ -92,3 +137,30 @@ def test_custom_sampler(sampler: rustuna.SamplerProtocol) -> None:
 
     study = rustuna.create_study(sampler=sampler)
     study.optimize(objective, n_trials=100)
+
+
+def test_custom_sampler_after_trial_is_called() -> None:
+    sampler = RecordingSampler()
+
+    study = rustuna.create_study(sampler=sampler)
+    study.optimize(lambda trial: trial.suggest_float("x", -1.0, 1.0), n_trials=3)
+
+    assert len(sampler.after_trial_calls) == 3
+    for study_id, trial_number, state, values in sampler.after_trial_calls:
+        assert study_id == study._study_id
+        assert trial_number >= 0
+        assert state == rustuna.TrialState.COMPLETE
+        assert values is not None
+        assert len(values) == 1
+
+
+def test_custom_sampler_after_trial_failure_still_persists_trial() -> None:
+    study = rustuna.create_study(sampler=FailingAfterTrialSampler())
+    trial = study.ask()
+
+    with pytest.raises(RuntimeError, match="Failed to tell"):
+        study.tell(trial.number, 1.0)
+
+    persisted = study.trials[0]
+    assert persisted.state == rustuna.TrialState.COMPLETE
+    assert persisted.values == [1.0]

--- a/rustuna_samplers/src/nsgaii.rs
+++ b/rustuna_samplers/src/nsgaii.rs
@@ -258,6 +258,15 @@ impl Sampler for NSGAIISampler {
         }
         Ok(params)
     }
+
+    fn after_trial(
+        &mut self,
+        _ctx: &Context,
+        _storage: Arc<RwLock<dyn Storage>>,
+        _state_values: &TrialStateValues,
+    ) -> Result<()> {
+        Ok(())
+    }
 }
 
 fn fast_non_dominated_sort(

--- a/rustuna_samplers/src/tpe/sampler.rs
+++ b/rustuna_samplers/src/tpe/sampler.rs
@@ -445,6 +445,15 @@ impl Sampler for TpeSampler {
         let params = self.sample(ctx, storage, search_space)?;
         Ok(params)
     }
+
+    fn after_trial(
+        &mut self,
+        _ctx: &Context,
+        _storage: Arc<RwLock<dyn Storage>>,
+        _state_values: &TrialStateValues,
+    ) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR adds sampler-side `after_trial` support across Rust and Python layers.

Changes:

- add `Sampler::after_trial(...)` to the core sampler trait
- call `after_trial` from `Study::tell()` using Optuna-compatible timing
- persist final trial state/value even if after_trial raises, then propagate the error
- expose `after_trial(...)` in Python sampler bindings and protocol stubs
- update `ToOptunaSampler` to forward Optuna's `after_trial(...)` to Rustuna samplers
