### PR TITLE
Add `rustuna.study` module

### DIFF
--- a/docs/docs/api/rustuna.md
+++ b/docs/docs/api/rustuna.md
@@ -3,15 +3,10 @@
 ::: rustuna
     options:
       members:
-        - Study
-        - PersistedStudy
         - StudyDirection
         - Sampler
         - SamplerContext
         - Storage
         - TrialQueue
-        - create_study
-        - load_study
-        - copy_study
         - get_param_importance
       show_submodules: false

--- a/docs/docs/api/study.md
+++ b/docs/docs/api/study.md
@@ -1,13 +1,17 @@
-# Study API
+# rustuna.study
 
-::: rustuna.Study
+The `study` module implements the Study object and related functions.
+A public constructor is available for the Study class, but direct use of this constructor is not recommended.
+Instead, library users should create and load a Study using `create_study()` and `load_study()` respectively.
 
-::: rustuna.PersistedStudy
+::: rustuna.study.Study
 
-::: rustuna.StudyDirection
+::: rustuna.study.PersistedStudy
 
-::: rustuna.create_study
+::: rustuna.study.StudyDirection
 
-::: rustuna.load_study
+::: rustuna.study.create_study
 
-::: rustuna.copy_study
+::: rustuna.study.load_study
+
+::: rustuna.study.copy_study

