### PR TITLE
Add rustdoc for `rustuna_storages` public APIs

### DIFF
--- a/rustuna_storages/src/cache.rs
+++ b/rustuna_storages/src/cache.rs
@@ -11,6 +11,11 @@ use rustuna_core::{Error, ErrorKind, Result};
 
 use crate::optuna::OptunaCompatibleStorage;
 
+/// Backend interface for [`CachedStorage`].
+///
+/// Unlike `rustuna_core::storage::Storage`, this trait returns owned values instead of references.
+/// This allows the caching wrapper to materialize in-memory state and then hand out borrowed
+/// references required by the core storage interface.
 pub trait CachedStorageBackend: Send + Sync {
     // Design Note:
     // This trait is intended for backends that return owned values (not references) so that
@@ -68,8 +73,14 @@ pub trait CachedStorageBackend: Send + Sync {
     ) -> Result<Vec<PersistedTrial>>;
 }
 
+/// Convenience alias for cached backends that also support Optuna compatibility helpers.
 pub trait OptunaCachedStorageBackend: CachedStorageBackend + OptunaCompatibleStorage {}
 
+/// Caching storage wrapper over a backend that returns owned values.
+///
+/// This type plays a role similar to Optuna's `_CachedStorage`: the backend is responsible for
+/// persistence, while `CachedStorage` keeps studies and trials in memory and serves borrowed
+/// references to callers.
 pub struct CachedStorage {
     studies: Vec<PersistedStudy>,
     trials: HashMap<u32, HashMap<u32, PersistedTrial>>,
@@ -86,6 +97,7 @@ pub struct CachedStorage {
 }
 
 impl CachedStorage {
+    /// Creates a caching wrapper around the given backend.
     pub fn new(backend: Box<dyn OptunaCachedStorageBackend>) -> CachedStorage {
         CachedStorage {
             studies: Vec::new(),

--- a/rustuna_storages/src/directory_queue.rs
+++ b/rustuna_storages/src/directory_queue.rs
@@ -9,6 +9,11 @@ use rustuna_core::{Error, ErrorKind, Result};
 
 static SEQUENCE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+/// Directory-backed trial queue.
+///
+/// Each enqueued trial is represented by a file on disk. This backend is useful when multiple
+/// processes on the same filesystem need to share queued trial IDs without depending on a
+/// database server.
 pub struct DirectoryTrialQueue {
     pending_dir: PathBuf,
     processing_dir: PathBuf,

--- a/rustuna_storages/src/journal/file.rs
+++ b/rustuna_storages/src/journal/file.rs
@@ -42,10 +42,16 @@ fn fsync_file(file: &File) -> std::io::Result<()> {
 }
 
 pub trait JournalFileLock: Send + Sync {
+    /// Acquires the file lock in a blocking manner.
     fn acquire(&self) -> Result<()>;
+    /// Releases the file lock.
     fn release(&self) -> Result<()>;
 }
 
+/// File-based backend for [`super::storage::JournalStorage`].
+///
+/// Logs are appended as newline-delimited JSON records. A pluggable lock implementation is used
+/// to coordinate concurrent writers across processes.
 pub struct JournalFileBackend {
     file_path: PathBuf,
     lock: Box<dyn JournalFileLock>,
@@ -53,6 +59,7 @@ pub struct JournalFileBackend {
 }
 
 impl JournalFileBackend {
+    /// Creates a file-backed journal backend.
     pub fn new(
         file_path: impl AsRef<Path>,
         lock: Option<Box<dyn JournalFileLock>>,
@@ -184,12 +191,19 @@ impl JournalBackend for JournalFileBackend {
     }
 }
 
+/// Lock implementation based on symlink creation.
+///
+/// This lock creates a symlink next to the journal file and removes it when the lock is released.
+/// Similar to Optuna's symlink-based journal lock, this variant is intended for environments
+/// where symlink creation provides a more portable inter-process exclusion mechanism than
+/// exclusive file creation.
 pub struct JournalFileSymlinkLock {
     lock_target_file: PathBuf,
     lock_file: PathBuf,
 }
 
 impl JournalFileSymlinkLock {
+    /// Creates a symlink-based lock next to the journal file.
     pub fn new(filepath: impl AsRef<Path>) -> Self {
         let filepath = filepath.as_ref().to_path_buf();
         JournalFileSymlinkLock {
@@ -200,6 +214,7 @@ impl JournalFileSymlinkLock {
 }
 
 impl JournalFileLock for JournalFileSymlinkLock {
+    /// Acquires the lock by creating a symlink in a blocking retry loop.
     fn acquire(&self) -> Result<()> {
         let mut sleep_secs = 0.001f64;
         loop {
@@ -220,6 +235,7 @@ impl JournalFileLock for JournalFileSymlinkLock {
         }
     }
 
+    /// Releases the lock by renaming and removing the symlink.
     fn release(&self) -> Result<()> {
         let rename_file = PathBuf::from(format!(
             "{}{}{}",
@@ -250,11 +266,17 @@ impl JournalFileLock for JournalFileSymlinkLock {
     }
 }
 
+/// Lock implementation based on exclusive file creation.
+///
+/// This lock creates a dedicated lock file with exclusive open semantics and removes it when the
+/// lock is released. Similar to Optuna's open-based journal lock, this variant is suitable for
+/// environments where `O_EXCL` style file creation can be relied on for process synchronization.
 pub struct JournalFileOpenLock {
     lock_file: PathBuf,
 }
 
 impl JournalFileOpenLock {
+    /// Creates an open-file-based lock next to the journal file.
     pub fn new(filepath: impl AsRef<Path>) -> Self {
         let filepath = filepath.as_ref().to_path_buf();
         JournalFileOpenLock {
@@ -264,6 +286,7 @@ impl JournalFileOpenLock {
 }
 
 impl JournalFileLock for JournalFileOpenLock {
+    /// Acquires the lock by creating the lock file in a blocking retry loop.
     fn acquire(&self) -> Result<()> {
         let mut sleep_secs = 0.001f64;
         loop {
@@ -285,6 +308,7 @@ impl JournalFileLock for JournalFileOpenLock {
         }
     }
 
+    /// Releases the lock by removing the created lock file.
     fn release(&self) -> Result<()> {
         let rename_file = PathBuf::from(format!(
             "{}{}{}",

--- a/rustuna_storages/src/journal/mod.rs
+++ b/rustuna_storages/src/journal/mod.rs
@@ -10,17 +10,25 @@ use rustuna_core::{Error, ErrorKind, Result};
 pub mod file;
 pub mod storage;
 
+/// Backend interface for journal-based storage.
+///
+/// Journal storage persists a log of storage operations and reconstructs the latest state by
+/// replaying those logs. Backends implementing this trait only need to support appending logs and
+/// reading them back in order.
 pub trait JournalBackend: Send + Sync {
+    /// Reads logs starting from `log_number_from` and passes them to `handler` in order.
     fn read_logs(
         &mut self,
         log_number_from: usize,
         handler: &mut dyn FnMut(JournalLog) -> Result<()>,
     ) -> Result<()>;
+    /// Appends one or more logs atomically if possible.
     fn append_logs(&mut self, logs: &[JournalLog]) -> Result<()>;
 }
 
 #[repr(i32)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// Operation kinds recorded in the journal log.
 pub enum JournalOperation {
     CreateStudy = 0,
     DeleteStudy = 1,
@@ -35,6 +43,7 @@ pub enum JournalOperation {
 }
 
 impl JournalOperation {
+    /// Decodes an operation code stored in a journal log.
     pub fn from_i32(value: i32) -> Result<Self> {
         match value {
             0 => Ok(JournalOperation::CreateStudy),
@@ -53,6 +62,7 @@ impl JournalOperation {
 }
 
 #[derive(Clone, Debug, Serialize)]
+/// One operation record written to a journal backend.
 pub struct JournalLog {
     pub op_code: i32,
     pub worker_id: String,
@@ -63,6 +73,7 @@ pub struct JournalLog {
 }
 
 impl JournalLog {
+    /// Returns the worker identifier that produced this log record.
     pub fn worker_id(&self) -> &str {
         self.worker_id.as_str()
     }

--- a/rustuna_storages/src/journal/storage.rs
+++ b/rustuna_storages/src/journal/storage.rs
@@ -21,12 +21,17 @@ use crate::optuna::OptunaCompatibleStorage;
 
 use super::{JournalBackend, JournalLog, JournalOperation};
 
+/// Storage implementation backed by an append-only journal log.
+///
+/// Similar in spirit to Optuna's `JournalStorage`, this storage writes every state-changing
+/// operation as a journal record and reconstructs the latest snapshot by replaying logs.
 pub struct JournalStorage {
     backend: Box<dyn JournalBackend>,
     replay: JournalReplayState,
 }
 
 impl JournalStorage {
+    /// Creates a journal storage and synchronizes its in-memory replay state from the backend.
     pub fn new(backend: Box<dyn JournalBackend>) -> Result<Self> {
         let worker_id_prefix = format!("{}-{}-", unique_prefix(), std::process::id());
         let mut storage = JournalStorage {

--- a/rustuna_storages/src/lib.rs
+++ b/rustuna_storages/src/lib.rs
@@ -1,3 +1,10 @@
+//! Storage and queue backends for Rustuna.
+//!
+//! This crate provides concrete persistence layers and trial-queue implementations built on top
+//! of `rustuna_core`, including caching wrappers, SQLite-backed storage, journal-based storage,
+//! and shared queue backends used by `Study::enqueue_trial`. These are concrete backends for the
+//! `rustuna_core::storage::Storage` and `rustuna_core::trial_queue::TrialQueue` traits.
+
 pub mod cache;
 pub mod directory_queue;
 pub mod journal;

--- a/rustuna_storages/src/optuna.rs
+++ b/rustuna_storages/src/optuna.rs
@@ -3,7 +3,13 @@ use std::collections::HashMap;
 use rustuna_core::Result;
 use serde::{Deserialize, Serialize};
 
+/// Optional extension trait for storage backends that preserve Optuna compatibility data.
+///
+/// Rustuna itself stores trial intermediate values and attributes as strings, but converters that
+/// interoperate with Optuna sometimes need extra structured metadata. Backends implementing this
+/// trait can persist such compatibility-specific state directly.
 pub trait OptunaCompatibleStorage: Send + Sync {
+    /// Stores all intermediate values for a trial in a backend-specific format.
     fn set_trial_intermediate_values(
         &mut self,
         trial_id: u32,

--- a/rustuna_storages/src/sqlite3.rs
+++ b/rustuna_storages/src/sqlite3.rs
@@ -10,6 +10,11 @@ use serde_json::{json, Number, Value};
 use std::collections::HashMap;
 use std::sync::Mutex;
 
+/// SQLite-backed storage backend.
+///
+/// This backend persists studies and trials in a local SQLite database and is typically wrapped
+/// by [`crate::cache::CachedStorage`] to provide the reference-based `Storage` API from
+/// `rustuna_core`.
 pub struct SQLite3Storage {
     conn: Mutex<Connection>,
 }
@@ -18,6 +23,7 @@ const SCHEMA_SQL: &str = include_str!("sqlite3_schema.sql");
 type TrialRow = (u32, u32, String, Option<String>, Option<String>);
 
 impl SQLite3Storage {
+    /// Opens a SQLite database file.
     pub fn new(file_path: &str) -> Result<SQLite3Storage> {
         let conn = Connection::open(file_path).map_err(|e| {
             Error::with_reason(
@@ -30,6 +36,7 @@ impl SQLite3Storage {
         })
     }
 
+    /// Creates the Rustuna schema if the database has not been initialized yet.
     pub fn create_database(&self) -> Result<()> {
         let conn = self
             .conn

--- a/rustuna_storages/src/sqlite3_queue.rs
+++ b/rustuna_storages/src/sqlite3_queue.rs
@@ -4,6 +4,9 @@ use rustuna_core::{Error, ErrorKind, Result};
 use std::path::Path;
 use std::sync::Mutex;
 
+/// SQLite-backed trial queue.
+///
+/// Multiple logical queues can share the same database file by using different namespaces.
 pub struct SQLite3TrialQueue {
     conn: Mutex<Connection>,
     namespace: String,


### PR DESCRIPTION
Follow-up #114 

This PR adds rustdoc across the public API surface of `rustuna_storages`. To check the rustdoc, please execute a following command:

```
$ cargo doc -p rustuna_storages --no-deps && python3 -m http.server --directory ./target/doc/
```