### PR TITLE
Add support for conditional search spaces in PED-ANOVA

### DIFF
--- a/rustuna_core/src/parzen_estimator/scott.rs
+++ b/rustuna_core/src/parzen_estimator/scott.rs
@@ -75,8 +75,8 @@ impl<'a> NumericalDistributionBuilder for ScottNumericalDistributionBuilder<'a> 
             var.sqrt()
         };
 
-        let q1_idx = weights_cum.partition_point(|&v| v < weights_sum * 0.25);
-        let q3_idx = weights_cum.partition_point(|&v| v <= weights_sum * 0.75);
+        let q1_idx = weights_cum.partition_point(|&v| v < (weights_sum / 4.0).floor());
+        let q3_idx = weights_cum.partition_point(|&v| v <= (weights_sum * 3.0 / 4.0).floor());
         let iqr = observations[q3_idx.min(n_observations - 1)] - observations[q1_idx];
 
         let sigma_est = 1.059 * sigma_est.min(iqr / 1.34) * weights_sum.powf(-0.2);

--- a/rustuna_core/src/parzen_estimator/scott.rs
+++ b/rustuna_core/src/parzen_estimator/scott.rs
@@ -38,12 +38,21 @@ impl<'a> NumericalDistributionBuilder for ScottNumericalDistributionBuilder<'a> 
             } => (*low, *high, *step, *log),
             _ => panic!("Unsupported distribution type for ScottNumericalDistributionBuilder"),
         };
-        let weights_sum = self.weights.iter().sum::<f64>();
+        let weights_cum = self.weights.iter().scan(0.0, |acc, &w| {
+            *acc += w;
+            Some(*acc)
+        }).collect::<Vec<_>>();
+        let weights_sum = weights_cum.last().cloned().unwrap_or(1.0);
         let n_observations = observations.len();
         let observations = if log {
             observations.iter().map(|v| v.ln()).collect()
         } else {
             observations.to_vec()
+        };
+        let (low, high) = if log {
+            (low.ln(), high.ln())
+        } else {
+            (low, high)
         };
 
         let mean_est = observations

--- a/rustuna_core/src/parzen_estimator/scott.rs
+++ b/rustuna_core/src/parzen_estimator/scott.rs
@@ -38,10 +38,14 @@ impl<'a> NumericalDistributionBuilder for ScottNumericalDistributionBuilder<'a> 
             } => (*low, *high, *step, *log),
             _ => panic!("Unsupported distribution type for ScottNumericalDistributionBuilder"),
         };
-        let weights_cum = self.weights.iter().scan(0.0, |acc, &w| {
-            *acc += w;
-            Some(*acc)
-        }).collect::<Vec<_>>();
+        let weights_cum = self
+            .weights
+            .iter()
+            .scan(0.0, |acc, &w| {
+                *acc += w;
+                Some(*acc)
+            })
+            .collect::<Vec<_>>();
         let weights_sum = weights_cum.last().cloned().unwrap_or(1.0);
         let n_observations = observations.len();
         let observations = if log {

--- a/rustuna_core/src/parzen_estimator/scott.rs
+++ b/rustuna_core/src/parzen_estimator/scott.rs
@@ -71,25 +71,17 @@ impl<'a> NumericalDistributionBuilder for ScottNumericalDistributionBuilder<'a> 
             var.sqrt()
         };
 
-        let inter_quantile_range = if observations.is_empty() {
-            0.0
-        } else {
-            let mut sorted_obs = observations.clone();
-            sorted_obs.sort_by(|a, b| a.total_cmp(b));
-            let q1_idx =
-                ((0.25 * (n_observations as f64 - 1.0)).floor() as usize).min(n_observations - 1);
-            let q3_idx =
-                ((0.75 * (n_observations as f64 - 1.0)).floor() as usize).min(n_observations - 1);
-            sorted_obs[q3_idx] - sorted_obs[q1_idx]
-        };
-        let sigma_est = 1.059 * sigma_est.min(inter_quantile_range / 1.34) * weights_sum.powf(-0.2);
+        let q1_idx = weights_cum.partition_point(|&v| v < weights_sum * 0.25);
+        let q3_idx = weights_cum.partition_point(|&v| v <= weights_sum * 0.75);
+        let iqr = observations[q3_idx.min(n_observations - 1)] - observations[q1_idx];
+
+        let sigma_est = 1.059 * sigma_est.min(iqr / 1.34) * weights_sum.powf(-0.2);
         // To avoid numerical errors. 0.5/1.64 means 1.64sigma (=90%) will fit in the target grid.
         let sigma_min = 0.5 / 1.64;
-        let sigmas = std::iter::repeat_n(sigma_est.max(sigma_min), n_observations);
-
         let mus_with_prior = observations
             .into_iter()
             .chain(std::iter::once((low + high) / 2.0));
