### PR TITLE
Remove `compact_str` and `once_cell` from the dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,6 @@ name = "rustuna_core"
 version = "0.1.0"
 dependencies = [
  "lasso",
- "once_cell",
  "rand",
  "rand_distr",
  "statrs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,15 +63,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 
 [[package]]
-name = "castaway"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,20 +87,6 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "windows-link",
-]
-
-[[package]]
-name = "compact_str"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "rustversion",
- "ryu",
- "static_assertions",
 ]
 
 [[package]]
@@ -724,7 +701,6 @@ dependencies = [
 name = "rustuna_core"
 version = "0.1.0"
 dependencies = [
- "compact_str",
  "lasso",
  "once_cell",
  "rand",
@@ -891,12 +867,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "statrs"

--- a/rustuna_core/Cargo.toml
+++ b/rustuna_core/Cargo.toml
@@ -14,4 +14,3 @@ rand = { workspace = true }
 rand_distr = "0.4.3"
 statrs = "0.18.0"
 lasso = { version = "0.7", features = ["multi-threaded"] }
-once_cell = "1.21"

--- a/rustuna_core/Cargo.toml
+++ b/rustuna_core/Cargo.toml
@@ -13,6 +13,5 @@ readme = "README.md"
 rand = { workspace = true }
 rand_distr = "0.4.3"
 statrs = "0.18.0"
-compact_str = "0.9"
 lasso = { version = "0.7", features = ["multi-threaded"] }
 once_cell = "1.21"

--- a/rustuna_core/src/attr.rs
+++ b/rustuna_core/src/attr.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 use std::fmt;
+use std::sync::OnceLock;
 
 use lasso::{Spur, ThreadedRodeo};
-use once_cell::sync::Lazy;
 
 pub type Attrs = HashMap<AttrKey, String>;
 
@@ -12,14 +12,18 @@ pub enum AttrKey {
     System(InternedString),
 }
 
-static INTERNER: Lazy<ThreadedRodeo> = Lazy::new(ThreadedRodeo::new);
+static INTERNER: OnceLock<ThreadedRodeo> = OnceLock::new();
+
+fn interner() -> &'static ThreadedRodeo {
+    INTERNER.get_or_init(ThreadedRodeo::new)
+}
 
 #[derive(Eq, Hash, Clone, Debug, PartialEq)]
 pub struct InternedString(Spur);
 
 impl InternedString {
     pub fn as_str(&self) -> &'static str {
-        INTERNER.resolve(&self.0)
+        interner().resolve(&self.0)
     }
 }
 
@@ -37,13 +41,13 @@ impl AsRef<str> for InternedString {
 
 impl From<&str> for InternedString {
     fn from(value: &str) -> Self {
-        InternedString(INTERNER.get_or_intern(value))
+        InternedString(interner().get_or_intern(value))
     }
 }
 
 impl From<String> for InternedString {
     fn from(value: String) -> Self {
-        InternedString(INTERNER.get_or_intern(value))
+        InternedString(interner().get_or_intern(value))
     }
 }
 


### PR DESCRIPTION
Follow-up #36.

This PR suggests remove the `compact_str` and `once_cell` from the dependency.