### PR TITLE
Add rustdoc for `rustuna_importance` public APIs

### DIFF
--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -4,6 +4,7 @@ use rustuna_core::trial::{PersistedTrial, TrialStateValues};
 use rustuna_core::{Error, ErrorKind, Result};
 use std::collections::HashMap;
 
+/// Options shared by parameter-importance evaluators.
 pub struct ImportanceOptions<'a> {
     // NOTE(kAIto47802): Currently, the `param` argument is not implemented.
     // We plan to implement it when we support condPED-ANOVA:
@@ -22,21 +23,31 @@ impl<'a> Default for ImportanceOptions<'a> {
 }
 
 impl<'a> ImportanceOptions<'a> {
+    /// Creates the default options.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Sets the target value used to evaluate importances.
+    ///
+    /// By default, evaluators use the first objective value of each completed trial. For
+    /// multi-objective studies, this target must be specified explicitly.
     pub fn with_target(mut self, target: &'a dyn Fn(&PersistedTrial) -> f64) -> Self {
         self.target = Some(target);
         self
     }
 
+    /// Sets whether the returned importances should be normalized to sum to `1.0`.
     pub fn normalize(mut self, normalize: bool) -> Self {
         self.normalize = normalize;
         self
     }
 }
 
+/// Evaluates parameter importances for completed trials in a study.
+///
+/// The returned map associates parameter names with non-negative importance values. By default,
+/// the importances are normalized to sum to `1.0`.
 pub fn get_param_importances(
     study: &Study,
     evaluator: &impl ImportanceEvaluator,
@@ -44,6 +55,9 @@ pub fn get_param_importances(
     get_param_importances_with(study, evaluator, ImportanceOptions::default())
 }
 
+/// Evaluates parameter importances with explicit options.
+///
+/// This variant allows callers to provide a custom target function and to disable normalization.
 pub fn get_param_importances_with(
     study: &Study,
     evaluator: &impl ImportanceEvaluator,
@@ -58,10 +72,14 @@ pub fn get_param_importances_with(
     }
 }
 
+/// Trait implemented by parameter-importance evaluators.
 pub trait ImportanceEvaluator {
+    /// Evaluates parameter importances with the default options.
     fn evaluate(&self, study: &Study) -> Result<HashMap<String, f64>> {
         self.evaluate_with(study, ImportanceOptions::default())
     }
+
+    /// Evaluates parameter importances with explicit options.
     fn evaluate_with(
         &self,
         study: &Study,

--- a/rustuna_importance/src/fanova.rs
+++ b/rustuna_importance/src/fanova.rs
@@ -4,6 +4,10 @@ use rustuna_core::study::Study;
 use rustuna_core::trial::{PersistedTrial, TrialStateValues};
 use rustuna_core::{Error, ErrorKind, Result};
 
+/// Computes parameter importances with the legacy fANOVA-based implementation.
+///
+/// This helper fits a random-forest model and returns one importance vector per objective.
+/// It is kept for compatibility, but new code should prefer [`crate::PedAnovaImportanceEvaluator`].
 pub fn get_param_importance(study: &Study) -> Result<Vec<Vec<f64>>> {
     let mut guard = study
         .storage

--- a/rustuna_importance/src/lib.rs
+++ b/rustuna_importance/src/lib.rs
@@ -1,8 +1,7 @@
 //! Hyperparameter importance evaluators for Rustuna.
 //!
 //! This crate provides utilities to estimate parameter importances from completed trials in a
-//! study. It currently includes PED-ANOVA as the primary public evaluator and also exposes a
-//! legacy fANOVA-based helper.
+//! study. It currently includes PED-ANOVA and legacy fANOVA-based helper.
 
 mod common;
 pub mod fanova;

--- a/rustuna_importance/src/lib.rs
+++ b/rustuna_importance/src/lib.rs
@@ -1,3 +1,9 @@
+//! Hyperparameter importance evaluators for Rustuna.
+//!
+//! This crate provides utilities to estimate parameter importances from completed trials in a
+//! study. It currently includes PED-ANOVA as the primary public evaluator and also exposes a
+//! legacy fANOVA-based helper.
+
 mod common;
 pub mod fanova;
 mod ped_anova;

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -14,8 +14,8 @@ use std::collections::HashMap;
 /// user-specified baseline quantile and measures how much each parameter contributes to achieving
 /// values better than that baseline.
 ///
-/// For further information, see
-/// [PED-ANOVA: Efficiently Quantifying Hyperparameter Importance in Arbitrary Subspaces](https://arxiv.org/abs/2304.10255).
+/// For further information, see the original paper
+/// [PED-ANOVA: Efficiently Quantifying Hyperparameter Importance in Arbitrary Subspaces](https://arxiv.org/abs/2304.10255) (IJCAI 2023).
 ///
 /// The quality of the result depends on how many trials are included above the target quantile.
 /// In practice, it is preferable to have at least several top trials in the selected region.

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -6,6 +6,57 @@ use rustuna_core::trial::PersistedTrial;
 use rustuna_core::Result;
 use std::collections::HashMap;
 
+/// PED-ANOVA importance evaluator.
+///
+/// This evaluator implements the PED-ANOVA hyperparameter importance algorithm.
+///
+/// PED-ANOVA fits Parzen estimators to completed trials that perform better than a
+/// user-specified baseline quantile and measures how much each parameter contributes to achieving
+/// values better than that baseline.
+///
+/// For further information, see
+/// [PED-ANOVA: Efficiently Quantifying Hyperparameter Importance in Arbitrary Subspaces](https://arxiv.org/abs/2304.10255).
+///
+/// The quality of the result depends on how many trials are included above the target quantile.
+/// In practice, it is preferable to have at least several top trials in the selected region.
+///
+/// `evaluate_on_local` controls whether importances are measured against the empirical search
+/// region explored during optimization or against the full search space. Local evaluation is
+/// especially useful when the effective search region changes during the study.
+///
+/// # Examples
+///
+/// ```no_run
+/// use rustuna_core::storage::InMemoryStorage;
+/// use rustuna_core::study::{create_study, Direction};
+/// use rustuna_core::sampler::RandomSampler;
+/// use rustuna_core::Result;
+/// use rustuna_importance::{get_param_importances, PedAnovaImportanceEvaluator};
+///
+/// fn main() -> Result<()> {
+///     let storage = InMemoryStorage::new();
+///     let study = create_study(
+///         "ped-anova",
+///         storage,
+///         RandomSampler::new(),
+///         vec![Direction::Minimize],
+///     )?;
+///
+///     study.optimize(
+///         |mut trial| {
+///             let x1 = trial.suggest_float("x1", -10.0, 10.0)?;
+///             let x2 = trial.suggest_float("x2", -10.0, 10.0)?;
+///             Ok(vec![x1 + x2 / 1000.0])
+///         },
+///         100,
+///     )?;
+///
+///     let evaluator = PedAnovaImportanceEvaluator::default();
+///     let importances = get_param_importances(&study, &evaluator)?;
+///     println!("{importances:?}");
+///     Ok(())
+/// }
+/// ```
 pub struct PedAnovaImportanceEvaluator {
     target_quantile: f64,
     region_quantile: f64,
@@ -29,6 +80,17 @@ impl Default for PedAnovaImportanceEvaluator {
 }
 
 impl PedAnovaImportanceEvaluator {
+    /// Creates a PED-ANOVA evaluator.
+    ///
+    /// `target_quantile` selects the top fraction of completed trials used as the target region.
+    /// For example, `0.1` evaluates which parameters were important for achieving the top 10% of
+    /// observed objective values.
+    ///
+    /// `region_quantile` selects the reference region against which the target region is compared.
+    /// The default behavior in [`Default`] compares against all completed trials.
+    ///
+    /// `evaluate_on_local` controls whether the reference density is estimated from the explored
+    /// region (`true`) or from the full search space (`false`).
     pub fn new(target_quantile: f64, region_quantile: f64, evaluate_on_local: bool) -> Self {
         Self {
             target_quantile,
@@ -120,6 +182,7 @@ impl PedAnovaImportanceEvaluator {
 }
 
 impl ImportanceEvaluator for PedAnovaImportanceEvaluator {
+    /// Evaluates parameter importances from completed trials in the study.
     fn evaluate_with(
         &self,
         study: &Study,


### PR DESCRIPTION
Follow-up #114 

This PR adds rustdoc across the public API surface of `rustuna_importance`. To check the rustdoc, please execute a following command:

```
$ cargo doc -p rustuna_importance --no-deps && python3 -m http.server --directory ./target/doc/
```

<img width="1399" height="1093" alt="Screenshot 2026-05-15 11 45 35" src="https://github.com/user-attachments/assets/5c4cec2a-163f-4b61-b5bb-17901124a367" />
