### PR TITLE
Align PED-ANOVA with Optuna’s implementation

### DIFF
--- a/rustuna_core/src/parzen_estimator/scott.rs
+++ b/rustuna_core/src/parzen_estimator/scott.rs
@@ -75,8 +75,8 @@ impl<'a> NumericalDistributionBuilder for ScottNumericalDistributionBuilder<'a> 
             var.sqrt()
         };
 
-        let q1_idx = weights_cum.partition_point(|&v| v < weights_sum * 0.25);
-        let q3_idx = weights_cum.partition_point(|&v| v <= weights_sum * 0.75);
+        let q1_idx = weights_cum.partition_point(|&v| v < (weights_sum / 4.0).floor());
+        let q3_idx = weights_cum.partition_point(|&v| v <= (weights_sum * 3.0 / 4.0).floor());
         let iqr = observations[q3_idx.min(n_observations - 1)] - observations[q1_idx];
 
         let sigma_est = 1.059 * sigma_est.min(iqr / 1.34) * weights_sum.powf(-0.2);

--- a/rustuna_core/src/parzen_estimator/scott.rs
+++ b/rustuna_core/src/parzen_estimator/scott.rs
@@ -38,12 +38,21 @@ impl<'a> NumericalDistributionBuilder for ScottNumericalDistributionBuilder<'a> 
             } => (*low, *high, *step, *log),
             _ => panic!("Unsupported distribution type for ScottNumericalDistributionBuilder"),
         };
-        let weights_sum = self.weights.iter().sum::<f64>();
+        let weights_cum = self.weights.iter().scan(0.0, |acc, &w| {
+            *acc += w;
+            Some(*acc)
+        }).collect::<Vec<_>>();
+        let weights_sum = weights_cum.last().cloned().unwrap_or(1.0);
         let n_observations = observations.len();
         let observations = if log {
             observations.iter().map(|v| v.ln()).collect()
         } else {
             observations.to_vec()
+        };
+        let (low, high) = if log {
+            (low.ln(), high.ln())
+        } else {
+            (low, high)
         };
 
         let mean_est = observations

--- a/rustuna_core/src/parzen_estimator/scott.rs
+++ b/rustuna_core/src/parzen_estimator/scott.rs
@@ -38,10 +38,14 @@ impl<'a> NumericalDistributionBuilder for ScottNumericalDistributionBuilder<'a> 
             } => (*low, *high, *step, *log),
             _ => panic!("Unsupported distribution type for ScottNumericalDistributionBuilder"),
         };
-        let weights_cum = self.weights.iter().scan(0.0, |acc, &w| {
-            *acc += w;
-            Some(*acc)
-        }).collect::<Vec<_>>();
+        let weights_cum = self
+            .weights
+            .iter()
+            .scan(0.0, |acc, &w| {
+                *acc += w;
+                Some(*acc)
+            })
+            .collect::<Vec<_>>();
         let weights_sum = weights_cum.last().cloned().unwrap_or(1.0);
         let n_observations = observations.len();
         let observations = if log {

--- a/rustuna_core/src/parzen_estimator/scott.rs
+++ b/rustuna_core/src/parzen_estimator/scott.rs
@@ -71,25 +71,17 @@ impl<'a> NumericalDistributionBuilder for ScottNumericalDistributionBuilder<'a> 
             var.sqrt()
         };
 
-        let inter_quantile_range = if observations.is_empty() {
-            0.0
-        } else {
-            let mut sorted_obs = observations.clone();
-            sorted_obs.sort_by(|a, b| a.total_cmp(b));
-            let q1_idx =
-                ((0.25 * (n_observations as f64 - 1.0)).floor() as usize).min(n_observations - 1);
-            let q3_idx =
-                ((0.75 * (n_observations as f64 - 1.0)).floor() as usize).min(n_observations - 1);
-            sorted_obs[q3_idx] - sorted_obs[q1_idx]
-        };
-        let sigma_est = 1.059 * sigma_est.min(inter_quantile_range / 1.34) * weights_sum.powf(-0.2);
+        let q1_idx = weights_cum.partition_point(|&v| v < weights_sum * 0.25);
+        let q3_idx = weights_cum.partition_point(|&v| v <= weights_sum * 0.75);
+        let iqr = observations[q3_idx.min(n_observations - 1)] - observations[q1_idx];
+
+        let sigma_est = 1.059 * sigma_est.min(iqr / 1.34) * weights_sum.powf(-0.2);
         // To avoid numerical errors. 0.5/1.64 means 1.64sigma (=90%) will fit in the target grid.
         let sigma_min = 0.5 / 1.64;
