### PR TITLE
Improve Python module exports and move public protocols out of stub-only definitions

### DIFF
--- a/docs/docs/api/samplers.md
+++ b/docs/docs/api/samplers.md
@@ -1,5 +1,7 @@
 # rustuna.samplers
 
+::: rustuna.samplers.SamplerProtocol
+
 ::: rustuna.samplers.RandomSampler
 
 ::: rustuna.samplers.TPESampler

--- a/docs/docs/api/storages.md
+++ b/docs/docs/api/storages.md
@@ -1,5 +1,7 @@
 # rustuna.storages
 
+::: rustuna.storages.StorageProtocol
+
 ::: rustuna.storages.InMemoryStorage
 
 ::: rustuna.storages.SQLite3Storage

--- a/docs/docs/api/trial_queue.md
+++ b/docs/docs/api/trial_queue.md
@@ -1,5 +1,7 @@
 # rustuna.trial_queue
 
+::: rustuna.trial_queue.TrialQueueProtocol
+
 ::: rustuna.trial_queue.InMemoryTrialQueue
 
 ::: rustuna.trial_queue.SQLite3TrialQueue

--- a/rustuna_pyo3/rustuna/_protocols.py
+++ b/rustuna_pyo3/rustuna/_protocols.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from rustuna import CategoricalChoiceType
+    from rustuna._rustuna import Distribution
+    from rustuna.samplers import SamplerContext
+    from rustuna.study import PersistedStudy, StudyDirection
+    from rustuna.trial import PersistedTrial, TrialState
+
+
+class SamplerProtocol(Protocol):
+    """Protocol for sampler implementations.
+
+    This protocol defines the interface that samplers must implement
+    to suggest parameter values.
+    """
+
+    @property
+    def support_joint_sampling(self) -> bool:
+        """Return True if the sampler supports joint parameter sampling."""
+
+    def sample_joint(
+        self,
+        ctx: SamplerContext,
+        storage: StorageProtocol,
+        search_space: dict[str, Distribution],
+    ) -> dict[str, float]:
+        """Sample multiple parameters simultaneously.
+
+        Args:
+            ctx: Sampler context.
+            storage: Storage object.
+            search_space: Parameter distributions.
+
+        Returns:
+            Suggested parameter values (Optuna's internal representation).
+        """
+
+    def sample_independent(
+        self,
+        ctx: SamplerContext,
+        storage: StorageProtocol,
+        name: str,
+        distribution: Distribution,
+    ) -> float:
+        """Sample a single parameter independently.
+
+        Args:
+            ctx: Sampler context.
+            storage: Storage object.
+            name: Parameter name.
+            distribution: Parameter distribution.
+
+        Returns:
+            Suggested parameter value (Optuna's internal representation).
+        """
+
+    def after_trial(
+        self,
+        ctx: SamplerContext,
+        storage: StorageProtocol,
+        state: TrialState,
+        values: list[float] | None = None,
+    ) -> None:
+        """Run sampler post-processing after a trial finishes.
+
+        Args:
+            ctx: Sampler context.
+            storage: Storage object.
+            state: Final trial state.
+            values: Final objective values. ``None`` unless the trial completed.
+        """
+
+
+class TrialQueueProtocol(Protocol):
+    """Protocol for trial queue implementations.
+
+    This protocol defines the interface implemented by trial queue objects.
+    """
+
+    def enqueue(self, trial_id: int) -> None:
+        """Add a trial ID to the queue.
+
+        Args:
+            trial_id: The trial ID to enqueue.
+        """
+
+    def dequeue(self) -> int:
+        """Remove and return the next trial ID from the queue.
+
+        Returns:
+            The next trial ID in FIFO order.
+
+        Raises:
+            Exception: If the queue is empty.
+        """
+
+
+class StorageProtocol(Protocol):
+    """Protocol for storage implementations.
+
+    This protocol defines the interface that storage backends must implement
+    to persist optimization history.
+    """
+
+    def create_new_study(
+        self, study_name: str, directions: list[StudyDirection]
+    ) -> PersistedStudy:
+        """Create a new study.
+
+        Args:
+            study_name: Name of the study.
+            directions: Optimization directions.
+
+        Returns:
+            The created study.
+        """
+
+    def delete_study(self, study_id: int) -> None:
+        """Delete a study.
+
+        Args:
+            study_id: ID of the study to delete.
+        """
+
+    def create_new_trial(
+        self,
+        study_id: int,
+        template_trial: PersistedTrial | None = None,
+    ) -> PersistedTrial:
+        """Create a new trial in the specified study.
+
+        Args:
+            study_id: ID of the study.
+            template_trial: Template PersistedTrial with default user-attributes,
+                system-attributes, intermediate-values, and a state.
+
+        Returns:
+            The created trial.
+        """
+
+    def set_trial_param(
+        self,
+        trial_id: int,
+        name: str,
+        distribution: Distribution,
+        value: float,
+    ) -> None:
+        """Set a parameter value for a trial.
+
+        Args:
+            trial_id: ID of the trial.
+            name: Parameter name.
+            distribution: Parameter distribution.
+            value: Internal representation of the parameter value.
+        """
+
+    def set_trial_state_values(
+        self,
+        trial_id: int,
+        state: TrialState,
+        values: None | list[float] = None,
+    ) -> None:
+        """Set the state and values of a trial.
+
+        Args:
+            trial_id: ID of the trial.
+            state: New state of the trial.
+            values: Objective values (required when state is COMPLETE).
+        """
+
+    def get_studies(self) -> list[PersistedStudy]:
+        """Get all studies.
+
+        Returns:
+            List of all studies.
+        """
+
+    def get_study(self, study_id: int) -> PersistedStudy:
+        """Get a study by ID.
+
+        Args:
+            study_id: ID of the study.
+
+        Returns:
+            The study.
+        """
+
+    def get_trials(
+        self, study_id: int, *, states: list[TrialState] | None = None
+    ) -> list[PersistedTrial]:
+        """Get all trials in a study.
+
+        Args:
+            study_id: ID of the study.
+            states: Optional trial states to filter by.
+
+        Returns:
+            List of all trials in the study.
+        """
+
+    def get_trial(self, trial_id: int) -> PersistedTrial:
+        """Get a trial by ID.
+
+        Args:
+            trial_id: ID of the trial.
+
+        Returns:
+            The trial.
+        """
+
+    def get_cached_trial(self, trial_id: int) -> PersistedTrial:
+        """Get a cached trial by ID without synchronizing with backends.
+
+        Args:
+            trial_id: ID of the trial.
+
+        Returns:
+            The trial.
+        """
+
+    def get_study_user_attr(self, study_id: int, key: str) -> str:
+        """Get a single user attribute of a study.
+
+        Args:
+            study_id: ID of the study.
+            key: Attribute key.
+
+        Returns:
+            The attribute value as a string.
+        """
+
+    def get_study_system_attr(self, study_id: int, key: str) -> str:
+        """Get a single system attribute of a study.
+
+        Args:
+            study_id: ID of the study.
+            key: Attribute key.
+
+        Returns:
+            The attribute value as a string.
+        """
+
+    def get_trial_id_from_study_id_trial_number(
+        self, study_id: int, trial_number: int
+    ) -> int:
+        """Get a trial ID from study ID and trial number.
+
+        Args:
+            study_id: ID of the study.
+            trial_number: Number of the trial within the study.
+
+        Returns:
+            ID of the trial.
+        """
+
+    def set_study_system_attrs(self, study_id: int, attrs: dict[str, str]) -> None:
+        """Set system attributes of a study.
+
+        Args:
+            study_id: ID of the study.
+            attrs: System attributes to set.
+        """
+
+    def set_study_user_attrs(self, study_id: int, attrs: dict[str, str]) -> None:
+        """Set user attributes of a study.
+
+        Args:
+            study_id: ID of the study.
+            attrs: User attributes to set.
+        """
+
+    def set_trial_system_attrs(self, trial_id: int, attrs: dict[str, str]) -> None:
+        """Set system attributes of a trial.
+
+        Args:
+            trial_id: ID of the trial.
+            attrs: System attributes to set.
+        """
+
+    def set_trial_user_attrs(self, trial_id: int, attrs: dict[str, str]) -> None:
+        """Set user attributes of a trial.
+
+        Args:
+            trial_id: ID of the trial.
+            attrs: User attributes to set.
+        """
+
+    def set_category_labels(
+        self,
+        study_id: int,
+        param_name: str,
+        choices: list[CategoricalChoiceType],
+    ) -> None:
+        """Set category labels for a categorical parameter.
+
+        Args:
+            study_id: ID of the study.
+            param_name: Name of the categorical parameter.
+            choices: List of category labels.
+        """
+
+    def get_category_labels(
+        self,
+        study_id: int,
+        param_name: str,
+        cardinality: int,
+    ) -> list[CategoricalChoiceType] | None:
+        """Get category labels for a categorical parameter.
+
+        Args:
+            study_id: ID of the study.
+            param_name: Name of the categorical parameter.
+            cardinality: Number of categories.
+
+        Returns:
+            List of category labels, or None if not set.
+        """
+
+
+class OptunaStorageProtocol(StorageProtocol, Protocol):
+    def set_trial_intermediate_value(
+        self, trial_id: int, step: int, intermediate_value: float
+    ) -> None:
+        """Set an intermediate value for a trial.
+
+        Args:
+            trial_id: ID of the trial.
+            step: Step at which the intermediate value is reported.
+            intermediate_value: Intermediate objective value.
+        """

