### PR TITLE
Accept custom sampler in Study constructor

### DIFF
--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -339,16 +339,12 @@ impl PyStudy {
         study_id: u32,
         name: String,
         directions: Vec<PyDirection>,
-        storage: PyStorage,
-        sampler: PySampler,
+        storage: Py<PyAny>,
+        sampler: Py<PyAny>,
     ) -> PyResult<Self> {
         let directions: Vec<Direction> = directions.into_iter().map(|d| d.into()).collect();
-        let storage_pyobj = Python::attach(|py| -> PyResult<Py<PyAny>> {
-            Ok(Py::new(py, storage.clone())?.into_any())
-        })?;
-        let sampler_pyobj = Python::attach(|py| -> PyResult<Py<PyAny>> {
-            Ok(Py::new(py, sampler.clone())?.into_any())
-        })?;
+        let (storage_arc, storage_pyobj) = Python::attach(|py| resolve_storage_pyobj(py, storage))?;
+        let (sampler_arc, sampler_pyobj) = Python::attach(|py| resolve_sampler_pyobj(py, sampler))?;
         let trial_queue = PyTrialQueue {
             queue: Arc::new(RwLock::new(
                 rustuna_core::trial_queue::InMemoryTrialQueue::new(),
@@ -362,8 +358,8 @@ impl PyStudy {
             study_id,
             name,
             directions,
-            storage.storage,
-            sampler.sampler.clone(),
+            storage_arc,
+            sampler_arc,
             trial_queue_arc,
         );
         Ok(PyStudy {

--- a/rustuna_pyo3/tests/test_samplers.py
+++ b/rustuna_pyo3/tests/test_samplers.py
@@ -144,6 +144,24 @@ def test_custom_sampler(sampler: rustuna.samplers.SamplerProtocol) -> None:
     study.optimize(objective, n_trials=100)
 
 
+def test_study_constructor_accepts_custom_sampler() -> None:
+    storage = rustuna.storages.InMemoryStorage()
+    persisted_study = storage.create_new_study(
+        "direct-study", [rustuna.study.StudyDirection.MINIMIZE]
+    )
+    study = rustuna.study.Study(
+        persisted_study.id,
+        persisted_study.name,
+        persisted_study.directions,
+        storage,
+        DummyIndependentSampler(),
+    )
+
+    study.optimize(lambda trial: trial.suggest_float("x", -1.0, 1.0), n_trials=1)
+
+    assert study.trials[0].state == rustuna.trial.TrialState.COMPLETE
+
+
 def test_custom_sampler_after_trial_is_called() -> None:
     sampler = RecordingSampler()
 


### PR DESCRIPTION
Fix `rustuna.study.Study(...)` so that its `sampler` argument accepts Python objects implementing `SamplerProtocol`, matching the behavior of `rustuna.create_study(...)` and `rustuna.load_study(...)`.