--- a/docs/docs/tutorial/getting-started.md
+++ b/docs/docs/tutorial/getting-started.md
@@ -42,7 +42,7 @@ A [Trial](../api/trial.md) object corresponds to a single execution of the objec
 
 The suggest APIs (for example, [suggest_float()](../api/trial.md#rustuna.trial.Trial.suggest_float)) are called inside the objective function to obtain parameters for a trial. [suggest_float()](../api/trial.md#rustuna.trial.Trial.suggest_float) selects parameters uniformly within the range provided. In our example, from $−10$ to $10$.
 
-To start the optimization, we create a study object and pass the objective function to method [optimize()](../api/study.md#rustuna.Study.optimize) as follows.
+To start the optimization, we create a study object and pass the objective function to method [optimize()](../api/study.md#rustuna.study.Study.optimize) as follows.
 
 ```python
 study = rustuna.create_study()
@@ -70,7 +70,7 @@ Found x: 1.9977979724456008, (x - 2)^2: 4.848925350333516e-06
 
 ## Study Object
 
-In Rustuna, we use the study object to manage optimization. Method [create_study()](../api/rustuna.md#rustuna.create_study) returns a study object. A study object has useful properties for analyzing the optimization outcome.
+In Rustuna, we use the study object to manage optimization. Method [create_study()](../api/study.md#rustuna.study.create_study) returns a study object. A study object has useful properties for analyzing the optimization outcome.
 
 To get the best trial:
 
@@ -250,7 +250,7 @@ Rustuna provides the following sampling algorithms:
 
 The default sampler is [rustuna.Sampler.tpe](../api/sampler.md#rustuna.Sampler.tpe).
 
-You can specify a sampler using the `sampler` argument in [create_study()](../api/rustuna.md#rustuna.create_study) as follows.
+You can specify a sampler using the `sampler` argument in [create_study()](../api/study.md#rustuna.study.create_study) as follows.
 
 ```python
 study = rustuna.create_study(sampler=rustuna.Sampler.nsgaii())
@@ -279,7 +279,7 @@ Rustuna uses in-memory storage ([rustuna.Storage.in_memory](../api/storage.md#ru
 
 An RDB backend enables persistent experiments (i.e., to save and resume a study) as well as access to history of studies. In this section, let’s try simple examples running on a local environment with SQLite DB.
 
-We can create a persistent study by calling [create_study()](../api/rustuna.md#rustuna.create_study) function with a sqlite3 storage object as follows. An SQLite file `sqlite3_example.db` is created to store a new study record.
+We can create a persistent study by calling [create_study()](../api/study.md#rustuna.study.create_study) function with a sqlite3 storage object as follows. An SQLite file `sqlite3_example.db` is created to store a new study record.
 
 ```python
 import rustuna
@@ -312,7 +312,7 @@ Best value: [0.17297553171217403]
 Best params: {'x': 2.415903272062356, 'y': 0}
 ```
 
-To resume a study, call [load_study](../api/rustuna.md#rustuna.load_study) with the `study_name` and `storage` arguments as follows. When loading, you must specify the same database file and study name. Also, set `create_database` to `False` (Note: This argument is `False` by default, so it can be omitted).
+To resume a study, call [load_study](../api/study.md#rustuna.study.load_study) with the `study_name` and `storage` arguments as follows. When loading, you must specify the same database file and study name. Also, set `create_database` to `False` (Note: This argument is `False` by default, so it can be omitted).
 
 ```python
 storage = rustuna.Storage.sqlite3("rustuna_example.db", create_database=False)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -38,7 +38,7 @@ nav:
       - Getting Started: tutorial/getting-started.md
   - API Reference:
       - rustuna: api/rustuna.md
-      - rustuna.Study: api/study.md
+      - rustuna.study: api/study.md
       - rustuna.trial: api/trial.md
       - rustuna.Sampler: api/sampler.md
       - rustuna.Storage: api/storage.md

--- a/rustuna_pyo3/rustuna/__init__.py
+++ b/rustuna_pyo3/rustuna/__init__.py
@@ -1,7 +1,7 @@
 # See https://pyo3.rs/v0.20.0/python_typing_hints#if-you-need-other-python-files
 from typing import TYPE_CHECKING
 
-from rustuna import exceptions, trial
+from rustuna import exceptions, study, trial
 from rustuna._rustuna import (
     Distribution,
     PersistedStudy,
@@ -10,7 +10,6 @@ from rustuna._rustuna import (
     SamplerContext,
     Storage,
     Study,
-    StudyDirection,
     Trial,
     TrialQueue,
     copy_study,
@@ -32,6 +31,7 @@ if TYPE_CHECKING:
 __all__ = [
     # modules
     "exceptions",
+    "study",
     "trial",
     # functions or classes
     "Distribution",
@@ -41,7 +41,6 @@ __all__ = [
     "SamplerContext",
     "Storage",
     "Study",
-    "StudyDirection",
     "Trial",
     "TrialQueue",
     "TrialPruned",

--- a/rustuna_pyo3/rustuna/converter/_direction.py
+++ b/rustuna_pyo3/rustuna/converter/_direction.py
@@ -9,27 +9,31 @@ import rustuna
 
 def to_rustuna_directions(
     items: Sequence[optuna.study.StudyDirection],
-) -> list[rustuna.StudyDirection]:
+) -> list[rustuna.study.StudyDirection]:
     return [to_rustuna_direction(item) for item in items]
 
 
 def to_optuna_directions(
-    items: Sequence[rustuna.StudyDirection],
+    items: Sequence[rustuna.study.StudyDirection],
 ) -> list[optuna.study.StudyDirection]:
     return [to_optuna_direction(item) for item in items]
 
 
-def to_rustuna_direction(item: optuna.study.StudyDirection) -> rustuna.StudyDirection:
+def to_rustuna_direction(
+    item: optuna.study.StudyDirection,
+) -> rustuna.study.StudyDirection:
     if item == optuna.study.StudyDirection.MAXIMIZE:
-        return rustuna.StudyDirection.MAXIMIZE
+        return rustuna.study.StudyDirection.MAXIMIZE
     elif item == optuna.study.StudyDirection.MINIMIZE:
-        return rustuna.StudyDirection.MINIMIZE
+        return rustuna.study.StudyDirection.MINIMIZE
     else:
         raise ValueError("Rustuna does not support StudyDirection.UNSET.")
 
 
-def to_optuna_direction(item: rustuna.StudyDirection) -> optuna.study.StudyDirection:
-    if item == rustuna.StudyDirection.MAXIMIZE:
+def to_optuna_direction(
+    item: rustuna.study.StudyDirection,
+) -> optuna.study.StudyDirection:
+    if item == rustuna.study.StudyDirection.MAXIMIZE:
         return optuna.study.StudyDirection.MAXIMIZE
     else:
         return optuna.study.StudyDirection.MINIMIZE

--- a/rustuna_pyo3/rustuna/converter/_storage.py
+++ b/rustuna_pyo3/rustuna/converter/_storage.py
@@ -44,7 +44,7 @@ class ToRustunaStorage:
         self._lock = threading.Lock()
 
     def create_new_study(
-        self, study_name: str, directions: list[rustuna.StudyDirection]
+        self, study_name: str, directions: list[rustuna.study.StudyDirection]
     ) -> rustuna.PersistedStudy:
         optuna_directions = to_optuna_directions(directions)
         study_id = self._storage.create_new_study(optuna_directions, study_name)
@@ -210,12 +210,12 @@ class ToOptunaStorage(BaseStorage):
     def create_new_study(
         self, directions: Sequence[StudyDirection], study_name: str | None = None
     ) -> int:
-        rustuna_directions: list[rustuna.StudyDirection] = []
+        rustuna_directions: list[rustuna.study.StudyDirection] = []
         for d in directions:
             if d == StudyDirection.MINIMIZE:
-                rustuna_directions.append(rustuna.StudyDirection.MINIMIZE)
+                rustuna_directions.append(rustuna.study.StudyDirection.MINIMIZE)
             elif d == StudyDirection.MAXIMIZE:
-                rustuna_directions.append(rustuna.StudyDirection.MAXIMIZE)
+                rustuna_directions.append(rustuna.study.StudyDirection.MAXIMIZE)
             else:
                 raise ValueError("Unexpected Study Direction")
 

--- a/rustuna_pyo3/rustuna/study.py
+++ b/rustuna_pyo3/rustuna/study.py
@@ -1,0 +1,6 @@
+from ._rustuna import PersistedStudy  # NOQA
+from ._rustuna import Study  # NOQA
+from ._rustuna import StudyDirection  # NOQA
+from ._rustuna import copy_study  # NOQA
+from ._rustuna import create_study  # NOQA
+from ._rustuna import load_study  # NOQA

--- a/rustuna_pyo3/tests/storage_tests/test_storage.py
+++ b/rustuna_pyo3/tests/storage_tests/test_storage.py
@@ -52,7 +52,9 @@ def storage(request: FixtureRequest) -> Generator[StorageProtocol, None, None]:
 
 
 def test_get_study_attr_methods(storage: StorageProtocol) -> None:
-    study = storage.create_new_study("example study", [rustuna.StudyDirection.MINIMIZE])
+    study = storage.create_new_study(
+        "example study", [rustuna.study.StudyDirection.MINIMIZE]
+    )
     storage.set_study_user_attrs(
         study.id,
         {
@@ -88,7 +90,9 @@ def test_study_get_user_attr_method(storage: StorageProtocol) -> None:
 
 
 def test_get_trial_attr_methods(storage: StorageProtocol) -> None:
-    study = storage.create_new_study("example study", [rustuna.StudyDirection.MINIMIZE])
+    study = storage.create_new_study(
+        "example study", [rustuna.study.StudyDirection.MINIMIZE]
+    )
     trial = storage.create_new_trial(study.id)
     storage.set_trial_user_attrs(
         trial._trial_id,

--- a/rustuna_pyo3/tests/test_rustuna.py
+++ b/rustuna_pyo3/tests/test_rustuna.py
@@ -215,7 +215,7 @@ def test_create_study_load_if_exists_true():
     )
 
     assert first._study_id == second._study_id
-    assert second.directions == [rustuna.StudyDirection.MINIMIZE]
+    assert second.directions == [rustuna.study.StudyDirection.MINIMIZE]
 
 
 def test_create_study_load_if_exists_false():
@@ -396,7 +396,7 @@ def test_sample():
 
 def test_storage():
     storage = rustuna.Storage.in_memory()
-    study = storage.create_new_study("example", [rustuna.StudyDirection.MINIMIZE])
+    study = storage.create_new_study("example", [rustuna.study.StudyDirection.MINIMIZE])
 
 
 def test_get_pareto_front():


### PR DESCRIPTION
To improve the compatibility with Optuna, this PR introduces the following API changes:

- ` rustuna.Study` -> `rustuna.study.Study`
- ` rustuna.PersistedStudy` -> `rustuna.study.PersistedStudy`
- ` rustuna.StudyDirection` -> `rustuna.study.StudyDirection`
- ` rustuna.create_study` -> `rustuna.study.create_study`
- ` rustuna.load_study` -> `rustuna.study.load_study`
- ` rustuna.copy_study` -> `rustuna.study.copy_study`