--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -11,6 +11,13 @@ from collections.abc import (
 )
 from typing import Any, Literal, Protocol, TypedDict, TypeVar, overload
 
+from ._protocols import (
+    OptunaStorageProtocol,
+    SamplerProtocol,
+    StorageProtocol,
+    TrialQueueProtocol,
+)
+
 _T = TypeVar("_T")
 
 CategoricalChoiceType = float | int | str | bool | None
@@ -595,221 +602,8 @@ class PersistedStudy:
     def system_attrs(self) -> dict[str, str]: ...
 
 ## Storage
-class StorageProtocol(Protocol):
-    """Protocol for storage implementations.
 
-    This protocol defines the interface that storage backends must implement
-    to persist optimization history.
-    """
-    def create_new_study(
-        self, study_name: str, directions: list[StudyDirection]
-    ) -> PersistedStudy:
-        """Create a new study.
-
-        Args:
-            study_name: Name of the study.
-            directions: Optimization directions.
-
-        Returns:
-            The created study.
-        """
-    def delete_study(self, study_id: int) -> None:
-        """Delete a study.
-
-        Args:
-            study_id: ID of the study to delete.
-        """
-    def create_new_trial(
-        self,
-        study_id: int,
-        template_trial: PersistedTrial | None = None,
-    ) -> PersistedTrial:
-        """Create a new trial in the specified study.
-
-        Args:
-            study_id: ID of the study.
-            template_trial: Template PersistedTrial with default user-attributes,
-                system-attributes, intermediate-values, and a state.
-
-        Returns:
-            The created trial.
-        """
-    def set_trial_param(
-        self,
-        trial_id: int,
-        name: str,
-        distribution: Distribution,
-        value: float,
-    ) -> None:
-        """Set a parameter value for a trial.
-
-        Args:
-            trial_id: ID of the trial.
-            name: Parameter name.
-            distribution: Parameter distribution.
-            value: Internal representation of the parameter value.
-        """
-    def set_trial_state_values(
-        self,
-        trial_id: int,
-        state: TrialState,
-        values: None | list[float] = None,
-    ) -> None:
-        """Set the state and values of a trial.
-
-        Args:
-            trial_id: ID of the trial.
-            state: New state of the trial.
-            values: Objective values (required when state is COMPLETE).
-        """
-    def get_studies(self) -> list[PersistedStudy]:
-        """Get all studies.
-
-        Returns:
-            List of all studies.
-        """
-    def get_study(self, study_id: int) -> PersistedStudy:
-        """Get a study by ID.
-
-        Args:
-            study_id: ID of the study.
-
-        Returns:
-            The study.
-        """
-    def get_trials(
-        self, study_id: int, *, states: list[TrialState] | None = None
-    ) -> list[PersistedTrial]:
-        """Get all trials in a study.
-
-        Args:
-            study_id: ID of the study.
-            states: Optional trial states to filter by.
-
-        Returns:
-            List of all trials in the study.
-        """
-    def get_trial(self, trial_id: int) -> PersistedTrial:
-        """Get a trial by ID.
-
-        Args:
-            trial_id: ID of the trial.
-
-        Returns:
-            The trial.
-        """
-    def get_cached_trial(self, trial_id: int) -> PersistedTrial:
-        """Get a cached trial by ID without synchronizing with backends.
-
-        Args:
-            trial_id: ID of the trial.
-
-        Returns:
-            The trial.
-        """
-    def get_study_user_attr(self, study_id: int, key: str) -> str:
-        """Get a single user attribute of a study.
-
-        Args:
-            study_id: ID of the study.
-            key: Attribute key.
-
-        Returns:
-            The attribute value as a string.
-        """
-    def get_study_system_attr(self, study_id: int, key: str) -> str:
-        """Get a single system attribute of a study.
-
-        Args:
-            study_id: ID of the study.
-            key: Attribute key.
-
-        Returns:
-            The attribute value as a string.
-        """
-    def get_trial_id_from_study_id_trial_number(
-        self, study_id: int, trial_number: int
-    ) -> int:
-        """Get a trial ID from study ID and trial number.
-
-        Args:
-            study_id: ID of the study.
-            trial_number: Number of the trial within the study.
-
-        Returns:
-            ID of the trial.
-        """
-    def set_study_system_attrs(self, study_id: int, attrs: dict[str, str]) -> None:
-        """Set system attributes of a study.
-
-        Args:
-            study_id: ID of the study.
-            attrs: System attributes to set.
-        """
-    def set_study_user_attrs(self, study_id: int, attrs: dict[str, str]) -> None:
-        """Set user attributes of a study.
-
-        Args:
-            study_id: ID of the study.
-            attrs: User attributes to set.
-        """
-    def set_trial_system_attrs(self, trial_id: int, attrs: dict[str, str]) -> None:
-        """Set system attributes of a trial.
-
-        Args:
-            trial_id: ID of the trial.
-            attrs: System attributes to set.
-        """
-    def set_trial_user_attrs(self, trial_id: int, attrs: dict[str, str]) -> None:
-        """Set user attributes of a trial.
-
-        Args:
-            trial_id: ID of the trial.
-            attrs: User attributes to set.
-        """
-    def set_category_labels(
-        self,
-        study_id: int,
-        param_name: str,
-        choices: list[CategoricalChoiceType],
-    ) -> None:
-        """Set category labels for a categorical parameter.
-
-        Args:
-            study_id: ID of the study.
-            param_name: Name of the categorical parameter.
-            choices: List of category labels.
-        """
-    def get_category_labels(
-        self,
-        study_id: int,
-        param_name: str,
-        cardinality: int,
-    ) -> list[CategoricalChoiceType] | None:
-        """Get category labels for a categorical parameter.
-
-        Args:
-            study_id: ID of the study.
-            param_name: Name of the categorical parameter.
-            cardinality: Number of categories.
-
-        Returns:
-            List of category labels, or None if not set.
-        """
-
-class OptunaStorageProtocol(StorageProtocol, Protocol):
-    def set_trial_intermediate_value(
-        self, trial_id: int, step: int, intermediate_value: float
-    ) -> None:
-        """Set an intermediate value for a trial.
-
-        Args:
-            trial_id: ID of the trial.
-            step: Step at which the intermediate value is reported.
-            intermediate_value: Intermediate objective value.
-        """
-
-class PyObjectStorage(StorageProtocol):
+class PyObjectStorage:
     """Wrapper to convert a StorageProtocol implementation to Rust Storage trait.
 
     This class wraps a Python object implementing StorageProtocol and makes it
@@ -828,19 +622,59 @@ class PyObjectStorage(StorageProtocol):
             storage: A Python object implementing StorageProtocol.
         """
 
