### PR TITLE
Add `rustuna.trial` module

### DIFF
--- a/docs/docs/api/rustuna.md
+++ b/docs/docs/api/rustuna.md
@@ -1,8 +1,17 @@
 # Rustuna General API
 
 ::: rustuna
-		options:
-			members: true
-			filters:
-				- "!.*"
-			show_submodules: false
+    options:
+      members:
+        - Study
+        - PersistedStudy
+        - StudyDirection
+        - Sampler
+        - SamplerContext
+        - Storage
+        - TrialQueue
+        - create_study
+        - load_study
+        - copy_study
+        - get_param_importance
+      show_submodules: false

--- a/docs/docs/api/trial.md
+++ b/docs/docs/api/trial.md
@@ -1,7 +1,11 @@
-# Trial API
+# rustuna.trial
 
-::: rustuna.Trial
+The `trial` module contains `Trial` related classes and functions.
 
-::: rustuna.PersistedTrial
+::: rustuna.trial.Trial
 
-::: rustuna.TrialState
+::: rustuna.trial.PersistedTrial
+
+::: rustuna.trial.TrialState
+
+::: rustuna.trial.create_trial

--- a/docs/docs/tutorial/getting-started.md
+++ b/docs/docs/tutorial/getting-started.md
@@ -40,7 +40,7 @@ This function returns the value of $(x-2)^2$. Our goal is to find the value of `
 
 A [Trial](../api/trial.md) object corresponds to a single execution of the objective function and is internally instantiated upon each invocation of the function.
 
-The suggest APIs (for example, [suggest_float()](../api/trial.md#rustuna.Trial.suggest_float)) are called inside the objective function to obtain parameters for a trial. [suggest_float()](../api/trial.md#rustuna.Trial.suggest_float) selects parameters uniformly within the range provided. In our example, from $−10$ to $10$.
+The suggest APIs (for example, [suggest_float()](../api/trial.md#rustuna.trial.Trial.suggest_float)) are called inside the objective function to obtain parameters for a trial. [suggest_float()](../api/trial.md#rustuna.trial.Trial.suggest_float) selects parameters uniformly within the range provided. In our example, from $−10$ to $10$.
 
 To start the optimization, we create a study object and pass the objective function to method [optimize()](../api/study.md#rustuna.Study.optimize) as follows.
 
@@ -154,9 +154,9 @@ Found x: 1.9991240057627049, (x - 2)^2: 7.673659037742573e-07
 
 For parameter sampling, Rustuna provides the following features:
 
-- [rustuna.Trial.suggest_categorical()](../api/trial.md#rustuna.Trial.suggest_categorical) for categorical parameters
-- [rustuna.Trial.suggest_int()](../api/trial.md#rustuna.Trial.suggest_int) for integer parameters
-- [rustuna.Trial.suggest_float()](../api/trial.md#rustuna.Trial.suggest_float) for floating point parameters
+- [Trial.suggest_categorical()](../api/trial.md#rustuna.trial.Trial.suggest_categorical) for categorical parameters
+- [Trial.suggest_int()](../api/trial.md#rustuna.trial.Trial.suggest_int) for integer parameters
+- [Trial.suggest_float()](../api/trial.md#rustuna.trial.Trial.suggest_float) for floating point parameters
 
 With optional arguments of `step` and `log`, we can discretize or take the logarithm of integer and floating point parameters.
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -39,7 +39,7 @@ nav:
   - API Reference:
       - rustuna: api/rustuna.md
       - rustuna.Study: api/study.md
-      - rustuna.Trial: api/trial.md
+      - rustuna.trial: api/trial.md
       - rustuna.Sampler: api/sampler.md
       - rustuna.Storage: api/storage.md
       - rustuna.TrialQueue: api/trial_queue.md

--- a/rustuna_pyo3/rustuna/__init__.py
+++ b/rustuna_pyo3/rustuna/__init__.py
@@ -1,4 +1,53 @@
 # See https://pyo3.rs/v0.20.0/python_typing_hints#if-you-need-other-python-files
-from ._rustuna import *  # NOQA
+from typing import TYPE_CHECKING
 
-from . import exceptions  # NOQA
+from rustuna import exceptions, trial
+from rustuna._rustuna import (
+    Distribution,
+    PersistedStudy,
+    PyObjectStorage,
+    Sampler,
+    SamplerContext,
+    Storage,
+    Study,
+    StudyDirection,
+    Trial,
+    TrialQueue,
+    copy_study,
+    create_study,
+    create_trial,
+    get_param_importance,
+    load_study,
+)
+from rustuna.exceptions import TrialPruned
+
+if TYPE_CHECKING:
+    from rustuna._rustuna import (
+        CategoricalChoiceType,
+        OptunaStorageProtocol,
+        SamplerProtocol,
+        StorageProtocol,
+    )
+
+__all__ = [
+    # modules
+    "exceptions",
+    "trial",
+    # functions or classes
+    "Distribution",
+    "PersistedStudy",
+    "PyObjectStorage",
+    "Sampler",
+    "SamplerContext",
+    "Storage",
+    "Study",
+    "StudyDirection",
+    "Trial",
+    "TrialQueue",
+    "TrialPruned",
+    "copy_study",
+    "create_study",
+    "create_trial",
+    "get_param_importance",
+    "load_study",
+]

--- a/rustuna_pyo3/rustuna/converter/_storage.py
+++ b/rustuna_pyo3/rustuna/converter/_storage.py
@@ -57,8 +57,8 @@ class ToRustunaStorage:
         )
 
     def create_new_trial(
-        self, study_id: int, template_trial: rustuna.PersistedTrial | None = None
-    ) -> rustuna.PersistedTrial:
+        self, study_id: int, template_trial: rustuna.trial.PersistedTrial | None = None
+    ) -> rustuna.trial.PersistedTrial:
         template_frozen = to_frozen_trial(template_trial) if template_trial else None
         trial_id = self._storage.create_new_trial(
             study_id, template_trial=template_frozen
@@ -82,7 +82,7 @@ class ToRustunaStorage:
     def set_trial_state_values(
         self,
         trial_id: int,
-        state: rustuna.TrialState,
+        state: rustuna.trial.TrialState,
         values: None | list[float] = None,
     ) -> None:
         self._storage.set_trial_state_values(
@@ -106,21 +106,21 @@ class ToRustunaStorage:
         self,
         study_id: int,
         *,
-        states: list[rustuna.TrialState] | None = None,
-    ) -> list[rustuna.PersistedTrial]:
+        states: list[rustuna.trial.TrialState] | None = None,
+    ) -> list[rustuna.trial.PersistedTrial]:
         optuna_states = None
         if states is not None:
             optuna_states = tuple(to_optuna_state(state) for state in states)
         frozen_trials = self._storage.get_all_trials(study_id, states=optuna_states)
 
-        persisted_trials: list[rustuna.PersistedTrial] = []
+        persisted_trials: list[rustuna.trial.PersistedTrial] = []
         with self._lock:
             for t in frozen_trials:
                 persisted_trials.append(to_persisted_trial(t, study_id))
                 self._trial_id_to_study_id[t._trial_id] = study_id
         return persisted_trials
 
-    def get_trial(self, trial_id: int) -> rustuna.PersistedTrial:
+    def get_trial(self, trial_id: int) -> rustuna.trial.PersistedTrial:
         with self._lock:
             study_id = self._trial_id_to_study_id.get(trial_id, -1)
         if study_id == -1:
@@ -131,7 +131,7 @@ class ToRustunaStorage:
         frozen_trial = self._storage.get_trial(trial_id)
         return to_persisted_trial(frozen_trial, study_id=study_id)
 
-    def get_cached_trial(self, trial_id: int) -> rustuna.PersistedTrial:
+    def get_cached_trial(self, trial_id: int) -> rustuna.trial.PersistedTrial:
         return self.get_trial(trial_id)
 
     def delete_study(self, study_id: int) -> None:
@@ -268,7 +268,7 @@ class ToOptunaStorage(BaseStorage):
     def create_new_trial(
         self, study_id: int, template_trial: FrozenTrial | None = None
     ) -> int:
-        persisted_trial_template: rustuna.PersistedTrial | None = None
+        persisted_trial_template: rustuna.trial.PersistedTrial | None = None
         if template_trial is not None:
             for param_name, distribution in template_trial.distributions.items():
                 if isinstance(
@@ -350,7 +350,7 @@ class ToOptunaStorage(BaseStorage):
         deepcopy: bool = True,
         states: Container[TrialState] | None = None,
     ) -> list[FrozenTrial]:
-        rustuna_states: list[rustuna.TrialState] | None = None
+        rustuna_states: list[rustuna.trial.TrialState] | None = None
         if states is not None:
             assert isinstance(states, Iterable), (
                 "ToOptunaStorage assumes that states is Iterable to make this faster"

--- a/rustuna_pyo3/rustuna/converter/_trial.py
+++ b/rustuna_pyo3/rustuna/converter/_trial.py
@@ -28,32 +28,32 @@ if typing.TYPE_CHECKING:
 
 
 to_rustuna_state_map = {
-    optuna.trial.TrialState.RUNNING: rustuna.TrialState.RUNNING,
-    optuna.trial.TrialState.COMPLETE: rustuna.TrialState.COMPLETE,
-    optuna.trial.TrialState.FAIL: rustuna.TrialState.FAIL,
-    optuna.trial.TrialState.PRUNED: rustuna.TrialState.PRUNED,
-    optuna.trial.TrialState.WAITING: rustuna.TrialState.WAITING,
+    optuna.trial.TrialState.RUNNING: rustuna.trial.TrialState.RUNNING,
+    optuna.trial.TrialState.COMPLETE: rustuna.trial.TrialState.COMPLETE,
+    optuna.trial.TrialState.FAIL: rustuna.trial.TrialState.FAIL,
+    optuna.trial.TrialState.PRUNED: rustuna.trial.TrialState.PRUNED,
+    optuna.trial.TrialState.WAITING: rustuna.trial.TrialState.WAITING,
 }
-# TODO(c-bata): Make rustuna.TrialState hashable.
+# TODO(c-bata): Make rustuna.trial.TrialState hashable.
 # to_optuna_state_map = {v: k for k, v in to_optuna_state_map.items()}
 
 
-def to_optuna_state(state: rustuna.TrialState) -> optuna.trial.TrialState:
-    if state == rustuna.TrialState.RUNNING:
+def to_optuna_state(state: rustuna.trial.TrialState) -> optuna.trial.TrialState:
+    if state == rustuna.trial.TrialState.RUNNING:
         return optuna.trial.TrialState.RUNNING
-    elif state == rustuna.TrialState.COMPLETE:
+    elif state == rustuna.trial.TrialState.COMPLETE:
         return optuna.trial.TrialState.COMPLETE
-    elif state == rustuna.TrialState.FAIL:
+    elif state == rustuna.trial.TrialState.FAIL:
         return optuna.trial.TrialState.FAIL
-    elif state == rustuna.TrialState.PRUNED:
+    elif state == rustuna.trial.TrialState.PRUNED:
         return optuna.trial.TrialState.PRUNED
-    elif state == rustuna.TrialState.WAITING:
+    elif state == rustuna.trial.TrialState.WAITING:
         return optuna.trial.TrialState.WAITING
     else:
         raise KeyError(f"Unknown state: {state}")
 
 
-def to_rustuna_state(state: optuna.trial.TrialState) -> rustuna.TrialState:
+def to_rustuna_state(state: optuna.trial.TrialState) -> rustuna.trial.TrialState:
     return to_rustuna_state_map[state]
 
 
@@ -78,7 +78,7 @@ def _encode_intermediate_values(
 def to_persisted_trial(
     trial: optuna.trial.FrozenTrial,
     study_id: int,
-) -> rustuna.PersistedTrial:
+) -> rustuna.trial.PersistedTrial:
     optuna_system_attrs = trial.system_attrs.copy()
     if trial.intermediate_values:
         optuna_system_attrs["intermediate_values"] = _encode_intermediate_values(
@@ -90,7 +90,7 @@ def to_persisted_trial(
         optuna_distribution = trial.distributions[param_name]
         distributions[param_name] = to_rustuna_distribution(optuna_distribution)
 
-    return rustuna.PersistedTrial(
+    return rustuna.trial.PersistedTrial(
         trial_id=max(trial._trial_id, 0),
         study_id=study_id,
         number=max(trial.number, 0),
@@ -153,7 +153,7 @@ class _LazyJSONAttrs(dict[str, typing.Any]):
 
 
 class FrozenTrialLike(FrozenTrial):
-    def __init__(self, persisted_trial: rustuna.PersistedTrial) -> None:
+    def __init__(self, persisted_trial: rustuna.trial.PersistedTrial) -> None:
         self._persisted_trial = persisted_trial
 
         # Pre-cache frequently accessed lightweight fields to avoid repeated conversions
@@ -473,7 +473,7 @@ class FrozenTrialLike(FrozenTrial):
 
 
 def to_frozen_trial(
-    persisted_trial: rustuna.PersistedTrial,
+    persisted_trial: rustuna.trial.PersistedTrial,
     *,
     use_frozen_trial_like: bool = True,
 ) -> FrozenTrial:

--- a/rustuna_pyo3/rustuna/trial.py
+++ b/rustuna_pyo3/rustuna/trial.py
@@ -1,0 +1,4 @@
+from ._rustuna import create_trial  # NOQA
+from ._rustuna import PersistedTrial  # NOQA
+from ._rustuna import TrialState  # NOQA
+from ._rustuna import Trial  # NOQA

--- a/rustuna_pyo3/tests/storage_tests/test_journal_storage.py
+++ b/rustuna_pyo3/tests/storage_tests/test_journal_storage.py
@@ -48,11 +48,11 @@ def test_create_new_trial_from_template_optuna_compatibility() -> None:
             storage=rustuna_storage, study_name="example"
         )
         rustuna_study.add_trial(
-            rustuna.PersistedTrial(
+            rustuna.trial.PersistedTrial(
                 trial_id=0,
                 study_id=0,
                 number=0,
-                state=rustuna.TrialState.WAITING,
+                state=rustuna.trial.TrialState.WAITING,
             )
         )
 

--- a/rustuna_pyo3/tests/storage_tests/test_storage.py
+++ b/rustuna_pyo3/tests/storage_tests/test_storage.py
@@ -137,23 +137,23 @@ def test_get_trials_with_states_filter(storage: StorageProtocol) -> None:
     failed = study.ask()
 
     study.tell(completed.number, 1.0)
-    study.tell(failed.number, state=rustuna.TrialState.FAIL)
+    study.tell(failed.number, state=rustuna.trial.TrialState.FAIL)
 
     completed_trials = storage.get_trials(
-        study._study_id, states=[rustuna.TrialState.COMPLETE]
+        study._study_id, states=[rustuna.trial.TrialState.COMPLETE]
     )
     assert len(completed_trials) == 1
     assert completed_trials[0].number == completed.number
 
     running_trials = storage.get_trials(
-        study._study_id, states=[rustuna.TrialState.RUNNING]
+        study._study_id, states=[rustuna.trial.TrialState.RUNNING]
     )
     assert len(running_trials) == 1
     assert running_trials[0].number == running.number
 
     finished_trials = storage.get_trials(
         study._study_id,
-        states=[rustuna.TrialState.COMPLETE, rustuna.TrialState.FAIL],
+        states=[rustuna.trial.TrialState.COMPLETE, rustuna.trial.TrialState.FAIL],
     )
     assert {trial.number for trial in finished_trials} == {
         completed.number,

--- a/rustuna_pyo3/tests/test_optuna_samplers.py
+++ b/rustuna_pyo3/tests/test_optuna_samplers.py
@@ -33,7 +33,7 @@ class RecordingSampler:
 
     def __init__(self) -> None:
         self.after_trial_calls: list[
-            tuple[int, int, rustuna.TrialState, list[float] | None]
+            tuple[int, int, rustuna.trial.TrialState, list[float] | None]
         ] = []
 
     def sample_joint(
@@ -64,7 +64,7 @@ class RecordingSampler:
         self,
         ctx: rustuna.SamplerContext,
         storage: rustuna.StorageProtocol,
-        state: rustuna.TrialState,
+        state: rustuna.trial.TrialState,
         values: Sequence[float] | None = None,
     ) -> None:
         self.after_trial_calls.append(
@@ -82,7 +82,7 @@ class FailingAfterTrialSampler(RecordingSampler):
         self,
         ctx: rustuna.SamplerContext,
         storage: rustuna.StorageProtocol,
-        state: rustuna.TrialState,
+        state: rustuna.trial.TrialState,
         values: Sequence[float] | None = None,
     ) -> None:
         raise RuntimeError("after_trial failed")
@@ -98,7 +98,7 @@ def test_to_optuna_sampler_after_trial_is_called() -> None:
     for study_id, trial_number, state, values in sampler.after_trial_calls:
         assert study_id == study._study_id
         assert trial_number >= 0
-        assert state == rustuna.TrialState.COMPLETE
+        assert state == rustuna.trial.TrialState.COMPLETE
         assert values is not None
         assert len(values) == 1
 

--- a/rustuna_pyo3/tests/test_rustuna.py
+++ b/rustuna_pyo3/tests/test_rustuna.py
@@ -7,11 +7,11 @@ def test_load_study_with_trial_queue():
     storage = rustuna.Storage.in_memory()
     created = rustuna.create_study(study_name="queued-study", storage=storage)
 
-    template = rustuna.PersistedTrial(
+    template = rustuna.trial.PersistedTrial(
         trial_id=0,
         study_id=created._study_id,
         number=0,
-        state=rustuna.TrialState.WAITING,
+        state=rustuna.trial.TrialState.WAITING,
         system_attrs={"fixed_params:x": "f:0x4014000000000000"},
     )
     trial = storage.create_new_trial(created._study_id, template)
@@ -82,17 +82,17 @@ def test_study_get_trials_filters_by_states():
     study = rustuna.create_study()
     failed_trial = study.ask()
     completed_trial = study.ask()
-    study.tell(failed_trial.number, state=rustuna.TrialState.FAIL)
+    study.tell(failed_trial.number, state=rustuna.trial.TrialState.FAIL)
     study.tell(completed_trial.number, values=1.0)
 
     filtered = study.get_trials(
-        states=[rustuna.TrialState.FAIL, rustuna.TrialState.COMPLETE]
+        states=[rustuna.trial.TrialState.FAIL, rustuna.trial.TrialState.COMPLETE]
     )
 
     assert len(filtered) == 2
     assert [trial.state for trial in filtered] == [
-        rustuna.TrialState.FAIL,
-        rustuna.TrialState.COMPLETE,
+        rustuna.trial.TrialState.FAIL,
+        rustuna.trial.TrialState.COMPLETE,
     ]
 
 
@@ -108,10 +108,10 @@ def test_optimize_catch_exception():
     study.optimize(objective, n_trials=2, catch=(Exception, RuntimeError))
 
     assert len(study.trials) == 4
-    assert study.trials[0].state == rustuna.TrialState.FAIL
-    assert study.trials[1].state == rustuna.TrialState.COMPLETE
-    assert study.trials[2].state == rustuna.TrialState.FAIL
-    assert study.trials[3].state == rustuna.TrialState.COMPLETE
+    assert study.trials[0].state == rustuna.trial.TrialState.FAIL
+    assert study.trials[1].state == rustuna.trial.TrialState.COMPLETE
+    assert study.trials[2].state == rustuna.trial.TrialState.FAIL
+    assert study.trials[3].state == rustuna.trial.TrialState.COMPLETE
 
 
 def test_optimize_reraises_uncaught_exception():
@@ -126,7 +126,7 @@ def test_optimize_reraises_uncaught_exception():
     with pytest.raises(ValueError):
         study.optimize(objective, n_trials=1, catch=(RuntimeError,))
 
-    assert study.trials[0].state == rustuna.TrialState.FAIL
+    assert study.trials[0].state == rustuna.trial.TrialState.FAIL
 
 
 def test_optimize_trial_pruned():
@@ -137,7 +137,7 @@ def test_optimize_trial_pruned():
 
     study.optimize(objective, n_trials=1)
 
-    assert study.trials[0].state == rustuna.TrialState.PRUNED
+    assert study.trials[0].state == rustuna.trial.TrialState.PRUNED
 
 
 def test_optimize_multi_objective():
@@ -348,16 +348,16 @@ def test_ask():
 
 
 def test_trial_state():
-    state = rustuna.TrialState.COMPLETE
+    state = rustuna.trial.TrialState.COMPLETE
     assert state.is_finished()
 
 
 def test_persisted_trial():
-    trial = rustuna.PersistedTrial(
+    trial = rustuna.trial.PersistedTrial(
         trial_id=2,
         study_id=1,
         number=2,
-        state=rustuna.TrialState.COMPLETE,
+        state=rustuna.trial.TrialState.COMPLETE,
         values=[0.5],
     )
     assert trial.study_id == 1
@@ -367,8 +367,8 @@ def test_persisted_trial():
 
     pytest.raises(
         ValueError,
-        lambda: rustuna.PersistedTrial(
-            trial_id=2, study_id=1, number=2, state=rustuna.TrialState.COMPLETE
+        lambda: rustuna.trial.PersistedTrial(
+            trial_id=2, study_id=1, number=2, state=rustuna.trial.TrialState.COMPLETE
         ),
     )
 

--- a/rustuna_pyo3/tests/test_samplers.py
+++ b/rustuna_pyo3/tests/test_samplers.py
@@ -41,7 +41,7 @@ class DummyIndependentSampler:
         self,
         ctx: rustuna.SamplerContext,
         storage: rustuna.StorageProtocol,
-        state: rustuna.TrialState,
+        state: rustuna.trial.TrialState,
         values: list[float] | None = None,
     ) -> None:
         return None
@@ -94,7 +94,7 @@ class DummyJointSampler:
         self,
         ctx: rustuna.SamplerContext,
         storage: rustuna.StorageProtocol,
-        state: rustuna.TrialState,
+        state: rustuna.trial.TrialState,
         values: list[float] | None = None,
     ) -> None:
         return None
@@ -103,14 +103,14 @@ class DummyJointSampler:
 class RecordingSampler(DummyIndependentSampler):
     def __init__(self) -> None:
         self.after_trial_calls: list[
-            tuple[int, int, rustuna.TrialState, list[float] | None]
+            tuple[int, int, rustuna.trial.TrialState, list[float] | None]
         ] = []
 
     def after_trial(
         self,
         ctx: rustuna.SamplerContext,
         storage: rustuna.StorageProtocol,
-        state: rustuna.TrialState,
+        state: rustuna.trial.TrialState,
         values: list[float] | None = None,
     ) -> None:
         self.after_trial_calls.append((ctx.study_id, ctx.trial_number, state, values))
@@ -121,7 +121,7 @@ class FailingAfterTrialSampler(DummyIndependentSampler):
         self,
         ctx: rustuna.SamplerContext,
         storage: rustuna.StorageProtocol,
-        state: rustuna.TrialState,
+        state: rustuna.trial.TrialState,
         values: list[float] | None = None,
     ) -> None:
         raise RuntimeError("after_trial failed")
@@ -149,7 +149,7 @@ def test_custom_sampler_after_trial_is_called() -> None:
     for study_id, trial_number, state, values in sampler.after_trial_calls:
         assert study_id == study._study_id
         assert trial_number >= 0
-        assert state == rustuna.TrialState.COMPLETE
+        assert state == rustuna.trial.TrialState.COMPLETE
         assert values is not None
         assert len(values) == 1
 
@@ -162,5 +162,5 @@ def test_custom_sampler_after_trial_failure_still_persists_trial() -> None:
         study.tell(trial.number, 1.0)
 
     persisted = study.trials[0]
-    assert persisted.state == rustuna.TrialState.COMPLETE
+    assert persisted.state == rustuna.trial.TrialState.COMPLETE
     assert persisted.values == [1.0]

--- a/rustuna_pyo3/tests/test_trial.py
+++ b/rustuna_pyo3/tests/test_trial.py
@@ -4,7 +4,7 @@ import rustuna
 
 
 def test_create_trial() -> None:
-    trial = rustuna.create_trial(
+    trial = rustuna.trial.create_trial(
         params={"x": 1.5, "y": "foo"},
         distributions={
             "x": rustuna.Distribution.float(0.0, 10.0),
@@ -18,7 +18,7 @@ def test_create_trial() -> None:
     assert trial._trial_id == 0
     assert trial.study_id == 0
     assert trial.number == 0
-    assert trial.state == rustuna.TrialState.COMPLETE
+    assert trial.state == rustuna.trial.TrialState.COMPLETE
     assert trial.values == [5.0]
     assert trial.params == {"x": 1.5, "y": "foo"}
     assert trial.user_attrs["user"] == "attr"
@@ -34,7 +34,7 @@ def test_create_trial() -> None:
 
 
 def test_create_trial_distributions() -> None:
-    trial = rustuna.create_trial(
+    trial = rustuna.trial.create_trial(
         params={"lr": 0.01, "n_layers": 3, "activation": "relu"},
         distributions={
             "lr": rustuna.Distribution.float(1e-5, 1e-1),
@@ -43,7 +43,7 @@ def test_create_trial_distributions() -> None:
         },
         value=0.95,
     )
-    assert trial.state == rustuna.TrialState.COMPLETE
+    assert trial.state == rustuna.trial.TrialState.COMPLETE
     assert trial.params["lr"] == pytest.approx(0.01)
     assert trial.params["n_layers"] == 3
     assert trial.params["activation"] == "relu"
@@ -54,7 +54,7 @@ def test_create_trial_distributions() -> None:
 
 def test_create_trial_unknown_param_raises() -> None:
     with pytest.raises(Exception):
-        rustuna.create_trial(
+        rustuna.trial.create_trial(
             params={"x": 1.0, "unknown": 99.0},
             distributions={"x": rustuna.Distribution.float(0.0, 10.0)},
             value=1.0,
@@ -62,11 +62,11 @@ def test_create_trial_unknown_param_raises() -> None:
 
 
 def test_persisted_trial_new_distributions() -> None:
-    trial = rustuna.PersistedTrial(
+    trial = rustuna.trial.PersistedTrial(
         trial_id=10,
         study_id=1,
         number=5,
-        state=rustuna.TrialState.COMPLETE,
+        state=rustuna.trial.TrialState.COMPLETE,
         params={"lr": 0.001, "n_layers": 2, "activation": "tanh"},
         distributions={
             "lr": rustuna.Distribution.float(1e-5, 1e-1),
@@ -93,11 +93,11 @@ def test_persisted_trial_new_distributions() -> None:
 
 def test_persisted_trial_new_value_and_values_error() -> None:
     with pytest.raises(Exception):
-        rustuna.PersistedTrial(
+        rustuna.trial.PersistedTrial(
             trial_id=0,
             study_id=0,
             number=0,
-            state=rustuna.TrialState.COMPLETE,
+            state=rustuna.trial.TrialState.COMPLETE,
             value=1.0,
             values=[1.0],
         )


### PR DESCRIPTION
To improve the compatibility with Optuna, this PR introduces the following API changes:

- `rustuna.Trial` -> `rustuna.trial.Trial`
- `rustuna.PersistedTrial` -> `rustuna.trial.PersistedTrial`
- `rustuna.TrialState` -> `rustuna.trial.TrialState`
- `rustuna.create_trial` -> `rustuna.trial.create_trial`