### PR TITLE
Replace `lasso` dependency with the custom string interner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,24 +3,6 @@
 version = 4
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,20 +103,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,16 +188,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -243,7 +201,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown",
 ]
 
 [[package]]
@@ -311,16 +269,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lasso"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e14eda50a3494b3bf7b9ce51c52434a761e383d7238ce1dd5dcec2fbc13e9fb"
-dependencies = [
- "dashmap",
- "hashbrown 0.14.5",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,15 +295,6 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
-
-[[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -467,19 +406,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
 ]
 
 [[package]]
@@ -662,15 +588,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "rusqlite"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,7 +618,6 @@ dependencies = [
 name = "rustuna_core"
 version = "0.1.0"
 dependencies = [
- "lasso",
  "rand",
  "rand_distr",
  "statrs",
@@ -781,12 +697,6 @@ checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
 dependencies = [
  "bytemuck",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -952,12 +862,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/rustuna_core/Cargo.toml
+++ b/rustuna_core/Cargo.toml
@@ -13,4 +13,3 @@ readme = "README.md"
 rand = { workspace = true }
 rand_distr = "0.4.3"
 statrs = "0.18.0"
-lasso = { version = "0.7", features = ["multi-threaded"] }

--- a/rustuna_core/src/attr.rs
+++ b/rustuna_core/src/attr.rs
@@ -1,8 +1,5 @@
+use crate::string_interner::InternedString;
 use std::collections::HashMap;
-use std::fmt;
-use std::sync::OnceLock;
-
-use lasso::{Spur, ThreadedRodeo};
 
 pub type Attrs = HashMap<AttrKey, String>;
 
@@ -10,45 +7,6 @@ pub type Attrs = HashMap<AttrKey, String>;
 pub enum AttrKey {
     User(InternedString),
     System(InternedString),
-}
-
-static INTERNER: OnceLock<ThreadedRodeo> = OnceLock::new();
-
-fn interner() -> &'static ThreadedRodeo {
-    INTERNER.get_or_init(ThreadedRodeo::new)
-}
-
-#[derive(Eq, Hash, Clone, Debug, PartialEq)]
-pub struct InternedString(Spur);
-
-impl InternedString {
-    pub fn as_str(&self) -> &'static str {
-        interner().resolve(&self.0)
-    }
-}
-
-impl fmt::Display for InternedString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-impl AsRef<str> for InternedString {
-    fn as_ref(&self) -> &str {
-        self.as_str()
-    }
-}
-
-impl From<&str> for InternedString {
-    fn from(value: &str) -> Self {
-        InternedString(interner().get_or_intern(value))
-    }
-}
-
-impl From<String> for InternedString {
-    fn from(value: String) -> Self {
-        InternedString(interner().get_or_intern(value))
-    }
 }
 
 // Compatible with CategoricalChoiceType.
@@ -130,12 +88,10 @@ pub fn get_category_labels(
     let mut labels: Vec<CategoryLabel> = Vec::with_capacity(len);
     for i in 0..len {
         let key = system_key_category_label(param_name, i);
-        match attrs.get(&key) {
-            Some(label) => {
-                let label = CategoryLabel::deserialize(label)?;
-                labels.push(label);
-            }
-            None => return None,
+        {
+            let label = attrs.get(&key)?;
+            let label = CategoryLabel::deserialize(label)?;
+            labels.push(label);
         }
     }
     Some(labels)

--- a/rustuna_core/src/lib.rs
+++ b/rustuna_core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod distribution;
 pub mod parzen_estimator;
 pub mod sampler;
 pub mod storage;
+pub mod string_interner;
 pub mod study;
 pub mod study_cache;
 pub mod trial;

--- a/rustuna_core/src/string_interner.rs
+++ b/rustuna_core/src/string_interner.rs
@@ -1,0 +1,123 @@
+use std::borrow::Borrow;
+use std::cmp::Ordering;
+use std::collections::HashMap;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::sync::{OnceLock, RwLock};
+
+// rustuna only interns keys whose cardinality is typically low, such as parameter names and
+// AttrKey strings. We do not currently have a lifecycle where interned keys become unreachable
+// and need to be reclaimed, so a small process-global interner is sufficient here without
+// depending on a more feature-rich crate.
+static INTERNER: OnceLock<RwLock<StringInterner>> = OnceLock::new();
+
+fn interner() -> &'static RwLock<StringInterner> {
+    INTERNER.get_or_init(|| RwLock::new(StringInterner::default()))
+}
+
+#[derive(Default)]
+struct StringInterner {
+    map: HashMap<&'static str, u32>,
+    strings: Vec<&'static str>,
+}
+
+#[derive(Eq, Clone, Copy, Debug, PartialEq)]
+pub struct InternedString(u32);
+
+impl InternedString {
+    pub fn as_str(&self) -> &'static str {
+        interner().read().unwrap().resolve(self.0)
+    }
+
+    fn new(value: &str) -> Self {
+        if let Some(symbol) = interner().read().unwrap().get(value) {
+            return InternedString(symbol);
+        }
+
+        let mut interner = interner().write().unwrap();
+        if let Some(symbol) = interner.get(value) {
+            return InternedString(symbol);
+        }
+        InternedString(interner.intern(value))
+    }
+}
+
+impl StringInterner {
+    fn get(&self, value: &str) -> Option<u32> {
+        self.map.get(value).copied()
+    }
+
+    fn intern(&mut self, value: &str) -> u32 {
+        let symbol = u32::try_from(self.strings.len()).expect("too many interned strings");
+        let leaked = Box::leak(value.to_owned().into_boxed_str());
+        self.map.insert(leaked, symbol);
+        self.strings.push(leaked);
+        symbol
+    }
+
+    fn resolve(&self, symbol: u32) -> &'static str {
+        self.strings[symbol as usize]
+    }
+}
+
+impl fmt::Display for InternedString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl AsRef<str> for InternedString {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Borrow<str> for InternedString {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Hash for InternedString {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state);
+    }
+}
+
+impl PartialOrd for InternedString {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for InternedString {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
+
+impl From<&str> for InternedString {
+    fn from(value: &str) -> Self {
+        InternedString::new(value)
+    }
+}
+
+impl From<String> for InternedString {
+    fn from(value: String) -> Self {
+        InternedString::new(&value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_interned_string_reuses_symbol() {
+        let a = InternedString::from("owner");
+        let b = InternedString::from("owner".to_string());
+
+        assert_eq!(a, b);
+        assert!(std::ptr::eq(a.as_str(), b.as_str()));
+    }
+}


### PR DESCRIPTION
This PR removes the lasso dependency from `rustuna_core` and replaces it with a small purpose-built string interner for `AttrKey` keys.

Motivation:
- `AttrKey` entries are numerous across trials, so per-entry key size has a noticeable memory impact.
- In rustuna, interned keys are limited to relatively low-cardinality strings such as parameter names and attribute keys.
- We do not currently need reclamation for interned keys, so a general-purpose multi-threaded interner is more than necessary here.

Approach:
- Replace `lasso::ThreadedRodeo` with a process-global interner implemented in `rustuna_core`.
- Store interned keys as compact `u32` symbols.
- Maintain:
  - `HashMap<&'static str, u32>` for interning
  - `Vec<&'static str>` for resolution

Notes:
- Interned strings are still retained for the lifetime of the process.
- `as_str()` now resolves through the local interner and takes a read lock.
- `u32` is a practical upper bound for the current workload.

This keeps `AttrKey` compact, removes the `lasso` dependency, and better matches rustuna’s current usage pattern.