-class PyObjectTrialQueue(TrialQueueProtocol):
-    """Wrapper to convert a TrialQueueProtocol implementation to Rust TrialQueue trait.
-
-    This class wraps a Python object implementing TrialQueueProtocol and makes it
-    usable as a Rust TrialQueue trait implementation.
-    """
-
-    def __init__(self, trial_queue: TrialQueueProtocol) -> None:
-        """Create a PyObjectTrialQueue from a TrialQueueProtocol instance.
-
-        Args:
-            trial_queue: A Python object implementing TrialQueueProtocol.
-        """
+    def create_new_study(
+        self, study_name: str, directions: list[StudyDirection]
+    ) -> PersistedStudy: ...
+    def delete_study(self, study_id: int) -> None: ...
+    def create_new_trial(
+        self,
+        study_id: int,
+        template_trial: PersistedTrial | None = None,
+    ) -> PersistedTrial: ...
+    def set_trial_param(
+        self,
+        trial_id: int,
+        name: str,
+        distribution: Distribution,
+        value: float,
+    ) -> None: ...
+    def set_trial_state_values(
+        self,
+        trial_id: int,
+        state: TrialState,
+        values: None | list[float] = None,
+    ) -> None: ...
+    def get_studies(self) -> list[PersistedStudy]: ...
+    def get_study(self, study_id: int) -> PersistedStudy: ...
+    def get_trials(
+        self, study_id: int, *, states: list[TrialState] | None = None
+    ) -> list[PersistedTrial]: ...
+    def get_trial(self, trial_id: int) -> PersistedTrial: ...
+    def get_cached_trial(self, trial_id: int) -> PersistedTrial: ...
+    def get_trial_id_from_study_id_trial_number(
+        self, study_id: int, trial_number: int
+    ) -> int: ...
+    def get_study_user_attr(self, study_id: int, key: str) -> str: ...
+    def get_study_system_attr(self, study_id: int, key: str) -> str: ...
+    def set_study_system_attrs(self, study_id: int, attrs: dict[str, str]) -> None: ...
+    def set_study_user_attrs(self, study_id: int, attrs: dict[str, str]) -> None: ...
+    def set_trial_system_attrs(self, trial_id: int, attrs: dict[str, str]) -> None: ...
+    def set_trial_user_attrs(self, trial_id: int, attrs: dict[str, str]) -> None: ...
+    def set_category_labels(
+        self,
+        study_id: int,
+        param_name: str,
+        choices: list[CategoricalChoiceType],
+    ) -> None: ...
+    def get_category_labels(
+        self,
+        study_id: int,
+        param_name: str,
+        cardinality: int,
+    ) -> list[CategoricalChoiceType] | None: ...
+    def set_trial_intermediate_value(
+        self, trial_id: int, step: int, intermediate_value: float
+    ) -> None: ...
 
 class Storage:
     """Storage for persisting optimization history."""