+        let sigmas = std::iter::repeat_n(sigma_est.max(sigma_min), n_observations);
         let sigmas_with_prior = sigmas.chain(std::iter::once(high - low + 1.0));
 
         match (step, log) {

--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -190,7 +190,7 @@ pub(crate) fn get_distributions(
         .map(|t| {
             t.distributions
                 .iter()
-                .filter(|(name, _)| params_set.as_ref().map_or(true, |s| s.contains(*name)))
+                .filter(|(name, _)| params_set.as_ref().is_none_or(|s| s.contains(*name)))
                 .map(|(name, dist)| (name.clone(), dist.clone()))
                 .collect::<HashMap<_, _>>()
         })

--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -166,16 +166,6 @@ pub(crate) fn get_filtered_trials(
     }
 }
 
-pub(crate) fn get_intersection_search_space(
-    trials: &[PersistedTrial],
-) -> HashMap<String, Distribution> {
-    let mut intersection_search_space = trials[0].distributions.clone();
-    for trial in &trials[1..] {
-        intersection_search_space
-            .retain(|k, v| trial.distributions.get(k).is_some_and(|v2| v2 == v));
-    }
-    intersection_search_space
-}
 
 #[cfg(test)]
 mod tests {

--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -169,19 +169,7 @@ pub(crate) fn get_filtered_trials(
 pub(crate) fn get_distributions(
     trials: &[PersistedTrial],
     params: &Option<Vec<String>>,
-) -> Result<Vec<HashMap<String, Distribution>>> {
-    if trials.is_empty() {
-        return Err(Error::with_reason(
-            ErrorKind::ImportanceEvaluatorError,
-            "Cannot evaluate parameter importances without completed trials.",
-        ));
-    }
-    if trials.len() == 1 {
-        return Err(Error::with_reason(
-            ErrorKind::ImportanceEvaluatorError,
-            "Cannot evaluate parameter importances with only a single trial.",
-        ));
-    }
+) -> Vec<HashMap<String, Distribution>> {
     let params_set = params
         .as_ref()
         .map(|p| p.iter().cloned().collect::<HashSet<_>>());
@@ -195,7 +183,7 @@ pub(crate) fn get_distributions(
                 .collect::<HashMap<_, _>>()
         })
         .collect::<Vec<_>>();
-    Ok(dists)
+    dists
 }
 
 #[cfg(test)]

--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -2,7 +2,7 @@ use rustuna_core::distribution::Distribution;
 use rustuna_core::study::Study;
 use rustuna_core::trial::{PersistedTrial, TrialStateValues};
 use rustuna_core::{Error, ErrorKind, Result};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Options shared by parameter-importance evaluators.
 pub struct ImportanceOptions<'a> {
@@ -166,24 +166,30 @@ pub(crate) fn get_filtered_trials(
     }
 }
 
-
-pub(crate) fn get_distributions(trials: &[PersistedTrial], params: &Option<Vec<String>>) -> Result<Vec<HashMap<String, Distribution>>> {
+pub(crate) fn get_distributions(
+    trials: &[PersistedTrial],
+    params: &Option<Vec<String>>,
+) -> Result<Vec<HashMap<String, Distribution>>> {
     if trials.is_empty() {
         return Err(Error::with_reason(
             ErrorKind::ImportanceEvaluatorError,
             "Cannot evaluate parameter importances without completed trials.",
-        ))
+        ));
     }
     if trials.len() == 1 {
         return Err(Error::with_reason(
             ErrorKind::ImportanceEvaluatorError,
             "Cannot evaluate parameter importances with only a single trial.",
-        ))
+        ));
     }