-        let sigmas = std::iter::repeat_n(sigma_est.max(sigma_min), n_observations);
-
         let mus_with_prior = observations
             .into_iter()
             .chain(std::iter::once((low + high) / 2.0));
+        let sigmas = std::iter::repeat_n(sigma_est.max(sigma_min), n_observations);
         let sigmas_with_prior = sigmas.chain(std::iter::once(high - low + 1.0));
 
         match (step, log) {

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -124,8 +124,7 @@ impl PedAnovaImportanceEvaluator {
                 }
             })
             .collect::<Vec<_>>();
-        let num_top_trials =
-            ((quantile * trials.len() as f64).ceil() as usize) - 1;
+        let num_top_trials = ((quantile * trials.len() as f64).ceil() as usize) - 1;
         let threshold = {
             let (_, &mut threshold, _) = objective_values
                 .clone()

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -124,7 +124,7 @@ impl PedAnovaImportanceEvaluator {
                 }
             })
             .collect::<Vec<_>>();
-        let num_top_trials = ((quantile * trials.len() as f64).ceil() as usize) - 1;
+        let num_top_trials = ((quantile * trials.len() as f64).ceil() as usize).max(1) - 1;
         let threshold = {
             let (_, &mut threshold, _) = objective_values
                 .clone()

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -274,11 +274,11 @@ fn count_numerical_param_in_grid(
             v
         }
     });
-    let step_size = (high - low) / (n_steps as f64);
+    let step_size = (high - low) / (n_steps as f64 - 1.0);
     let mut counts = vec![0u32; n_steps];
     for v in param_values {
-        let idx = ((v - low) / step_size)
-            .floor()
+        let idx = ((v - low) / step_size - 0.5)
+            .ceil()
             .max(0.0)
             .min((n_steps - 1) as f64) as usize;
         counts[idx] += 1;

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -131,7 +131,7 @@ impl PedAnovaImportanceEvaluator {
                 .select_nth_unstable_by(num_top_trials, |a, b| a.total_cmp(b));
             let (_, &mut threshold_min, _) = objective_values
                 .clone()
-                .select_nth_unstable_by(num_top_trials - 1, |a, b| a.total_cmp(b));
+                .select_nth_unstable_by(self.min_n_top_trials - 1, |a, b| a.total_cmp(b));
             threshold.max(threshold_min)
         };
         let top_trials = trials

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -124,18 +124,21 @@ impl PedAnovaImportanceEvaluator {
                 }
             })
             .collect::<Vec<_>>();
-        let num_trials = trials.len();
         let num_top_trials =
-            ((quantile * (num_trials as f64 - 1.0)).floor() as usize).min(num_trials - 1);
-
-        let (_, &mut threshold, _) = objective_values
-            .clone()
-            .select_nth_unstable_by(num_top_trials, |a, b| a.total_cmp(b));
+            ((quantile * trials.len() as f64).ceil() as usize) - 1;
+        let threshold = {
+            let (_, &mut threshold, _) = objective_values
+                .clone()
+                .select_nth_unstable_by(num_top_trials, |a, b| a.total_cmp(b));
+            let (_, &mut threshold_min, _) = objective_values
+                .clone()
+                .select_nth_unstable_by(num_top_trials - 1, |a, b| a.total_cmp(b));
+            threshold.max(threshold_min)
+        };
         let top_trials = trials
             .iter()
             .zip(objective_values.iter())
-            .filter(|(_, &v)| v <= threshold)
-            .map(|(t, _)| t)
+            .filter_map(|(t, &v)| (v <= threshold).then_some(t))
             .collect();
         top_trials
     }


### PR DESCRIPTION
## Motivation

The current implementation of PED-ANOVA has some minor discrepancies from Optuna's implementation.

The refactoring introduced in

- optuna/optuna#6681

makes the correspondence between the implementations easier to follow. This PR updates the implementation to more closely match Optuna's PED-ANOVA implementation.