@@ -934,66 +768,6 @@ class SamplerContext:
         directions: list[StudyDirection],
     ) -> None: ...
 
-class SamplerProtocol(Protocol):
-    """Protocol for sampler implementations.
-
-    This protocol defines the interface that samplers must implement
-    to suggest parameter values.
-    """
-    @property
-    def support_joint_sampling(self) -> bool:
-        """Return True if the sampler supports joint parameter sampling."""
-
-    def sample_joint(
-        self,
-        ctx: SamplerContext,
-        storage: StorageProtocol,
-        search_space: dict[str, Distribution],
-    ) -> dict[str, float]:
-        """Sample multiple parameters simultaneously.
-
-        Args:
-            ctx: Sampler context.
-            storage: Storage object.
-            search_space: Parameter distributions.
-
-        Returns:
-            Suggested parameter values (Optuna's internal representation).
-        """
-    def sample_independent(
-        self,
-        ctx: SamplerContext,
-        storage: StorageProtocol,
-        name: str,
-        distribution: Distribution,
-    ) -> float:
-        """Sample a single parameter independently.
-
-        Args:
-            ctx: Sampler context.
-            storage: Storage object.
-            name: Parameter name.
-            distribution: Parameter distribution.
-
-        Returns:
-            Suggested parameter value (Optuna's internal representation).
-        """
-    def after_trial(
-        self,
-        ctx: SamplerContext,
-        storage: StorageProtocol,
-        state: TrialState,
-        values: list[float] | None = None,
-    ) -> None:
-        """Run sampler post-processing after a trial finishes.
-
-        Args:
-            ctx: Sampler context.
-            storage: Storage object.
-            state: Final trial state.
-            values: Final objective values. ``None`` unless the trial completed.
-        """
-
 class Sampler:
     """Factory class for creating sampler instances."""
 
