### PR TITLE
Split `rustuna_js` wasm outputs for node and web

### DIFF
--- a/rustuna_js/README.md
+++ b/rustuna_js/README.md
@@ -27,26 +27,25 @@ console.log("best_trial.value: ", study.best_trial().value)
 
 ```
 $ cd rustuna_js/
-$ ./build.sh
+$ pnpm build
 ```
 
 #### Run examples
 
 ```
-$ ./build.sh
+$ pnpm build
 $ node dist/simple_quadratic.js
 ```
 
 #### Format
 
 ```
-$ npm i -g @biomejs/biome
+$ pnpm add -D @biomejs/biome
 $ biome format --write examples/*.ts test/*.mjs
 ```
 
 #### Test
 
 ```
-$ node --test
+$ pnpm test
 ```
-

--- a/rustuna_js/README.md
+++ b/rustuna_js/README.md
@@ -1,51 +1,95 @@
 ## rustuna_js
 
-### Example
+JavaScript and WebAssembly bindings for Rustuna.
+
+This package currently builds two wasm-bindgen outputs:
+
+- `pkg/node/` for Node.js
+- `pkg/web/` for browsers
+
+`package.json` exposes the Node.js build as the default entrypoint and the browser build via the
+`rustuna/web` subpath or the `browser` export condition.
+
+### Node.js example
 
 ```js
-import * as wasm from './pkg/rustuna_wasm.js';
+import * as rustuna from "rustuna";
 
-const study = wasm.create_study("test");
+const study = rustuna.create_study("node-example");
 
-const objective = (trial) => {
+study.optimize((trial) => {
+  const x = trial.suggest_float("x", -10.0, 10.0);
+  const y = trial.suggest_int("y", -10, 10);
+  return (x - 3) ** 2 + (y + 2) ** 2;
+}, 30);
+
+console.log(study.best_trial);
+```
+
+### Browser example
+
+For browsers, initialize the wasm module before calling exported APIs.
+
+```html
+<script type="module">
+  import init, { create_study } from "./pkg/web/rustuna.js";
+
+  await init();
+
+  const study = create_study("browser-example");
+  study.optimize((trial) => {
     const x = trial.suggest_float("x", -10.0, 10.0);
     const y = trial.suggest_int("y", -10, 10);
-    const z = trial.suggest_categorical("z", ["foo", "bar"]);
+    return (x - 3) ** 2 + (y + 2) ** 2;
+  }, 30);
 
-    const value = (x - 5) ** 2 + (y + 2) ** 2
-    console.log(`x: ${x}, y: ${y}, z: ${z}, value: ${value}`)
-    return value
-}
-study.optimize(objective, 10)
-console.log(study.best_trial())
-console.log("best_trial.value: ", study.best_trial().value)
+  console.log(study.best_trial.toJSON());
+</script>
 ```
 
-### Contributing
+A minimal browser example is available at `examples/browser/index.html`.
 
-#### Build from Source
+### Development
 
+#### Build from source
+
+```bash
+cd rustuna_js
+pnpm build
 ```
-$ cd rustuna_js/
-$ pnpm build
+
+#### Run Node.js tests
+
+```bash
+cd rustuna_js
+pnpm test
 ```
 
-#### Run examples
+#### Check the browser example locally
 
+```bash
+cd rustuna_js
+pnpm build
+python3 -m http.server 8000
 ```
-$ pnpm build
-$ node dist/simple_quadratic.js
+
+Then open:
+
+- `http://localhost:8000/examples/browser/`
+
+#### Run the TypeScript example
+
+If `tsc` is available, `pnpm build` also emits the example bundle under `dist/`.
+
+```bash
+cd rustuna_js
+pnpm build
+node dist/simple_quadratic.js
 ```
 
 #### Format
 