-    let params_set = params.as_ref().map(|p| p.iter().cloned().collect::<HashSet<_>>());
-    let dists = trials.iter()
+    let params_set = params
+        .as_ref()
+        .map(|p| p.iter().cloned().collect::<HashSet<_>>());
+    let dists = trials
+        .iter()
         .map(|t| {
-            t.distributions.iter()
+            t.distributions
+                .iter()
                 .filter(|(name, _)| params_set.as_ref().map_or(true, |s| s.contains(*name)))
                 .map(|(name, dist)| (name.clone(), dist.clone()))
                 .collect::<HashMap<_, _>>()
@@ -191,9 +197,6 @@ pub(crate) fn get_distributions(trials: &[PersistedTrial], params: &Option<Vec<S
         .collect::<Vec<_>>();
     Ok(dists)
 }
-
-
-
 
 #[cfg(test)]
 mod tests {

--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -191,16 +191,18 @@ mod tests {
     use super::*;
     use crate::ped_anova::PedAnovaImportanceEvaluator;
     use crate::test_utils;
+    use crate::test_utils::ObjectiveType;
     use rustuna_core::sampler::RandomSampler;
     use rustuna_core::storage::InMemoryStorage;
     use rustuna_core::study::{self, Direction};
     use rustuna_core::trial::PersistedTrial;
     use rustuna_core::{ErrorKind, Result};
     use std::collections::HashSet;
+
     #[test]
     fn test_error_multi_objective_wo_target() -> Result<()> {
         let evaluators = vec![PedAnovaImportanceEvaluator::default()];
-        let study = test_utils::get_study(42, 5, true, Direction::Minimize)?;
+        let study = test_utils::get_study(42, 5, ObjectiveType::Multi, Direction::Minimize)?;
         for evaluator in evaluators {
             let err = get_param_importances(&study, &evaluator).unwrap_err();
             assert!(matches!(err.kind, ErrorKind::ImportanceEvaluatorError));
@@ -211,7 +213,7 @@ mod tests {
     #[test]
     fn test_evaluator_error_multi_objective_wo_target() -> Result<()> {
         let evaluators = vec![PedAnovaImportanceEvaluator::default()];
-        let study = test_utils::get_study(42, 5, true, Direction::Minimize)?;
+        let study = test_utils::get_study(42, 5, ObjectiveType::Multi, Direction::Minimize)?;
         for evaluator in evaluators {
             let err = evaluator.evaluate(&study).unwrap_err();
             assert!(matches!(err.kind, ErrorKind::ImportanceEvaluatorError));
@@ -222,7 +224,7 @@ mod tests {
     #[test]
     fn test_get_param_importances() -> Result<()> {
         let evaluators = vec![PedAnovaImportanceEvaluator::default()];
-        let study = test_utils::get_study(42, 20, false, Direction::Minimize)?;
+        let study = test_utils::get_study(42, 20, ObjectiveType::Single, Direction::Minimize)?;
         for evaluator in evaluators {
             for normalize in [true, false] {
                 let importances = get_param_importances_with(
@@ -251,7 +253,7 @@ mod tests {
     #[test]
     fn test_get_param_importances_with_target() -> Result<()> {
         let evaluators = vec![PedAnovaImportanceEvaluator::default()];
-        let study = test_utils::get_study(42, 20, false, Direction::Minimize)?;
+        let study = test_utils::get_study(42, 20, ObjectiveType::Single, Direction::Minimize)?;
         let target =
             |t: &PersistedTrial| -> f64 { t.internal_params["x1"] + t.internal_params["x2"] };
         for evaluator in evaluators {
@@ -294,7 +296,7 @@ mod tests {
     #[test]
     fn test_evaluator_evaluate_with_target() -> Result<()> {
         let evaluators = vec![PedAnovaImportanceEvaluator::default()];
-        let study = test_utils::get_study(42, 20, false, Direction::Minimize)?;
+        let study = test_utils::get_study(42, 20, ObjectiveType::Single, Direction::Minimize)?;
         let target =
             |t: &PersistedTrial| -> f64 { t.internal_params["x1"] + t.internal_params["x2"] };
         for evaluator in evaluators {

--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -6,11 +6,9 @@ use std::collections::HashMap;
 
 /// Options shared by parameter-importance evaluators.
 pub struct ImportanceOptions<'a> {
-    // NOTE(kAIto47802): Currently, the `param` argument is not implemented.
-    // We plan to implement it when we support condPED-ANOVA:
-    // - https://arxiv.org/abs/2601.20800
     pub target: Option<&'a dyn Fn(&PersistedTrial) -> f64>,
     pub normalize: bool,
+    pub params: Option<Vec<String>>,
 }
 
 impl<'a> Default for ImportanceOptions<'a> {
@@ -18,6 +16,7 @@ impl<'a> Default for ImportanceOptions<'a> {
         Self {
             target: None,
             normalize: true,
+            params: None,
         }
     }
 }
@@ -40,6 +39,12 @@ impl<'a> ImportanceOptions<'a> {
     /// Sets whether the returned importances should be normalized to sum to `1.0`.
     pub fn normalize(mut self, normalize: bool) -> Self {
         self.normalize = normalize;
+        self
+    }
+
+    /// Sets the list of parameter names to evaluate importances for.
+    pub fn with_params(mut self, params: Vec<String>) -> Self {
+        self.params = Some(params);
         self
     }
 }

--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -167,6 +167,34 @@ pub(crate) fn get_filtered_trials(
 }
 
 
+pub(crate) fn get_distributions(trials: &[PersistedTrial], params: &Option<Vec<String>>) -> Result<Vec<HashMap<String, Distribution>>> {
+    if trials.is_empty() {
+        return Err(Error::with_reason(
+            ErrorKind::ImportanceEvaluatorError,
+            "Cannot evaluate parameter importances without completed trials.",
+        ))
+    }
+    if trials.len() == 1 {
+        return Err(Error::with_reason(
+            ErrorKind::ImportanceEvaluatorError,
+            "Cannot evaluate parameter importances with only a single trial.",
+        ))
+    }
+    let params_set = params.as_ref().map(|p| p.iter().cloned().collect::<HashSet<_>>());
+    let dists = trials.iter()
+        .map(|t| {
+            t.distributions.iter()
+                .filter(|(name, _)| params_set.as_ref().map_or(true, |s| s.contains(*name)))
+                .map(|(name, dist)| (name.clone(), dist.clone()))
+                .collect::<HashMap<_, _>>()
+        })
+        .collect::<Vec<_>>();
+    Ok(dists)
+}
+
+
+
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -64,6 +64,7 @@ pub struct PedAnovaImportanceEvaluator {
     n_steps: usize,
     prior_weight: f64,
     min_n_top_trials: usize,
+    min_n_trials_in_regime: usize,
 }
 
 impl Default for PedAnovaImportanceEvaluator {
@@ -75,6 +76,7 @@ impl Default for PedAnovaImportanceEvaluator {
             n_steps: 50,
             prior_weight: 1.0,
             min_n_top_trials: 2,
+            min_n_trials_in_regime: 2,
         }
     }
 }
@@ -99,6 +101,7 @@ impl PedAnovaImportanceEvaluator {
             n_steps: 50,
             prior_weight: 1.0,
             min_n_top_trials: 2,
+            min_n_trials_in_regime: 2,
         }
     }
 

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -465,4 +465,23 @@ mod tests {
         assert_ne!(importances_default, importances);
         Ok(())
     }
+
+    #[test]
+    fn test_conditional() -> Result<()> {
+        let study = test_utils::get_study(42, 20, ObjectiveType::Conditional, Direction::Minimize)?;
+        let evaluator = PedAnovaImportanceEvaluator::default();
+        let importances = evaluator.evaluate(&study)?;
+        assert!(importances.contains_key("c"));
+        assert!(importances.contains_key("x"));
+        assert!(importances.contains_key("y"));
+        assert_ne!(
+            importances,
+            HashMap::from([
+                ("c".to_string(), 0.0),
+                ("x".to_string(), 0.0),
+                ("y".to_string(), 0.0),
+            ])
+        );
+        Ok(())
+    }
 }

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -203,7 +203,7 @@ impl ImportanceEvaluator for PedAnovaImportanceEvaluator {
                 .iter()
                 .flat_map(|d| d.keys())
                 .cloned()
-                .collect::<BTreeSet<_>>()
+                .collect::<BTreeSet<_>>() // maintain a deterministic order of parameters
                 .into_iter()
                 .collect(),
         };

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -4,7 +4,7 @@ use rustuna_core::parzen_estimator::ParzenEstimator;
 use rustuna_core::study::{Direction, Study};
 use rustuna_core::trial::PersistedTrial;
 use rustuna_core::Result;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, BTreeSet};
 
 /// PED-ANOVA importance evaluator.
 ///

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -223,28 +223,41 @@ impl ImportanceEvaluator for PedAnovaImportanceEvaluator {
 
         let target_trial_ids = target_trials.iter().map(|t| t.id).collect::<HashSet<_>>();
         let importances = params.into_iter().map(|name| {
-            let regime_trials = partition_by_regime(&name, &region_trials, self.min_n_trials_in_regime);
-            let importance = regime_trials.into_iter().map(|(dist, region_trials_regime)| {
-                let target_trials_regime = region_trials_regime
-                    .iter()
-                    .filter(|t| target_trial_ids.contains(&t.id))
-                    .copied()
-                    .collect::<Vec<_>>();
-                let regime_prob_target = target_trials_regime.len() as f64 / target_trials.len() as f64; // alpha_i
-                let regime_prob_region = region_trials_regime.len() as f64 / region_trials.len() as f64; // beta_i
-                match dist {
-                    Some(dist) if !dist.is_single() && !target_trials_regime.is_empty() =>
-                        regime_prob_target.powi(2) / regime_prob_region
-                        * self.compute_pearson_divergence(&name, dist, &target_trials_regime, &region_trials_regime),
-                    _ => 0.0
-                }
-            }).sum::<f64>();
+            let regime_trials =
+                partition_by_regime(&name, &region_trials, self.min_n_trials_in_regime);
+            let importance = regime_trials
+                .into_iter()
+                .map(|(dist, region_trials_regime)| {
+                    let target_trials_regime = region_trials_regime
+                        .iter()
+                        .filter(|t| target_trial_ids.contains(&t.id))
+                        .copied()
+                        .collect::<Vec<_>>();
+                    let regime_prob_target =
+                        target_trials_regime.len() as f64 / target_trials.len() as f64; // alpha_i
+                    let regime_prob_region =
+                        region_trials_regime.len() as f64 / region_trials.len() as f64; // beta_i
+                    match dist {
+                        Some(dist) if !dist.is_single() && !target_trials_regime.is_empty() => {
+                            regime_prob_target.powi(2) / regime_prob_region
+                                * self.compute_pearson_divergence(
+                                    &name,
+                                    dist,
+                                    &target_trials_regime,
+                                    &region_trials_regime,
+                                )
+                        }
+                        _ => 0.0,
+                    }
+                })
+                .sum::<f64>();
             (name, importance)
         });
-        Ok(importances.map(|(k, v)| (k, quantile.powi(2) * v)).collect())
+        Ok(importances
+            .map(|(k, v)| (k, quantile.powi(2) * v))
+            .collect())
     }
 }
-
 
 fn partition_by_regime<'a>(
     param_name: &str,

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -203,7 +203,7 @@ impl ImportanceEvaluator for PedAnovaImportanceEvaluator {
                 .iter()
                 .flat_map(|d| d.keys())
                 .cloned()
-                .collect::<HashSet<_>>()
+                .collect::<BTreeSet<_>>()
                 .into_iter()
                 .collect(),
         };

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -193,38 +193,55 @@ impl ImportanceEvaluator for PedAnovaImportanceEvaluator {
         let target = common::resolve_target(opts.target);
         let trials = common::get_filtered_trials(study, target)?;
         common::ensure_target_for_multi_objective(&trials, opts.target)?;
-        let dists = common::get_intersection_search_space(&trials);
+        let dists = common::get_distributions(&trials, &opts.params)?;
+        let params = match opts.params {
+            Some(params) => params,
+            None => dists
+                .iter()
+                .flat_map(|d| d.keys())
+                .cloned()
+                .collect::<HashSet<_>>()
+                .into_iter()
+                .collect(),
+        };
 
         if trials.len() <= self.min_n_top_trials {
-            return Ok(dists.into_keys().map(|name| (name, 0.0)).collect());
+            return Ok(params.into_iter().map(|name| (name, 0.0)).collect());
         }
 
         let target_trials =
             self.get_top_quantile_trials(study, &trials, self.target_quantile, target);
         let region_trials =
             self.get_top_quantile_trials(study, &trials, self.region_quantile, target);
-
+        if target_trials.is_empty() {
+            return Ok(params.into_iter().map(|name| (name, 0.0)).collect());
+        }
         let quantile = target_trials.len() as f64 / region_trials.len() as f64;
 
-        let importances = dists
-            .into_iter()
-            .map(|(name, dist)| {
-                let importance = if dist.is_single() {
-                    0.0
-                } else {
-                    quantile.powi(2)
-                        * self.compute_pearson_divergence(
-                            &name,
-                            &dist,
-                            &target_trials,
-                            &region_trials,
-                        )
-                };
-                (name, importance)
-            })
-            .collect();
-        Ok(importances)
+        let target_trial_ids = target_trials.iter().map(|t| t.id).collect::<HashSet<_>>();
+        let importances = params.into_iter().map(|name| {
+            let regime_trials = partition_by_regime(&name, &region_trials, self.min_n_trials_in_regime);
+            let importance = regime_trials.into_iter().map(|(dist, region_trials_regime)| {
+                let target_trials_regime = region_trials_regime
+                    .iter()
+                    .filter(|t| target_trial_ids.contains(&t.id))
+                    .copied()
+                    .collect::<Vec<_>>();
+                let regime_prob_target = target_trials_regime.len() as f64 / target_trials.len() as f64; // alpha_i
+                let regime_prob_region = region_trials_regime.len() as f64 / region_trials.len() as f64; // beta_i
+                match dist {
+                    Some(dist) if !dist.is_single() && !target_trials_regime.is_empty() =>
+                        regime_prob_target.powi(2) / regime_prob_region
+                        * self.compute_pearson_divergence(&name, dist, &target_trials_regime, &region_trials_regime),
+                    _ => 0.0
+                }
+            }).sum::<f64>();
+            (name, importance)
+        });
+        Ok(importances.map(|(k, v)| (k, quantile.powi(2) * v)).collect())
     }
+}
+
 
 fn partition_by_regime<'a>(
     param_name: &str,

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -413,8 +413,12 @@ mod tests {
     #[test]
     fn test_n_trials_equal_to_min_n_top_trials() -> Result<()> {
         let evaluator = PedAnovaImportanceEvaluator::default();
-        let study =
-            test_utils::get_study(42, evaluator.min_n_top_trials, ObjectiveType::Single, Direction::Minimize)?;
+        let study = test_utils::get_study(
+            42,
+            evaluator.min_n_top_trials,
+            ObjectiveType::Single,
+            Direction::Minimize,
+        )?;
         let importances = evaluator.evaluate(&study)?;
         assert!(
             importances.values().all(|v| v.abs() <= 1e-12),
@@ -425,8 +429,10 @@ mod tests {
 
     #[test]
     fn test_direction() -> Result<()> {
-        let study_minimize = test_utils::get_study(42, 20, ObjectiveType::Single, Direction::Minimize)?;
-        let study_maximize = test_utils::get_study(42, 20, ObjectiveType::Single, Direction::Maximize)?;
+        let study_minimize =
+            test_utils::get_study(42, 20, ObjectiveType::Single, Direction::Minimize)?;
+        let study_maximize =
+            test_utils::get_study(42, 20, ObjectiveType::Single, Direction::Maximize)?;
         let evaluator = PedAnovaImportanceEvaluator::default();
         let importances_minimize = evaluator.evaluate(&study_minimize)?;
         let importances_maximize = evaluator.evaluate(&study_maximize)?;

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -4,7 +4,7 @@ use rustuna_core::parzen_estimator::ParzenEstimator;
 use rustuna_core::study::{Direction, Study};
 use rustuna_core::trial::PersistedTrial;
 use rustuna_core::Result;
-use std::collections::{HashMap, BTreeSet};
+use std::collections::{HashMap, BTreeSet, HashSet};
 
 /// PED-ANOVA importance evaluator.
 ///

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -406,6 +406,7 @@ fn build_parzen_estimator_on_grid(
 mod tests {
     use super::*;
     use crate::test_utils;
+    use crate::test_utils::ObjectiveType;
     use rustuna_core::study::Direction;
     use rustuna_core::Result;
 
@@ -413,7 +414,7 @@ mod tests {
     fn test_n_trials_equal_to_min_n_top_trials() -> Result<()> {
         let evaluator = PedAnovaImportanceEvaluator::default();
         let study =
-            test_utils::get_study(42, evaluator.min_n_top_trials, false, Direction::Minimize)?;
+            test_utils::get_study(42, evaluator.min_n_top_trials, ObjectiveType::Single, Direction::Minimize)?;
         let importances = evaluator.evaluate(&study)?;
         assert!(
             importances.values().all(|v| v.abs() <= 1e-12),
@@ -424,8 +425,8 @@ mod tests {
 
     #[test]
     fn test_direction() -> Result<()> {
-        let study_minimize = test_utils::get_study(42, 20, false, Direction::Minimize)?;
-        let study_maximize = test_utils::get_study(42, 20, false, Direction::Maximize)?;
+        let study_minimize = test_utils::get_study(42, 20, ObjectiveType::Single, Direction::Minimize)?;
+        let study_maximize = test_utils::get_study(42, 20, ObjectiveType::Single, Direction::Maximize)?;
         let evaluator = PedAnovaImportanceEvaluator::default();
         let importances_minimize = evaluator.evaluate(&study_minimize)?;
         let importances_maximize = evaluator.evaluate(&study_maximize)?;
@@ -435,7 +436,7 @@ mod tests {
 
     #[test]
     fn test_target_quantile() -> Result<()> {
-        let study = test_utils::get_study(42, 20, false, Direction::Minimize)?;
+        let study = test_utils::get_study(42, 20, ObjectiveType::Single, Direction::Minimize)?;
         let evaluator_default = PedAnovaImportanceEvaluator::default();
         let evaluator = PedAnovaImportanceEvaluator::new(0.3, 1.0, true);
         let importances_default = evaluator_default.evaluate(&study)?;
@@ -446,7 +447,7 @@ mod tests {
 
     #[test]
     fn test_region_quantile_less_than_one() -> Result<()> {
-        let study = test_utils::get_study(42, 20, false, Direction::Minimize)?;
+        let study = test_utils::get_study(42, 20, ObjectiveType::Single, Direction::Minimize)?;
         let evaluator_default = PedAnovaImportanceEvaluator::default();
         let evaluator = PedAnovaImportanceEvaluator::new(0.1, 0.5, true);
         let importances_default = evaluator_default.evaluate(&study)?;
@@ -457,7 +458,7 @@ mod tests {
 
     #[test]
     fn test_evaluate_on_local() -> Result<()> {
-        let study = test_utils::get_study(42, 20, false, Direction::Minimize)?;
+        let study = test_utils::get_study(42, 20, ObjectiveType::Single, Direction::Minimize)?;
         let evaluator_default = PedAnovaImportanceEvaluator::default();
         let evaluator = PedAnovaImportanceEvaluator::new(0.1, 1.0, false);
         let importances_default = evaluator_default.evaluate(&study)?;

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -124,8 +124,7 @@ impl PedAnovaImportanceEvaluator {
                 }
             })
             .collect::<Vec<_>>();
-        let num_top_trials =
-            ((quantile * trials.len() as f64).ceil() as usize) - 1;
+        let num_top_trials = ((quantile * trials.len() as f64).ceil() as usize) - 1;
         let threshold = {
             let (_, &mut threshold, _) = objective_values
                 .clone()

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -225,6 +225,28 @@ impl ImportanceEvaluator for PedAnovaImportanceEvaluator {
             .collect();
         Ok(importances)
     }
+
+fn partition_by_regime<'a>(
+    param_name: &str,
+    trials: &'a [&'a PersistedTrial],
+    min_n_trials_in_regime: usize,
+) -> Vec<(Option<&'a Distribution>, Vec<&'a PersistedTrial>)> {
+    // Distribution does not implement Eq or Hash, so we use Vec instead of HashMap.
+    let mut regime_trials: Vec<(Option<&'a Distribution>, Vec<&'a PersistedTrial>)> = vec![];
+    for trial in trials {
+        let dist = trial.distributions.get(param_name);
+
+        if let Some((_, group_trials)) = regime_trials
+            .iter_mut()
+            .find(|(existing_regime, _)| *existing_regime == dist)
+        {
+            group_trials.push(trial);
+        } else {
+            regime_trials.push((dist, vec![trial]));
+        }
+    }
+    regime_trials.retain(|(_, group_trials)| group_trials.len() >= min_n_trials_in_regime);
+    regime_trials
 }
 
 fn count_numerical_param_in_grid(

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -4,7 +4,7 @@ use rustuna_core::parzen_estimator::ParzenEstimator;
 use rustuna_core::study::{Direction, Study};
 use rustuna_core::trial::PersistedTrial;
 use rustuna_core::Result;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// PED-ANOVA importance evaluator.
 ///

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -274,11 +274,11 @@ fn count_numerical_param_in_grid(
             v
         }
     });
-    let step_size = (high - low) / (n_steps as f64);
+    let step_size = (high - low) / (n_steps as f64 - 1.0);
     let mut counts = vec![0u32; n_steps];
     for v in param_values {
-        let idx = ((v - low) / step_size)
-            .floor()
+        let idx = ((v - low) / step_size - 0.5)
+            .ceil()
             .max(0.0)
             .min((n_steps - 1) as f64) as usize;
         counts[idx] += 1;

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -4,7 +4,7 @@ use rustuna_core::parzen_estimator::ParzenEstimator;
 use rustuna_core::study::{Direction, Study};
 use rustuna_core::trial::PersistedTrial;
 use rustuna_core::Result;
-use std::collections::{HashMap, BTreeSet, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 /// PED-ANOVA importance evaluator.
 ///

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -196,7 +196,7 @@ impl ImportanceEvaluator for PedAnovaImportanceEvaluator {
         let target = common::resolve_target(opts.target);
         let trials = common::get_filtered_trials(study, target)?;
         common::ensure_target_for_multi_objective(&trials, opts.target)?;
-        let dists = common::get_distributions(&trials, &opts.params)?;
+        let dists = common::get_distributions(&trials, &opts.params);
         let params = match opts.params {
             Some(params) => params,
             None => dists

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -131,7 +131,7 @@ impl PedAnovaImportanceEvaluator {
                 .select_nth_unstable_by(num_top_trials, |a, b| a.total_cmp(b));
             let (_, &mut threshold_min, _) = objective_values
                 .clone()
-                .select_nth_unstable_by(num_top_trials - 1, |a, b| a.total_cmp(b));
+                .select_nth_unstable_by(self.min_n_top_trials - 1, |a, b| a.total_cmp(b));
             threshold.max(threshold_min)
         };
         let top_trials = trials

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -235,7 +235,6 @@ fn partition_by_regime<'a>(
     let mut regime_trials: Vec<(Option<&'a Distribution>, Vec<&'a PersistedTrial>)> = vec![];
     for trial in trials {
         let dist = trial.distributions.get(param_name);
-
         if let Some((_, group_trials)) = regime_trials
             .iter_mut()
             .find(|(existing_regime, _)| *existing_regime == dist)

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -124,18 +124,21 @@ impl PedAnovaImportanceEvaluator {
                 }
             })
             .collect::<Vec<_>>();
-        let num_trials = trials.len();
         let num_top_trials =
-            ((quantile * (num_trials as f64 - 1.0)).floor() as usize).min(num_trials - 1);
-
-        let (_, &mut threshold, _) = objective_values
-            .clone()
-            .select_nth_unstable_by(num_top_trials, |a, b| a.total_cmp(b));
+            ((quantile * trials.len() as f64).ceil() as usize) - 1;
+        let threshold = {
+            let (_, &mut threshold, _) = objective_values
+                .clone()
+                .select_nth_unstable_by(num_top_trials, |a, b| a.total_cmp(b));
+            let (_, &mut threshold_min, _) = objective_values
+                .clone()
+                .select_nth_unstable_by(num_top_trials - 1, |a, b| a.total_cmp(b));
+            threshold.max(threshold_min)
+        };
         let top_trials = trials
             .iter()
             .zip(objective_values.iter())
-            .filter(|(_, &v)| v <= threshold)
-            .map(|(t, _)| t)
+            .filter_map(|(t, &v)| (v <= threshold).then_some(t))
             .collect();
         top_trials
     }

--- a/rustuna_importance/src/test_utils.rs
+++ b/rustuna_importance/src/test_utils.rs
@@ -79,17 +79,27 @@ fn multi_objective(mut trial: Trial) -> Result<Vec<f64>> {
     Ok(vec![x1.powi(4) + x2 + x3, x4.pow(2) as f64 - x5 + x6])
 }
 
+fn conditional_objective(mut trial: Trial) -> Result<Vec<f64>> {
+    let c = trial.suggest_float("c", 0.0, 1.0)?;
+    if c < 0.5 {
+        let x = trial.suggest_float("x", 0.0, 10.0)?;
+        Ok(vec![x])
+    } else {
+        let y = trial.suggest_float("y", -10.0, 0.0)?;
+        Ok(vec![y])
+    }
+}
+
 pub(crate) fn get_study(
     seed: u64,
     n_trials: usize,
-    is_multi_objective: bool,
+    objective_type: ObjectiveType,
     direction: Direction,
 ) -> Result<Study> {
     let storage = InMemoryStorage::new();
-    let directions = if is_multi_objective {
-        vec![direction.clone(), direction]
-    } else {
-        vec![direction]
+    let directions = match objective_type {
+        ObjectiveType::Multi => vec![direction.clone(), direction],
+        _ => vec![direction],
     };
     let study = study::create_study(
         "test-study",
@@ -98,10 +108,10 @@ pub(crate) fn get_study(
         directions,
     )?;
     study.optimize(
-        if is_multi_objective {
-            multi_objective
-        } else {
-            single_objective
+        match objective_type {
+            ObjectiveType::Single => single_objective,
+            ObjectiveType::Multi => multi_objective,
+            ObjectiveType::Conditional => conditional_objective,
         },
         n_trials,
     )?;

--- a/rustuna_importance/src/test_utils.rs
+++ b/rustuna_importance/src/test_utils.rs
@@ -4,6 +4,13 @@ use rustuna_core::storage::InMemoryStorage;
 use rustuna_core::study::{self, Direction, Study};
 use rustuna_core::trial::Trial;
 use rustuna_core::Result;
+
+pub(crate) enum ObjectiveType {
+    Single,
+    Multi,
+    Conditional,
+}
+
 fn single_objective(mut trial: Trial) -> Result<Vec<f64>> {
     let x1 = trial.suggest_float("x1", 0.1, 3.0)?;
     let x2 = trial.suggest(


### PR DESCRIPTION
## Motivation

This PR adds support for conditional search spaces in PED-ANOVA, where the presence or domain of a hyperparameter can depend on other hyperparameters.

This PR is the Rustuna counterpart of the following Optuna PR:

- https://github.com/optuna/optuna/pull/6682.

The implementation is based on our paper:

<div align="center">
<a href="https://arxiv.org/abs/2601.20800">
<strong>Conditional PED-ANOVA: Hyperparameter Importance in Hierarchical & Dynamic Search Spaces</strong>
</a>
<br />
<strong>✨️Accepted to the 32nd ACM SIGKDD Conference on Knowledge Discovery and Data Mining (KDD 2026)✨️</strong>
</div>

## Compatibility Check

To check compatibility with Optuna's condPED-ANOVA, I run the same experiments as those conducted in the paper. I use Rustuna's `PedAnovaImportanceEvaluator` through the PyO3 bindings; all experimental settings are the same as in the paper, except for the importance evaluator implementation.


The results are shown in Figures 1 and 2. We can confirm that Rustuna's `PedAnovaImportanceEvaluator` produces qualitatively the same importance patterns as Optuna's implementation.


<img width="5370" height="810" alt="cond_ped_anova_1000trials_normalized" src="https://github.com/user-attachments/assets/50ef1adf-9d31-4273-a5e4-38aa87249009" />

<table>
  <tr>
    <td align="center"><strong>(a)</strong> Conditional activation (Equation (12)) with disjoint domains (Equation (13))</td>
    <td align="center"><strong>(b)</strong> Conditional activation (Equation (12)) with overlapping domains (Equation (14))</td>
    <td align="center"><strong>(c)</strong> Regime-dependent domains (Equations (15) and (16))</td>
  </tr>
</table>

Figure1: condPED-ANOVA (γ = 1.0) HPI values computed for the synthetic objective functions described in the paper, corresponding to Figure 1 of the paper. The lines denote the mean, and the shaded regions denote the standard error, both computed over ten independent runs with different random seeds.

<div align="center">
<img width="80%" alt="activation-disjoint_cond_ped_anova_1000trials_normalized" src="https://github.com/user-attachments/assets/a0f85799-e640-42fa-b7e9-c1f24e2bc1fe" />

(a) Conditional activation (Equation (12)) with disjoint domains (Equation (13))

<img width="80%" alt="activation-overlap_cond_ped_anova_1000trials_normalized" src="https://github.com/user-attachments/assets/f3ee3857-beab-4812-bd0d-54e71ec5291e" />

(b) Conditional activation (Equation (12)) with overlapping domains (Equation (14))

<img width="80%" alt="regime-dependent-domain_cond_ped_anova_1000trials_normalized" src="https://github.com/user-attachments/assets/ade6f9bd-8d1c-4622-af57-685493950ce8" />

(c) Regime-dependent domains (Equation (15) and Equation (16))
</div>
Figure2: condPED-ANOVA HPI computed for the synthetic objectives with varying γ, corresponding Figure 7 of the paper. The lines denote the mean, and the shaded regions denote the standard error, both computed over ten independent runs with different random seeds.

