### PR TITLE
Add rustdoc for rustuna_core public APIs

### DIFF
--- a/rustuna_core/src/attr.rs
+++ b/rustuna_core/src/attr.rs
@@ -1,16 +1,31 @@
 use crate::string_interner::InternedString;
 use std::collections::HashMap;
 
+/// Attribute map used by studies and trials.
+///
+/// In Optuna, user and system attributes are exposed as separate dictionaries. Rustuna stores
+/// both in a single map and distinguishes them with [`AttrKey::User`] and [`AttrKey::System`].
+/// Unlike Optuna, which accepts arbitrary JSON-serializable values, Rustuna stores attribute
+/// values as strings.
 pub type Attrs = HashMap<AttrKey, String>;
 
+/// Distinguishes between user and system attributes.
 #[derive(Eq, Hash, Clone, Debug, PartialEq)]
 pub enum AttrKey {
+    /// User-defined metadata.
     User(InternedString),
+    /// Internal metadata managed by Rustuna.
     System(InternedString),
 }
 
-// Compatible with CategoricalChoiceType.
-// https://github.com/optuna/optuna/blob/v3.5.0/optuna/distributions.py#L18
+/// Label used for categorical choices and fixed queued parameters.
+///
+/// This matches Optuna's `CategoricalChoiceType`.
+///
+/// In Optuna, categorical choices are stored directly in each `CategoricalDistribution` object.
+/// Rustuna's categorical distribution stores only its cardinality so that trials do not have to
+/// carry heap allocated choice lists repeatedly. The actual choice labels are stored separately in
+/// study system attributes and encoded with `CategoryLabel`.
 #[derive(PartialEq, Debug, Clone)]
 pub enum CategoryLabel {
     Float(f64),
@@ -20,6 +35,7 @@ pub enum CategoryLabel {
     None,
 }
 impl CategoryLabel {
+    /// Serializes the label to a stable string representation.
     pub fn serialize(&self) -> String {
         match self {
             CategoryLabel::Float(f) => format!("f:0x{:016x}", f.to_bits()),
@@ -35,6 +51,7 @@ impl CategoryLabel {
             CategoryLabel::None => "None".to_string(),
         }
     }
+    /// Deserializes a value produced by [`CategoryLabel::serialize`].
     pub fn deserialize(s: &str) -> Option<CategoryLabel> {
         if s == "None" {
             return Some(CategoryLabel::None);
@@ -67,10 +84,12 @@ impl CategoryLabel {
     }
 }
 
+/// Returns the internal system-attribute key used to store a categorical label.
 pub fn system_key_category_label(param_name: &str, choice_idx: usize) -> AttrKey {
     AttrKey::System(format!("category_labels:{param_name}:{choice_idx}").into())
 }
 
+/// Encodes categorical labels into system attributes.
 pub fn category_labels_to_attrs(param_name: &str, labels: &[CategoryLabel]) -> Attrs {
     let mut attrs = Attrs::new();
     for (i, label) in labels.iter().enumerate() {
@@ -80,6 +99,7 @@ pub fn category_labels_to_attrs(param_name: &str, labels: &[CategoryLabel]) -> A
     attrs
 }
 
+/// Decodes categorical labels from system attributes.
 pub fn get_category_labels(
     attrs: &Attrs,
     param_name: &str,
@@ -97,10 +117,12 @@ pub fn get_category_labels(
     Some(labels)
 }
 
+/// Returns the internal system-attribute key used for queued fixed parameters.
 pub fn system_key_fixed_param(param_name: &str) -> AttrKey {
     AttrKey::System(format!("fixed_params:{param_name}").into())
 }
 
+/// Encodes fixed parameter values into trial attributes.
 pub fn fixed_params_to_attrs(params: &HashMap<String, CategoryLabel>) -> Attrs {
     let mut attrs = Attrs::new();
     for (name, value) in params {
@@ -110,11 +132,13 @@ pub fn fixed_params_to_attrs(params: &HashMap<String, CategoryLabel>) -> Attrs {
     attrs
 }
 
+/// Returns a fixed parameter value stored in attributes.
 pub fn get_fixed_param(attrs: &Attrs, param_name: &str) -> Option<CategoryLabel> {
     let key = system_key_fixed_param(param_name);
     attrs.get(&key).and_then(|s| CategoryLabel::deserialize(s))
 }
 
+/// Extracts all fixed parameters stored in trial attributes.
 pub fn extract_fixed_params(attrs: &Attrs) -> HashMap<String, CategoryLabel> {
     let mut params = HashMap::new();
     for (key, value) in attrs {

--- a/rustuna_core/src/distribution.rs
+++ b/rustuna_core/src/distribution.rs
@@ -1,25 +1,38 @@
 use crate::{Error, ErrorKind, Result};
 
+/// Parameter distribution used by samplers and storages.
+///
+/// This type is the Rustuna counterpart of Optuna distributions. Trial parameters are stored
+/// internally as `f64`, and categorical parameters are represented by zero-based indices.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Distribution {
+    /// Continuous range over floating-point values.
     Float {
         low: f64,
         high: f64,
         step: Option<f64>,
         log: bool,
     },
+    /// Integer range with optional logarithmic sampling.
     Int {
         low: i64,
         high: i64,
         step: i64,
         log: bool,
     },
-    Categorical {
-        cardinality: usize,
-    },
+    /// Categorical distribution represented only by the number of choices.
+    ///
+    /// Unlike Optuna's `CategoricalDistribution`, Rustuna does not store the choice values in
+    /// each distribution object. The actual labels are stored separately in study system
+    /// attributes.
+    Categorical { cardinality: usize },
 }
 
 impl Distribution {
+    /// Checks whether two distributions are compatible for the same parameter name.
+    ///
+    /// Rustuna follows the same basic rule as Optuna here: the distribution kind must stay the
+    /// same, and categorical cardinality or the `log` flag must not change across trials.
     pub fn check_compatibility(&self, other: &Distribution) -> Result<()> {
         match (self, other) {
             (
@@ -58,6 +71,7 @@ impl Distribution {
         }
     }
 
+    /// Returns whether the distribution can produce only a single value.
     pub fn is_single(&self) -> bool {
         match self {
             Distribution::Float {
@@ -85,6 +99,7 @@ impl Distribution {
         }
     }
 
+    /// Returns whether the internal representation is contained in this distribution.
     pub fn contains(&self, internal_value: f64) -> bool {
         match self {
             Distribution::Float { low, high, .. } => {

--- a/rustuna_core/src/error.rs
+++ b/rustuna_core/src/error.rs
@@ -1,6 +1,9 @@
 use std::panic::Location;
 
-/// This crate specific `Error` type.
+/// Error type used by `rustuna_core`.
+///
+/// The error stores a coarse-grained [`ErrorKind`], an optional human-readable reason, and the
+/// call site where it was constructed.
 #[derive(Clone)]
 pub struct Error {
     pub kind: ErrorKind,
@@ -8,11 +11,13 @@ pub struct Error {
     pub location: &'static Location<'static>,
 }
 impl Error {
+    /// Creates a new error with the given kind.
     #[track_caller]
     pub fn new(kind: ErrorKind) -> Self {
         Self::with_reason(kind, String::new())
     }
 
+    /// Creates a new error with the given kind and reason.
     #[track_caller]
     pub fn with_reason<T: Into<String>>(kind: ErrorKind, reason: T) -> Self {
         Self {
@@ -41,7 +46,7 @@ impl core::fmt::Display for Error {
     }
 }
 
-/// ErrorKind represents the kind of error.
+/// Enumerates high-level error categories returned by `rustuna_core`.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum ErrorKind {

--- a/rustuna_core/src/lib.rs
+++ b/rustuna_core/src/lib.rs
@@ -1,3 +1,9 @@
+//! Core components for Rustuna.
+//!
+//! This crate provides the central study, trial, storage, sampler, queue, and distribution
+//! components used across Rustuna. Concrete storage backends, sampler implementations, and
+//! language bindings are implemented in other crates in the workspace.
+
 pub use error::{Error, ErrorKind};
 
 pub mod attr;
@@ -13,5 +19,5 @@ pub mod trial_queue;
 
 mod error;
 
-/// This is a custom `Result` type for this crate.
+/// A crate-specific [`std::result::Result`] alias.
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/rustuna_core/src/sampler.rs
+++ b/rustuna_core/src/sampler.rs
@@ -10,6 +10,11 @@ use crate::trial::TrialStateValues;
 use crate::Result;
 
 #[derive(Debug, Clone)]
+/// Lightweight study and trial metadata passed to samplers.
+///
+/// Rustuna does not pass full `Study` or `FrozenTrial` objects to samplers. Instead, it provides
+/// the identifiers and objective directions required to make sampling decisions, while richer
+/// state can be retrieved through [`Storage`] when necessary.
 pub struct Context {
     pub study_id: u32,
     pub directions: Vec<Direction>,
@@ -17,7 +22,24 @@ pub struct Context {
     pub trial_id: u32,
 }
 
+/// Interface for parameter suggestion algorithms.
+///
+/// Like Optuna, Rustuna supports two sampling modes:
+/// - independent sampling, which suggests one parameter at a time without modeling relationships
+///   between parameters, and
+/// - joint sampling, which suggests multiple parameters at once from a shared search space.
+///
+/// In Optuna terminology, Rustuna's joint sampling is the counterpart of relative sampling.
+/// If [`Sampler::support_joint_sampling`] returns `true`, [`Sampler::sample_joint`] is called once
+/// at the beginning of a trial with the inferred joint search space. Parameters not returned from
+/// that method, or all parameters when joint sampling is disabled, fall back to
+/// [`Sampler::sample_independent`].
 pub trait Sampler: Send {
+    /// Samples a single parameter independently.
+    ///
+    /// This method is used for parameters that are not covered by joint sampling. It is suitable
+    /// for samplers such as random search or univariate TPE that decide each parameter
+    /// separately.
     fn sample_independent(
         &mut self,
         ctx: &Context,
@@ -25,13 +47,25 @@ pub trait Sampler: Send {
         name: &str,
         distribution: &Distribution,
     ) -> Result<f64>;
+    /// Returns whether the sampler supports joint sampling.
+    ///
+    /// When this returns `true`, [`Sampler::sample_joint`] is called once per trial before any
+    /// parameter suggestions are requested from the objective function.
     fn support_joint_sampling(&self) -> bool;
+    /// Samples multiple parameters at once from a joint search space.
+    ///
+    /// This is the Rustuna counterpart of Optuna's `sample_relative`. The input search space is
+    /// inferred from previously observed compatible parameters in the study.
     fn sample_joint(
         &mut self,
         ctx: &Context,
         storage: Arc<RwLock<dyn Storage>>,
         search_space: &HashMap<String, Distribution>,
     ) -> Result<HashMap<String, f64>>;
+    /// Hook called when a trial is about to be finalized with the given state.
+    ///
+    /// This corresponds to Optuna's `after_trial` hook. Rustuna calls it after the objective
+    /// function returns and before the finalized state is written to storage.
     fn after_trial(
         &mut self,
         _ctx: &Context,
@@ -42,6 +76,10 @@ pub trait Sampler: Send {
     }
 }
 
+/// Uniform random sampler.
+///
+/// This sampler draws values independently from each parameter distribution and does not perform
+/// joint sampling.
 pub struct RandomSampler {
     rng: StdRng,
 }
@@ -51,12 +89,14 @@ impl Default for RandomSampler {
     }
 }
 impl RandomSampler {
+    /// Creates a sampler with a deterministic default seed.
     pub fn new() -> RandomSampler {
         RandomSampler {
             rng: StdRng::from_seed(Default::default()),
         }
     }
 
+    /// Creates a sampler seeded from a user-specified 64-bit seed.
     pub fn seed_from_u64(seed: u64) -> RandomSampler {
         RandomSampler {
             rng: StdRng::seed_from_u64(seed),

--- a/rustuna_core/src/storage.rs
+++ b/rustuna_core/src/storage.rs
@@ -7,19 +7,44 @@ use crate::study_cache::StudyCache;
 use crate::trial::{PersistedTrial, TrialStateValues};
 use crate::{Error, ErrorKind, Result};
 
+/// Abstraction over study and trial persistence.
+///
+/// This trait is the Rustuna counterpart of Optuna's `BaseStorage`. It abstracts the backend
+/// that stores studies, trials, parameter values, and metadata for hyperparameter optimization.
+///
+/// Rustuna differs from Optuna in a few storage-facing areas:
+/// - user and system attributes are merged into a single [`Attrs`] map keyed by [`AttrKey`],
+/// - attribute writes are exposed as bulk operations, and
+/// - categorical choice labels are stored separately from [`Distribution::Categorical`] and are
+///   retrieved through dedicated category-label APIs.
 pub trait Storage: Send + Sync {
+    /// Creates a new study.
+    ///
+    /// The returned study must have a unique ID even if previously created studies were deleted.
     fn create_new_study(
         &mut self,
         study_name: &str,
         directions: Vec<Direction>,
     ) -> Result<&PersistedStudy>;
+    /// Deletes an existing study and its trials.
     fn delete_study(&mut self, study_id: u32) -> Result<()>;
+    /// Creates a new running trial.
+    ///
+    /// Newly created trials are expected to start in [`TrialStateValues::Running`] unless they
+    /// are created from a template.
     fn create_new_trial(&mut self, study_id: u32) -> Result<&PersistedTrial>;
+    /// Creates a new trial by copying a template.
+    ///
+    /// This is used by features such as queued trials and `Study::add_trial`.
     fn create_new_trial_from_template(
         &mut self,
         study_id: u32,
         template: &PersistedTrial,
     ) -> Result<&PersistedTrial>;
+    /// Records a suggested parameter in internal representation.
+    ///
+    /// Implementations should reject incompatible distributions for the same parameter name
+    /// within a study.
     fn set_trial_param(
         &mut self,
         trial_id: u32,
@@ -27,6 +52,9 @@ pub trait Storage: Send + Sync {
         distribution: &Distribution,
         value: f64,
     ) -> Result<()>;
+    /// Updates the state and objective values of a trial.
+    ///
+    /// Finished trials must not become mutable again.
     fn set_trial_state_values(
         &mut self,
         trial_id: u32,
@@ -36,33 +64,49 @@ pub trait Storage: Send + Sync {
     // get_* methods take &mut self to allow in-place cache refresh in wrapper implementations
     // (e.g., CachedStorage). With &self it is impossible to safely update caches and return
     // references without relying on unsafe patterns.
+    /// Returns all studies.
     fn get_studies(&mut self) -> Result<&Vec<PersistedStudy>>;
+    /// Returns a study by ID.
     fn get_study(&mut self, study_id: u32) -> Result<&PersistedStudy>;
+    /// Returns a study attribute by key.
     fn get_study_attr(&mut self, study_id: u32, key: AttrKey) -> Result<String>;
+    /// Returns all trials that belong to a study.
+    ///
+    /// Trials are expected to be ordered by their trial number.
     fn get_trials(&mut self, study_id: u32) -> Result<&Vec<PersistedTrial>>;
+    /// Returns a trial by ID.
     fn get_trial(&mut self, trial_id: u32) -> Result<&PersistedTrial>;
     // Design Note:
     // get_cached_* methods always return references from the in-memory cache without
     // synchronizing with backends. These methods are separate from get_* to allow
     // callers to use read locks for cache-only reads.
+    /// Returns a cached trial reference without synchronizing external backends.
+    ///
+    /// This method is intended for read-only cache hits under a shared lock.
     fn get_cached_trial(&self, trial_id: u32) -> Result<&PersistedTrial>;
     // Design Note:
     // Category labels are stored in study system attrs internally, but exposed via dedicated
     // APIs for caching efficiency. Since category labels cannot be overwritten once set for
     // a given (study_id, param_name), implementations can safely cache them without
     // invalidation concerns.
+    /// Stores categorical labels for a study parameter.
+    ///
+    /// Rustuna keeps categorical labels outside [`Distribution::Categorical`] to avoid storing
+    /// heap-allocated choice lists repeatedly in each trial.
     fn set_category_labels(
         &mut self,
         study_id: u32,
         param_name: &str,
         labels: Vec<CategoryLabel>,
     ) -> Result<()>;
+    /// Returns categorical labels for a study parameter if present.
     fn get_category_labels(
         &mut self,
         study_id: u32,
         param_name: &str,
         cardinality: usize,
     ) -> Result<Option<Vec<CategoryLabel>>>;
+    /// Resolves a trial ID from a study ID and trial number.
     fn get_trial_id_from_study_id_trial_number(
         &mut self,
         study_id: u32,
@@ -75,21 +119,33 @@ pub trait Storage: Send + Sync {
     // which simplifies the implementation process for third-party storages.
     // Note: Some backend implementations (e.g., SQLite) may partially apply attributes across
     // user/system tables when error_on_overwrite is true.
+    /// Sets study attributes in bulk.
+    ///
+    /// If `error_on_overwrite` is `true`, implementations should reject keys that already exist.
     fn set_study_attrs(
         &mut self,
         study_id: u32,
         attrs: Attrs,
         error_on_overwrite: bool,
     ) -> Result<()>;
+    /// Sets trial attributes in bulk.
+    ///
+    /// If `error_on_overwrite` is `true`, implementations should reject keys that already exist.
     fn set_trial_attrs(
         &mut self,
         trial_id: u32,
         attrs: Attrs,
         error_on_overwrite: bool,
     ) -> Result<()>;
+    /// Returns the joint search space inferred from stored trials.
+    ///
+    /// This corresponds to the search space used for joint sampling.
     fn get_joint_search_space(&mut self, study_id: u32) -> Result<HashMap<String, Distribution>>;
 }
 
+/// In-memory storage implementation used by default in Rust code and tests.
+///
+/// This implementation keeps all studies, trials, and caches in process memory.
 #[derive(Default)]
 pub struct InMemoryStorage {
     studies: Vec<PersistedStudy>,
@@ -100,6 +156,7 @@ pub struct InMemoryStorage {
     next_trial_id: u32,
 }
 impl InMemoryStorage {
+    /// Creates an empty in-memory storage.
     pub fn new() -> InMemoryStorage {
         InMemoryStorage {
             studies: vec![],

--- a/rustuna_core/src/string_interner.rs
+++ b/rustuna_core/src/string_interner.rs
@@ -22,9 +22,11 @@ struct StringInterner {
 }
 
 #[derive(Eq, Clone, Copy, Debug, PartialEq)]
+/// Interned string used for low-cardinality keys such as parameter names and attribute names.
 pub struct InternedString(u32);
 
 impl InternedString {
+    /// Returns the interned string as a `'static` string slice.
     pub fn as_str(&self) -> &'static str {
         interner().read().unwrap().resolve(self.0)
     }

--- a/rustuna_core/src/study.rs
+++ b/rustuna_core/src/study.rs
@@ -9,6 +9,7 @@ use crate::trial::{PersistedTrial, Trial, TrialStateValues};
 use crate::trial_queue::{InMemoryTrialQueue, TrialQueue};
 use crate::{Error, ErrorKind, Result};
 
+/// Creates a study backed by the given storage and sampler.
 pub fn create_study<S: Storage + Send + Sync + 'static, T: Sampler + Send + 'static>(
     study_name: &str,
     mut storage: S,
@@ -29,6 +30,7 @@ pub fn create_study<S: Storage + Send + Sync + 'static, T: Sampler + Send + 'sta
     ))
 }
 
+/// Creates a study from shared storage and sampler handles.
 pub fn create_study_with_arc(
     study_name: &str,
     storage: Arc<RwLock<dyn Storage>>,
@@ -55,6 +57,13 @@ pub fn create_study_with_arc(
 }
 
 #[derive(Clone)]
+/// A study corresponds to an optimization task, that is, a set of trials.
+///
+/// This is the central object for running optimization in Rustuna. It provides interfaces to
+/// create new trials, evaluate objective functions, access trial history, enqueue fixed trials,
+/// and set or get study-level user attributes.
+///
+/// A `Study` holds shared handles to a storage backend, a sampler, and a trial queue.
 pub struct Study {
     pub id: u32,
     pub name: String,
@@ -64,6 +73,7 @@ pub struct Study {
     pub queue: Arc<RwLock<dyn TrialQueue>>,
 }
 impl Study {
+    /// Constructs a study from fully initialized components.
     pub fn new(
         id: u32,
         name: String,
@@ -82,6 +92,7 @@ impl Study {
         }
     }
 
+    /// Loads a study by ID from storage.
     pub fn from_id(
         id: u32,
         storage: Arc<RwLock<dyn Storage>>,
@@ -101,6 +112,7 @@ impl Study {
         Ok(Study::new(id, name, directions, storage, sampler, queue))
     }
 
+    /// Loads a study by name from storage.
     pub fn from_name(
         name: String,
         storage: Arc<RwLock<dyn Storage>>,
@@ -126,6 +138,7 @@ impl Study {
         ))
     }
 
+    /// Creates or dequeues the next trial to evaluate.
     pub fn ask(&self) -> Result<Trial> {
         let queued_trial_id = {
             let mut queue_guard = self.queue.write().map_err(|e| {
@@ -260,6 +273,7 @@ impl Study {
         Ok(trial)
     }
 
+    /// Finalizes a trial with the given state and objective values.
     pub fn tell(&self, trial_number: u32, state_values: TrialStateValues) -> Result<()> {
         let mut storage_guard = self.storage.write().map_err(|e| {
             Error::with_reason(
@@ -300,6 +314,10 @@ impl Study {
         Ok(())
     }
 
+    /// Runs the objective function repeatedly for `n_trials`.
+    ///
+    /// The objective returns one value per study direction. Returning an error marks the current
+    /// trial as failed and aborts the optimization loop.
     pub fn optimize<F>(&self, mut objective: F, n_trials: usize) -> Result<()>
     where
         F: FnMut(Trial) -> Result<Vec<f64>>,
@@ -326,6 +344,7 @@ impl Study {
         Ok(())
     }
 
+    /// Returns all trials that belong to this study.
     pub fn get_trials(&self) -> Result<Vec<PersistedTrial>> {
         let mut guard = self.storage.write().map_err(|e| {
             Error::with_reason(
@@ -337,6 +356,7 @@ impl Study {
         Ok(trials.clone())
     }
 
+    /// Returns a user attribute stored on the study.
     pub fn get_user_attr(&self, key: String) -> Result<Option<String>> {
         let mut guard = self.storage.write().map_err(|e| {
             Error::with_reason(
@@ -353,6 +373,7 @@ impl Study {
         }
     }
 
+    /// Sets one or more user attributes on the study.
     pub fn set_user_attr(&self, attrs: HashMap<String, String>) -> Result<()> {
         let mut guard = self.storage.write().map_err(|e| {
             Error::with_reason(
@@ -368,6 +389,9 @@ impl Study {
         Ok(())
     }
 
+    /// Inserts an existing persisted trial into the study.
+    ///
+    /// This is the Rustuna counterpart of Optuna's `study.add_trial`.
     pub fn add_trial(&self, trial: PersistedTrial) -> Result<()> {
         trial.validate()?;
         if let TrialStateValues::Complete(ref values) = trial.state_values {
@@ -392,6 +416,10 @@ impl Study {
         Ok(())
     }
 
+    /// Enqueues a trial with fixed parameters to be evaluated later.
+    ///
+    /// Queued parameters are stored as trial attributes and popped through the study's
+    /// [`TrialQueue`] implementation.
     pub fn enqueue_trial(
         &self,
         params: HashMap<String, CategoryLabel>,
@@ -429,12 +457,16 @@ impl Study {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+/// Optimization direction for an objective value.
 pub enum Direction {
     Minimize,
     Maximize,
 }
 
 #[derive(Clone)]
+/// Storage-side representation of a study.
+///
+/// This corresponds to Optuna's `FrozenStudy`.
 pub struct PersistedStudy {
     pub id: u32,
     pub name: String,
@@ -442,6 +474,7 @@ pub struct PersistedStudy {
     pub attrs: Attrs,
 }
 impl PersistedStudy {
+    /// Creates a persisted study with empty attributes.
     pub fn new(id: u32, study_name: String, directions: Vec<Direction>) -> PersistedStudy {
         PersistedStudy {
             id,
@@ -452,6 +485,7 @@ impl PersistedStudy {
     }
     // TODO(knshnb): Consider a builder pattern:
     // https://github.com/optuna/rustuna/pull/37#discussion_r1503510194
+    /// Creates a persisted study with pre-populated attributes.
     pub fn new_with_attrs(
         id: u32,
         study_name: String,
@@ -467,6 +501,7 @@ impl PersistedStudy {
     }
 }
 
+/// Returns the best completed trial number for a single-objective study.
 pub fn get_best_trial(study: &Study) -> Result<u32> {
     let mut guard = study.storage.write().map_err(|e| {
         Error::with_reason(
@@ -503,6 +538,7 @@ pub fn get_best_trial(study: &Study) -> Result<u32> {
 }
 
 // TODO(HideakiImamura): Support the faster algorithm for `len(directions) == 2`.
+/// Returns the trial numbers on the Pareto front of a multi-objective study.
 pub fn get_pareto_front(study: &Study) -> Result<Vec<u32>> {
     let mut guard = study.storage.write().map_err(|e| {
         Error::with_reason(
@@ -543,6 +579,7 @@ pub fn get_pareto_front(study: &Study) -> Result<Vec<u32>> {
     Ok(pareto_front_numbers)
 }
 
+/// Returns whether `values0` dominates `values1` under the given directions.
 pub fn dominates(values0: &[f64], values1: &[f64], directions: &[Direction]) -> bool {
     assert_eq!(values0.len(), values1.len());
     assert_eq!(values0.len(), directions.len());

--- a/rustuna_core/src/trial.rs
+++ b/rustuna_core/src/trial.rs
@@ -8,7 +8,10 @@ use crate::storage::Storage;
 use crate::study::Direction;
 use crate::{Error, ErrorKind, Result};
 
-/// Trial is a struct that is equivalent to `optuna.trial.Trial`.
+/// A trial object used while evaluating an objective function.
+///
+/// This is the Rustuna counterpart of `optuna.trial.Trial`. It provides parameter suggestion
+/// APIs and access to user-defined trial attributes.
 pub struct Trial {
     pub id: u32,
     pub study_id: u32,
@@ -23,6 +26,7 @@ pub struct Trial {
     cached_trial: PersistedTrial,
 }
 impl Trial {
+    /// Constructs a trial from storage and sampler state.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         trial_id: u32,
@@ -54,6 +58,10 @@ impl Trial {
         }
     }
 
+    /// Suggests a parameter value from the given distribution.
+    ///
+    /// The returned value is in Rustuna's internal representation. Categorical parameters are
+    /// represented by zero-based indices.
     pub fn suggest(&mut self, name: &str, distribution: &Distribution) -> Result<f64> {
         if let Some(fixed_value) = self.fixed_params.get(name) {
             let result = if let Distribution::Categorical { cardinality } = distribution {
@@ -151,6 +159,7 @@ impl Trial {
     // Design Note:
     // suggest_float and suggest_int do not support `step` and `log` arguments to keep the API easy to use.
     // Users who want to use them need to call `suggest()` function directly.
+    /// Suggests a floating-point parameter from a linear range.
     pub fn suggest_float(&mut self, name: &str, low: f64, high: f64) -> Result<f64> {
         let distribution = Distribution::Float {
             low,
@@ -162,6 +171,7 @@ impl Trial {
         Ok(param_value)
     }
 
+    /// Suggests an integer parameter from a linear range with step `1`.
     pub fn suggest_int(&mut self, name: &str, low: i64, high: i64) -> Result<i64> {
         let distribution = Distribution::Int {
             low,
@@ -173,6 +183,7 @@ impl Trial {
         Ok(param_value as i64)
     }
 
+    /// Suggests a categorical parameter and returns a borrowed [`CategoryLabel`].
     pub fn suggest_categorical_enum<'a>(
         &'a mut self,
         name: &str,
@@ -194,6 +205,7 @@ impl Trial {
         Ok(c)
     }
 
+    /// Suggests a categorical parameter and returns a borrowed element from `choices`.
     pub fn suggest_categorical<'a, T>(&'a mut self, name: &str, choices: &'a [T]) -> Result<&'a T> {
         let distribution = Distribution::Categorical {
             cardinality: choices.len(),
@@ -210,11 +222,13 @@ impl Trial {
     // Note that `AttrKind::System` should not be exposed to users,
     // as it may be updated without going through the `Trial` object,
     // making it difficult to cache the value.
+    /// Returns a user attribute stored on the trial.
     pub fn get_user_attr(&mut self, key: &str) -> Option<&String> {
         let key = AttrKey::User(key.into());
         self.cached_trial.attrs.get(&key)
     }
 
+    /// Sets a single user attribute on the trial.
     pub fn set_user_attr(&mut self, key: &str, value: String) -> Result<()> {
         let mut guard = self
             .storage
@@ -229,6 +243,7 @@ impl Trial {
         Ok(())
     }
 
+    /// Sets multiple user attributes on the trial.
     pub fn set_user_attrs(&mut self, user_attrs: HashMap<String, String>) -> Result<()> {
         let mut attrs = Attrs::with_capacity(user_attrs.len());
         for (key, value) in &user_attrs {
@@ -250,8 +265,10 @@ impl Trial {
     }
 }
 
-/// PersistedTrial is a struct that represents a trial that has been persisted to storage.
-/// This is equivalent to `optuna.trial.FrozenTrial`.
+/// Storage-side representation of a trial.
+///
+/// This corresponds to Optuna's `FrozenTrial`, but it stores user and system attributes as
+/// strings in a unified attribute map.
 #[derive(Clone, Debug)]
 pub struct PersistedTrial {
     pub id: u32,
@@ -265,6 +282,7 @@ pub struct PersistedTrial {
     pub datetime_complete: Option<String>,
 }
 impl PersistedTrial {
+    /// Creates a new running trial with no parameters or attributes.
     pub fn new(id: u32, study_id: u32, number: u32) -> PersistedTrial {
         PersistedTrial {
             id,
@@ -279,6 +297,7 @@ impl PersistedTrial {
         }
     }
 
+    /// Returns whether the trial is already in a finished state.
     pub fn is_finished(&self) -> bool {
         matches!(
             self.state_values,
@@ -286,6 +305,7 @@ impl PersistedTrial {
         )
     }
 
+    /// Validates the internal consistency of the persisted trial.
     pub fn validate(&self) -> Result<()> {
         // TODO(c-bata): Consider introducing ErrorKind::TrialInvalid.
         if let TrialStateValues::Complete(values) = &self.state_values {
@@ -326,12 +346,18 @@ impl PersistedTrial {
     }
 }
 
+/// Trial state together with objective values when available.
 #[derive(PartialEq, Clone, Debug)]
 pub enum TrialStateValues {
+    /// Trial is running.
     Running,
+    /// Trial was pruned.
     Pruned,
+    /// Trial finished successfully with one or more objective values.
     Complete(Vec<f64>),
+    /// Trial failed with an error.
     Fail,
+    /// Trial is waiting in a queue.
     Waiting,
 }
 

--- a/rustuna_core/src/trial_queue.rs
+++ b/rustuna_core/src/trial_queue.rs
@@ -2,17 +2,25 @@ use std::collections::VecDeque;
 
 use crate::{Error, ErrorKind, Result};
 
+/// Queue abstraction used by [`crate::study::Study::enqueue_trial`].
+///
+/// Rustuna keeps queuing outside the storage layer so that users who do not use queued trials do
+/// not pay coordination overhead on every trial creation.
 pub trait TrialQueue: Send + Sync {
+    /// Pushes a trial ID into the queue.
     fn enqueue(&mut self, trial_id: u32) -> Result<()>;
+    /// Pops the next queued trial ID.
     fn dequeue(&mut self) -> Result<u32>;
 }
 
+/// In-memory queue implementation used by default.
 #[derive(Default)]
 pub struct InMemoryTrialQueue {
     queue: VecDeque<u32>,
 }
 
 impl InMemoryTrialQueue {
+    /// Creates an empty queue.
     pub fn new() -> Self {
         Self {
             queue: VecDeque::new(),


### PR DESCRIPTION
This PR adds rustdoc across the public API surface of `rustuna_core`:

- Add crate-level documentation to clarify the role of `rustuna_core` within the workspace.
- Document core public types and traits such as `Study`, `Trial`, `PersistedTrial`,
  `PersistedStudy`, `Storage`, `Sampler`, `TrialQueue`, `Distribution`, and attribute-related
  types.

<img width="1293" height="883" alt="Screenshot 2026-05-14 19 58 59" src="https://github.com/user-attachments/assets/3d37745f-2d64-41a4-83b9-8794c7e8c53e" />