-```
-$ pnpm add -D @biomejs/biome
-$ biome format --write examples/*.ts test/*.mjs
-```
-
-#### Test
-
-```
-$ pnpm test
+```bash
+pnpm add -D @biomejs/biome
+biome format --write examples/**/*.ts test/*.mjs
 ```

--- a/rustuna_js/build.sh
+++ b/rustuna_js/build.sh
@@ -2,6 +2,8 @@
 
 DIR=$(cd $(dirname $0); pwd)
 OUTPUT_DIR=${DIR}/pkg
+NODE_OUTPUT_DIR=${OUTPUT_DIR}/node
+WEB_OUTPUT_DIR=${OUTPUT_DIR}/web
 
 set -ex
 
@@ -9,11 +11,18 @@ pushd ${DIR}
 
 # Build rustuna library
 cargo build --target wasm32-unknown-unknown --release
-wasm-bindgen ../target/wasm32-unknown-unknown/release/rustuna.wasm --out-dir ${OUTPUT_DIR} --target nodejs
-#wasm-opt -Oz -o pkg/rustuna_bg.wasm pkg/rustuna_bg.wasm
+mkdir -p ${NODE_OUTPUT_DIR} ${WEB_OUTPUT_DIR}
+wasm-bindgen ../target/wasm32-unknown-unknown/release/rustuna.wasm --out-dir ${NODE_OUTPUT_DIR} --target nodejs
+wasm-bindgen ../target/wasm32-unknown-unknown/release/rustuna.wasm --out-dir ${WEB_OUTPUT_DIR} --target web
+#wasm-opt -Oz -o pkg/node/rustuna_bg.wasm pkg/node/rustuna_bg.wasm
+#wasm-opt -Oz -o pkg/web/rustuna_bg.wasm pkg/web/rustuna_bg.wasm
 
 # Examples
-tsc --project tsconfig.examples.json
+if command -v tsc >/dev/null 2>&1; then
+  tsc --project tsconfig.examples.json
+else
+  echo "Skipping example compilation because tsc was not found."
+fi
 
 cat << 'EOF' > pkg/.gitignore
 *

--- a/rustuna_js/examples/browser/index.html
+++ b/rustuna_js/examples/browser/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>rustuna_js browser example</title>
+  </head>
+  <body>
+    <pre id="output"></pre>
+    <script type="module">
+      import init, { create_study } from "../../pkg/web/rustuna.js";
+
+      const output = document.getElementById("output");
+
+      async function main() {
+        await init();
+
+        const study = create_study("browser-example");
+        study.optimize((trial) => {
+          const x = trial.suggest_float("x", -10.0, 10.0);
+          const y = trial.suggest_int("y", -10, 10);
+          return (x - 3) ** 2 + (y + 2) ** 2;
+        }, 30);
+
+        output.textContent = JSON.stringify(study.best_trial.toJSON(), null, 2);
+      }
+
+      main().catch((error) => {
+        output.textContent = String(error);
+      });
+    </script>
+  </body>
+</html>

--- a/rustuna_js/examples/simple_quadratic.ts
+++ b/rustuna_js/examples/simple_quadratic.ts
@@ -1,4 +1,4 @@
-import * as rustuna from "../pkg/rustuna.js";
+import * as rustuna from "../pkg/node/rustuna.js";
 
 const study = rustuna.create_study("test");
 

--- a/rustuna_js/package-lock.json
+++ b/rustuna_js/package-lock.json
@@ -1,6 +1,0 @@
-{
-    "name": "rustuna_js",
-    "lockfileVersion": 3,
-    "requires": true,
-    "packages": {}
-}

--- a/rustuna_js/package.json
+++ b/rustuna_js/package.json
@@ -1,3 +1,48 @@
 {
-    "type": "commonjs"
+  "name": "rustuna",
+  "version": "0.1.0",
+  "private": true,
+  "description": "JavaScript bindings for Rustuna",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/optuna/rustuna.git",
+    "directory": "rustuna_js"
+  },
+  "keywords": [
+    "hyperparameter-optimization",
+    "optuna",
+    "wasm"
+  ],
+  "type": "commonjs",
+  "main": "./pkg/node/rustuna.js",
+  "types": "./pkg/node/rustuna.d.ts",
+  "browser": "./pkg/web/rustuna.js",
+  "exports": {
+    ".": {
+      "types": "./pkg/node/rustuna.d.ts",
+      "browser": "./pkg/web/rustuna.js",
+      "default": "./pkg/node/rustuna.js"
+    },
+    "./node": {
+      "types": "./pkg/node/rustuna.d.ts",
+      "default": "./pkg/node/rustuna.js"
+    },
+    "./web": {
+      "types": "./pkg/web/rustuna.d.ts",
+      "default": "./pkg/web/rustuna.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "pkg/node",
+    "pkg/web",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "bash ./build.sh",
+    "build:node": "mkdir -p ./pkg/node && cargo build --target wasm32-unknown-unknown --release && wasm-bindgen ../target/wasm32-unknown-unknown/release/rustuna.wasm --out-dir ./pkg/node --target nodejs",
+    "build:web": "mkdir -p ./pkg/web && cargo build --target wasm32-unknown-unknown --release && wasm-bindgen ../target/wasm32-unknown-unknown/release/rustuna.wasm --out-dir ./pkg/web --target web",
+    "test": "node --test ./test/*.mjs"
+  }
 }

--- a/rustuna_js/package.json
+++ b/rustuna_js/package.json
@@ -2,6 +2,7 @@
   "name": "rustuna",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@9.0.0",
   "description": "JavaScript bindings for Rustuna",
   "license": "MIT",
   "repository": {

--- a/rustuna_js/pnpm-lock.yaml
+++ b/rustuna_js/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}

--- a/rustuna_js/test/distribution.mjs
+++ b/rustuna_js/test/distribution.mjs
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert";
 
-import * as rustuna from "../pkg/rustuna.js";
+import * as rustuna from "../pkg/node/rustuna.js";
 
 test("optimize simple quadratic function", () => {
 	const study = rustuna.create_study("test");

--- a/rustuna_js/test/study_optimize.mjs
+++ b/rustuna_js/test/study_optimize.mjs
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert";
 
-import * as rustuna from "../pkg/rustuna.js";
+import * as rustuna from "../pkg/node/rustuna.js";
 import { type } from "node:os";
 
 test("optimize simple quadratic function", () => {

--- a/rustuna_js/test/user_attr.mjs
+++ b/rustuna_js/test/user_attr.mjs
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert";
 
-import * as rustuna from "../pkg/rustuna.js";
+import * as rustuna from "../pkg/node/rustuna.js";
 
 test("set_user_attr", () => {
 	const study = rustuna.create_study("test");

--- a/rustuna_js/tsconfig.examples.json
+++ b/rustuna_js/tsconfig.examples.json
@@ -9,5 +9,5 @@
     "outDir": "./dist",
     "noEmitOnError": true
   },
-  "include": ["examples/**/*.ts", "pkg/**/*.d.ts"]
+  "include": ["examples/**/*.ts", "pkg/node/**/*.d.ts"]
 }


### PR DESCRIPTION
This PR updates `rustuna_js` crate to include:

* Split rustuna_js wasm outputs for node and web
* Add package metadata for rustuna_js
* Switch rustuna_js to pnpm
* Add a minimal browser example
* Update `rustuna_js/README.md` for node and browser builds