@@ -1038,28 +812,6 @@ class Sampler:
         values: list[float] | None = None,
     ) -> None: ...
 
-class TrialQueueProtocol(Protocol):
-    """Protocol for trial queue implementations.
-
-    This protocol defines the interface implemented by trial queue objects.
-    """
-    def enqueue(self, trial_id: int) -> None:
-        """Add a trial ID to the queue.
-
-        Args:
-            trial_id: The trial ID to enqueue.
-        """
-
-    def dequeue(self) -> int:
-        """Remove and return the next trial ID from the queue.
-
-        Returns:
-            The next trial ID in LIFO order.
-
-        Raises:
-            Exception: If the queue is empty.
-        """
-
 # Trial Queue
 class TrialQueue:
     """Factory class for creating trial queue instances.
@@ -1074,3 +826,22 @@ class TrialQueue:
     def directory(cls, base_dir: str) -> TrialQueueProtocol: ...
     @classmethod
     def sqlite3(cls, db_path: str, namespace: str) -> TrialQueueProtocol: ...
+    def enqueue(self, trial_id: int) -> None: ...
+    def dequeue(self) -> int: ...
+
+class PyObjectTrialQueue:
+    """Wrapper to convert a TrialQueueProtocol implementation to Rust TrialQueue trait.
+
+    This class wraps a Python object implementing TrialQueueProtocol and makes it
+    usable as a Rust TrialQueue trait implementation.
+    """
+
+    def __init__(self, trial_queue: TrialQueueProtocol) -> None:
+        """Create a PyObjectTrialQueue from a TrialQueueProtocol instance.
+
+        Args:
+            trial_queue: A Python object implementing TrialQueueProtocol.
+        """
+
+    def enqueue(self, trial_id: int) -> None: ...
+    def dequeue(self) -> int: ...

--- a/rustuna_pyo3/rustuna/converter/_sampler.py
+++ b/rustuna_pyo3/rustuna/converter/_sampler.py
@@ -31,7 +31,7 @@ class ToOptunaSampler(BaseSampler):
         self._inter_section_search_space = IntersectionSearchSpace()
         self._storage: PyObjectStorage | None = None
 
-    def _get_storage(self, storage: BaseStorage) -> PyObjectStorage:
+    def _get_storage(self, storage: BaseStorage) -> StorageProtocol:
         if self._storage is None:
             self._storage = PyObjectStorage(ToRustunaStorage(storage))
         return self._storage

--- a/rustuna_pyo3/rustuna/distributions.py
+++ b/rustuna_pyo3/rustuna/distributions.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
     from rustuna._rustuna import CategoricalChoiceType
 
 __all__ = [
+    "Distribution",
     "FloatDistribution",
     "IntDistribution",
     "CategoricalDistribution",

--- a/rustuna_pyo3/rustuna/samplers.py
+++ b/rustuna_pyo3/rustuna/samplers.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from rustuna._rustuna import SamplerProtocol
-
+from rustuna._protocols import SamplerProtocol
 from rustuna._rustuna import Sampler, SamplerContext
 
 __all__ = [

--- a/rustuna_pyo3/rustuna/storages.py
+++ b/rustuna_pyo3/rustuna/storages.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from rustuna._rustuna import OptunaStorageProtocol, StorageProtocol
-
+from rustuna._protocols import OptunaStorageProtocol, StorageProtocol
 from rustuna._rustuna import Storage
 
 __all__ = [

--- a/rustuna_pyo3/rustuna/study.py
+++ b/rustuna_pyo3/rustuna/study.py
@@ -1,6 +1,17 @@
-from ._rustuna import PersistedStudy  # NOQA
-from ._rustuna import Study  # NOQA
-from ._rustuna import StudyDirection  # NOQA
-from ._rustuna import copy_study  # NOQA
-from ._rustuna import create_study  # NOQA
-from ._rustuna import load_study  # NOQA
+from ._rustuna import (
+    PersistedStudy,
+    Study,
+    StudyDirection,
+    copy_study,
+    create_study,
+    load_study,
+)
+
+__all__ = [
+    "PersistedStudy",
+    "Study",
+    "StudyDirection",
+    "copy_study",
+    "create_study",
+    "load_study",
+]

--- a/rustuna_pyo3/rustuna/trial.py
+++ b/rustuna_pyo3/rustuna/trial.py
@@ -1,4 +1,8 @@
-from ._rustuna import create_trial  # NOQA
-from ._rustuna import PersistedTrial  # NOQA
-from ._rustuna import TrialState  # NOQA
-from ._rustuna import Trial  # NOQA
+from ._rustuna import PersistedTrial, Trial, TrialState, create_trial
+
+__all__ = [
+    "PersistedTrial",
+    "Trial",
+    "TrialState",
+    "create_trial",
+]

--- a/rustuna_pyo3/rustuna/trial_queue.py
+++ b/rustuna_pyo3/rustuna/trial_queue.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from rustuna._rustuna import TrialQueueProtocol
-
+from rustuna._protocols import TrialQueueProtocol
 from rustuna._rustuna import TrialQueue
 
 __all__ = [
+    "TrialQueueProtocol",
     "InMemoryTrialQueue",
     "SQLite3TrialQueue",
     "DirectoryTrialQueue",

--- a/rustuna_pyo3/tests/trial_queue_tests/__init__.py
+++ b/rustuna_pyo3/tests/trial_queue_tests/__init__.py
@@ -10,7 +10,7 @@ import pytest
 import rustuna
 
 if TYPE_CHECKING:
-    from rustuna._rustuna import TrialQueueProtocol
+    from rustuna.trial_queue import TrialQueueProtocol
 
 TrialQueueType = Literal["in_memory", "python_in_memory", "directory", "sqlite3"]
 MultiprocessQueueType = Literal["directory", "sqlite3"]


### PR DESCRIPTION
`mypy` reported `attr-defined` errors for public names imported from submodules such as `rustuna.trial` and `rustuna.study`. The root cause was that some public exports were not declared explicitly, and several public protocol types existed only in `_rustuna.pyi` rather than in runtime Python modules.

Changes:
- add explicit `__all__` definitions for public submodules to make exported names clear to both users and type checkers
- move public protocol definitions (`StorageProtocol`, `OptunaStorageProtocol`, `SamplerProtocol`, and `TrialQueueProtocol`) from stub-only definitions into Python runtime modules via `rustuna._protocols`
- update public module re-exports and stubs so runtime imports and type-checking behavior stay aligned