### PR TITLE
Introduce `storage.discard_trials()` method

### DIFF
--- a/rustuna_core/src/storage.rs
+++ b/rustuna_core/src/storage.rs
@@ -149,6 +149,8 @@ pub trait Storage: Send + Sync {
     ///
     /// This corresponds to the search space used for joint sampling.
     fn get_joint_search_space(&mut self, study_id: u32) -> Result<HashMap<String, Distribution>>;
+    fn discard_trials(&mut self, trial_ids: &[u32]) -> Result<()>;
+    fn may_omit_trials(&self) -> bool;
 }
 
 /// In-memory storage implementation used by default in Rust code and tests.
@@ -529,6 +531,26 @@ impl Storage for InMemoryStorage {
         study_cache.update(&visible_trials);
         Ok(study_cache.get_joint_search_space())
     }
+
+    fn discard_trials(&mut self, trial_ids: &[u32]) -> Result<()> {
+        for trial_id in trial_ids {
+            let (study_id, trial_number) =
+                get_study_id_trial_number_by_trial_id(&self.trial_id_to_study_number, *trial_id)?;
+
+            let trials = get_mut_trials_by_study_id(&mut self.trials, study_id)?;
+            let slot = trials
+                .get_mut(trial_number as usize)
+                .ok_or(Error::new(ErrorKind::TrialNotFound))?;
+            *slot = None;
+        }
+        Ok(())
+    }
+
+    fn may_omit_trials(&self) -> bool {
+        self.trials
+            .values()
+            .any(|trials| trials.iter().any(Option::is_none))
+    }
 }
 
 fn check_trial_is_updatable(trial: &PersistedTrial) -> Result<()> {
@@ -660,6 +682,27 @@ mod tests {
             .get_study_attr(study_id, AttrKey::User("missing".into()))
             .unwrap_err();
         assert!(matches!(err.kind, ErrorKind::AttrNotFound));
+        Ok(())
+    }
+
+    #[test]
+    fn discard_trials_omits_trials() -> Result<()> {
+        let mut storage = InMemoryStorage::new();
+        let study_id = storage
+            .create_new_study("study", vec![Direction::Minimize])?
+            .id;
+        let trial0_id = storage.create_new_trial(study_id)?.id;
+        let trial1_id = storage.create_new_trial(study_id)?.id;
+
+        storage.discard_trials(&[trial0_id])?;
+        storage.discard_trials(&[trial0_id])?;
+
+        let trials = storage.get_trials(study_id)?;
+        assert!(trials[0].is_none());
+        assert_eq!(trials[1].as_ref().unwrap().id, trial1_id);
+        assert!(storage.may_omit_trials());
+        let err = storage.get_trial(trial0_id).unwrap_err();
+        assert!(matches!(err.kind, ErrorKind::TrialDiscarded));
         Ok(())
     }
 }

--- a/rustuna_pyo3/rustuna/_protocols.py
+++ b/rustuna_pyo3/rustuna/_protocols.py
@@ -329,3 +329,13 @@ class StorageProtocol(Protocol):
         Returns:
             List of category labels, or None if not set.
         """
+
+    def discard_trials(self, trial_ids: list[int]) -> None:
+        """Discard trials from the storage view.
+
+        Args:
+            trial_ids: IDs of trials to discard.
+        """
+
+    def may_omit_trials(self) -> bool:
+        """Return True if this storage view may omit discarded trials."""

--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -679,6 +679,8 @@ class PyObjectStorage:
         param_name: str,
         cardinality: int,
     ) -> list[CategoricalChoiceType] | None: ...
+    def discard_trials(self, trial_ids: list[int]) -> None: ...
+    def may_omit_trials(self) -> bool: ...
 
 class Storage:
     """Storage for persisting optimization history."""
@@ -693,6 +695,8 @@ class Storage:
     def journal_file(
         cls,
         file_path: str,
+        *,
+        load_discarded_trials: bool = False,
     ) -> StorageProtocol: ...
     def create_new_study(
         self, study_name: str, directions: list[StudyDirection]
@@ -747,6 +751,8 @@ class Storage:
         param_name: str,
         cardinality: int,
     ) -> list[CategoricalChoiceType] | None: ...
+    def discard_trials(self, trial_ids: list[int]) -> None: ...
+    def may_omit_trials(self) -> bool: ...
 
 # Sampler
 class SamplerContext:

--- a/rustuna_pyo3/rustuna/converter/_storage.py
+++ b/rustuna_pyo3/rustuna/converter/_storage.py
@@ -141,6 +141,12 @@ class ToRustunaStorage:
     def get_cached_trial(self, trial_id: int) -> rustuna.trial.PersistedTrial:
         return self.get_trial(trial_id)
 
+    def discard_trials(self, trial_ids: list[int]) -> None:
+        pass
+
+    def may_omit_trials(self) -> bool:
+        return False
+
     def delete_study(self, study_id: int) -> None:
         self._storage.delete_study(study_id)
 

--- a/rustuna_pyo3/rustuna/exceptions.py
+++ b/rustuna_pyo3/rustuna/exceptions.py
@@ -31,6 +31,12 @@ class StorageInternalError(RustunaError):
     pass
 
 
+class TrialDiscarded(RustunaError):
+    """Exception for accessing a discarded trial."""
+
+    pass
+
+
 class DuplicatedStudyError(RustunaError):
     """Exception for duplicate study names.
 

--- a/rustuna_pyo3/rustuna/storages.py
+++ b/rustuna_pyo3/rustuna/storages.py
@@ -22,16 +22,24 @@ def InMemoryStorage() -> StorageProtocol:
 
 
 # TODO(c-bata): Replace JournalFileStorage with a Python concrete class.
-def JournalFileStorage(file_path: str) -> StorageProtocol:
+def JournalFileStorage(
+    file_path: str,
+    *,
+    load_discarded_trials: bool = False,
+) -> StorageProtocol:
     """Create a Journal storage with its file backend.
 
     Args:
         file_path: Path to the journal log file.
+        load_discarded_trials: If True, ignore discard logs and load all trials.
 
     Returns:
         A Journal storage instance.
     """
-    return Storage.journal_file(file_path)
+    return Storage.journal_file(
+        file_path,
+        load_discarded_trials=load_discarded_trials,
+    )
 
 
 # TODO(c-bata): Replace InMemoryStorage with a Python concrete class.

--- a/rustuna_pyo3/src/exception.rs
+++ b/rustuna_pyo3/src/exception.rs
@@ -4,6 +4,7 @@ use pyo3::prelude::*;
 mod exceptions {
     pyo3::import_exception!(rustuna.exceptions, DuplicatedStudyError);
     pyo3::import_exception!(rustuna.exceptions, TrialPruned);
+    pyo3::import_exception!(rustuna.exceptions, TrialDiscarded);
     pyo3::import_exception!(rustuna.exceptions, UpdateFinishedTrialError);
     pyo3::import_exception!(rustuna.exceptions, StorageInternalError);
 }
@@ -13,6 +14,9 @@ pub fn err_to_exceptions(e: rustuna_core::Error) -> PyErr {
         rustuna_core::ErrorKind::TrialNotFound => PyKeyError::new_err("Trial not found"),
         rustuna_core::ErrorKind::StudyNotFound => PyKeyError::new_err("Study not found"),
         rustuna_core::ErrorKind::AttrNotFound => PyKeyError::new_err("Attribute not found"),
+        rustuna_core::ErrorKind::TrialDiscarded => {
+            exceptions::TrialDiscarded::new_err("Trial discarded")
+        }
         rustuna_core::ErrorKind::TrialAlreadyFinished => {
             exceptions::UpdateFinishedTrialError::new_err("Trial already finished")
         }

--- a/rustuna_pyo3/src/pyobject_storage.rs
+++ b/rustuna_pyo3/src/pyobject_storage.rs
@@ -699,6 +699,24 @@ impl Storage for PyObjectStorage {
         self.sync_trials(study_id)?;
         self.cache.get_joint_search_space(study_id)
     }
+
+    fn discard_trials(&mut self, trial_ids: &[u32]) -> rustuna_core::Result<()> {
+        Python::attach(|py| {
+            self.obj
+                .call_method1(py, "discard_trials", (trial_ids.to_vec(),))
+                .map_err(Self::map_pyerr)?;
+            Ok(())
+        })
+    }
+
+    fn may_omit_trials(&self) -> bool {
+        Python::attach(|py| {
+            self.obj
+                .call_method0(py, "may_omit_trials")
+                .and_then(|ret| ret.extract::<bool>(py))
+                .unwrap_or(false)
+        })
+    }
 }
 
 // TODO(c-bata): Rename PyStorage, PyObjectStorage, and PyPyObjectStorage to more descriptive names.

--- a/rustuna_pyo3/src/storage.rs
+++ b/rustuna_pyo3/src/storage.rs
@@ -11,7 +11,7 @@ use rustuna_core::study::Direction;
 use rustuna_core::trial::TrialStateValues;
 use rustuna_storage::cache::CachedStorage;
 use rustuna_storage::journal::file::{JournalFileBackend, JournalFileSymlinkLock};
-use rustuna_storage::journal::storage::JournalStorage;
+use rustuna_storage::journal::storage::{JournalStorage, JournalStorageOptions};
 use rustuna_storage::sqlite3::SQLite3Storage;
 
 use crate::attrs::{pyobj_to_attrs_with_kind, AttrKind};
@@ -58,16 +58,24 @@ impl PyStorage {
     }
 
     #[classmethod]
-    #[pyo3(name = "journal_file", signature = (file_path,))]
-    fn journal_file(_cls: &Bound<'_, PyType>, file_path: &str) -> PyResult<Self> {
+    #[pyo3(name = "journal_file", signature = (file_path, *, load_discarded_trials = false))]
+    fn journal_file(
+        _cls: &Bound<'_, PyType>,
+        file_path: &str,
+        load_discarded_trials: bool,
+    ) -> PyResult<Self> {
         // TODO(c-bata): Add lock_obj argument to use JournalFileOpenLock.
         let lock_obj = Box::new(JournalFileSymlinkLock::new(file_path));
         let backend = JournalFileBackend::new(file_path, Some(lock_obj)).map_err(|e| {
             PyRuntimeError::new_err(format!("Failed to create journal file: {e:?}"))
         })?;
-        let storage = JournalStorage::new(Box::new(backend)).map_err(|e| {
-            PyRuntimeError::new_err(format!("Failed to create journal storage: {e:?}"))
-        })?;
+        let storage = JournalStorage::new_with_options(
+            Box::new(backend),
+            JournalStorageOptions {
+                load_discarded_trials,
+            },
+        )
+        .map_err(|e| PyRuntimeError::new_err(format!("Failed to create journal storage: {e:?}")))?;
         let arc_storage = Arc::new(RwLock::new(storage));
         Ok(PyStorage {
             storage: arc_storage.clone(),
@@ -401,6 +409,23 @@ impl PyStorage {
             .set_trial_intermediate_values(trial_id, intermediate_values)
             .map_err(err_to_exceptions)?;
         Ok(())
+    }
+
+    fn discard_trials(&mut self, trial_ids: Vec<u32>) -> PyResult<()> {
+        let mut guard = self.storage.write().map_err(|e| {
+            PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
+        })?;
+        guard
+            .discard_trials(&trial_ids)
+            .map_err(err_to_exceptions)?;
+        Ok(())
+    }
+
+    fn may_omit_trials(&self) -> PyResult<bool> {
+        let guard = self.storage.read().map_err(|e| {
+            PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
+        })?;
+        Ok(guard.may_omit_trials())
     }
 }
 

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -834,12 +834,9 @@ pub fn py_copy_study(
             .set_study_attrs(to_study_id, from_attrs, false)
             .map_err(err_to_exceptions)?;
     }
-    for trial in trials {
+    for trial in trials.into_iter().flatten() {
         guard
-            .create_new_trial_from_template(
-                to_study_id,
-                trial.as_ref().expect("copied trial should exist"),
-            )
+            .create_new_trial_from_template(to_study_id, &trial)
             .map_err(err_to_exceptions)?;
     }
     Ok(())

--- a/rustuna_pyo3/tests/storage_tests/test_journal_storage.py
+++ b/rustuna_pyo3/tests/storage_tests/test_journal_storage.py
@@ -62,3 +62,36 @@ def test_create_new_trial_from_template_optuna_compatibility() -> None:
         trials = optuna_storage.get_all_trials(studies[0]._study_id, deepcopy=False)
         assert len(trials) == 1
         assert trials[0].state == optuna.trial.TrialState.WAITING
+
+
+def test_journal_file_storage_can_load_discarded_trials() -> None:
+    with tempfile.TemporaryDirectory() as workdir:
+        file_path = f"{workdir}/discarded.journal"
+        storage = rustuna.storages.JournalFileStorage(file_path)
+        study = rustuna.create_study(storage=storage, study_name="example")
+
+        first = study.ask()
+        second = study.ask()
+        first_persisted = study.tell(first.number, 1.0)
+        second_persisted = study.tell(second.number, 2.0)
+
+        storage.discard_trials([first_persisted._trial_id])
+
+        default_trials = storage.get_trials(study._study_id)
+        assert [trial._trial_id for trial in default_trials] == [
+            second_persisted._trial_id
+        ]
+
+        analysis_storage = rustuna.storages.JournalFileStorage(
+            file_path,
+            load_discarded_trials=True,
+        )
+        analysis_trials = analysis_storage.get_trials(study._study_id)
+        assert [trial._trial_id for trial in analysis_trials] == [
+            first_persisted._trial_id,
+            second_persisted._trial_id,
+        ]
+        assert (
+            analysis_storage.get_trial(first_persisted._trial_id)._trial_id
+            == first_persisted._trial_id
+        )

--- a/rustuna_storage/src/cache.rs
+++ b/rustuna_storage/src/cache.rs
@@ -597,6 +597,14 @@ impl rustuna_core::storage::Storage for CachedStorage {
         cache.update(&trials_vec);
         Ok(cache.get_joint_search_space())
     }
+
+    fn discard_trials(&mut self, _trial_ids: &[u32]) -> Result<()> {
+        Ok(())
+    }
+
+    fn may_omit_trials(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/rustuna_storage/src/journal/mod.rs
+++ b/rustuna_storage/src/journal/mod.rs
@@ -40,6 +40,7 @@ pub enum JournalOperation {
     SetTrialIntermediateValue = 7,
     SetTrialUserAttr = 8,
     SetTrialSystemAttr = 9,
+    DiscardTrials = 10,
 }
 
 impl JournalOperation {
@@ -56,6 +57,7 @@ impl JournalOperation {
             7 => Ok(JournalOperation::SetTrialIntermediateValue),
             8 => Ok(JournalOperation::SetTrialUserAttr),
             9 => Ok(JournalOperation::SetTrialSystemAttr),
+            10 => Ok(JournalOperation::DiscardTrials),
             _ => Err(Error::new(ErrorKind::StorageError)),
         }
     }

--- a/rustuna_storage/src/journal/storage.rs
+++ b/rustuna_storage/src/journal/storage.rs
@@ -18,6 +18,13 @@ use rustuna_core::{Error, ErrorKind, Result};
 
 use super::{JournalBackend, JournalLog, JournalOperation};
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+/// Options for [`JournalStorage`].
+pub struct JournalStorageOptions {
+    /// If `true`, discard logs are ignored during replay and all trials are loaded.
+    pub load_discarded_trials: bool,
+}
+
 /// Storage implementation backed by an append-only journal log.
 ///
 /// Similar in spirit to Optuna's `JournalStorage`, this storage writes every state-changing
@@ -30,10 +37,18 @@ pub struct JournalStorage {
 impl JournalStorage {
     /// Creates a journal storage and synchronizes its in-memory replay state from the backend.
     pub fn new(backend: Box<dyn JournalBackend>) -> Result<Self> {
+        Self::new_with_options(backend, JournalStorageOptions::default())
+    }
+
+    /// Creates a journal storage and synchronizes its in-memory replay state from the backend.
+    pub fn new_with_options(
+        backend: Box<dyn JournalBackend>,
+        options: JournalStorageOptions,
+    ) -> Result<Self> {
         let worker_id_prefix = format!("{}-{}-", unique_prefix(), std::process::id());
         let mut storage = JournalStorage {
             backend,
-            replay: JournalReplayState::new(worker_id_prefix),
+            replay: JournalReplayState::new(worker_id_prefix, options.load_discarded_trials),
         };
         storage.sync_with_backend()?;
         Ok(storage)
@@ -663,6 +678,49 @@ impl Storage for JournalStorage {
         cache.update(&visible_trials);
         Ok(cache.get_joint_search_space())
     }
+
+    fn discard_trials(&mut self, trial_ids: &[u32]) -> Result<()> {
+        self.sync_with_backend()?;
+        let mut unique_trial_ids = Vec::new();
+        for trial_id in trial_ids {
+            if unique_trial_ids.contains(trial_id) {
+                continue;
+            }
+            let (study_id, trial_number) = self
+                .replay
+                .trial_id_to_study_number
+                .get(trial_id)
+                .copied()
+                .ok_or_else(|| Error::new(ErrorKind::TrialNotFound))?;
+            let trials = self
+                .replay
+                .trials_by_study
+                .get(&study_id)
+                .ok_or_else(|| Error::new(ErrorKind::StudyNotFound))?;
+            let slot = trials
+                .get(trial_number as usize)
+                .ok_or_else(|| Error::new(ErrorKind::TrialNotFound))?;
+            if slot.is_none() {
+                continue;
+            }
+            unique_trial_ids.push(*trial_id);
+        }
+        let fields = HashMap::from([(
+            "trial_ids".to_string(),
+            serde_json::value::to_raw_value(&unique_trial_ids).map_err(|_| {
+                Error::with_reason(ErrorKind::StorageError, "Failed to serialize trial IDs")
+            })?,
+        )]);
+        self.write_log(JournalOperation::DiscardTrials, fields)?;
+        self.sync_with_backend()
+    }
+
+    fn may_omit_trials(&self) -> bool {
+        self.replay
+            .trials_by_study
+            .values()
+            .any(|trials| trials.iter().any(Option::is_none))
+    }
 }
 
 struct JournalReplayState {
@@ -678,10 +736,11 @@ struct JournalReplayState {
     last_created_trial_id_by_this_process: Option<u32>,
     studies_sorted: Vec<PersistedStudy>,
     study_caches: HashMap<u32, StudyCache>,
+    load_discarded_trials: bool,
 }
 
 impl JournalReplayState {
-    fn new(worker_id_prefix: String) -> Self {
+    fn new(worker_id_prefix: String, load_discarded_trials: bool) -> Self {
         JournalReplayState {
             log_number_read: 0,
             worker_id_prefix,
@@ -695,6 +754,7 @@ impl JournalReplayState {
             last_created_trial_id_by_this_process: None,
             studies_sorted: Vec::new(),
             study_caches: HashMap::new(),
+            load_discarded_trials,
         }
     }
 
@@ -724,6 +784,11 @@ impl JournalReplayState {
                 }
                 JournalOperation::SetTrialSystemAttr => {
                     self.apply_set_trial_system_attr(log, worker_id)?
+                }
+                JournalOperation::DiscardTrials => {
+                    if !self.load_discarded_trials {
+                        self.apply_discard_trials(log, worker_id)?
+                    }
                 }
             };
         }
@@ -1289,6 +1354,77 @@ impl JournalReplayState {
             }
             let v = raw_value_to_attr_string(&value)?;
             trial.attrs.insert(AttrKey::System(key.clone().into()), v);
+        }
+        Ok(())
+    }
+
+    fn apply_discard_trials(&mut self, log: &JournalLog, _worker_id: &str) -> Result<()> {
+        let raw = log.fields.get("trial_ids").ok_or_else(|| {
+            Error::with_reason(
+                ErrorKind::StorageError,
+                "Missing trial_ids in discard trials log",
+            )
+        })?;
+        let trial_ids: Vec<u32> = serde_json::from_str(raw.get()).map_err(|_| {
+            Error::with_reason(
+                ErrorKind::StorageError,
+                "Failed to deserialize trial_ids in discard trials log",
+            )
+        })?;
+        let mut targets = Vec::new();
+        for trial_id in trial_ids {
+            if targets
+                .iter()
+                .any(|(_, _, existing_trial_id)| existing_trial_id == &trial_id)
+            {
+                continue;
+            }
+            let (study_id, trial_number) = self
+                .trial_id_to_study_number
+                .get(&trial_id)
+                .copied()
+                .ok_or_else(|| {
+                    Error::with_reason(
+                        ErrorKind::TrialNotFound,
+                        format!("Trial not found during discard: trial_id={trial_id}"),
+                    )
+                })?;
+            let trials = self.trials_by_study.get(&study_id).ok_or_else(|| {
+                Error::with_reason(
+                    ErrorKind::StudyNotFound,
+                    format!("Study not found during discard: study_id={study_id}"),
+                )
+            })?;
+            let slot = trials.get(trial_number as usize).ok_or_else(|| {
+                Error::with_reason(
+                    ErrorKind::TrialNotFound,
+                    format!(
+                        "Trial not found at position during discard: trial_number={trial_number}"
+                    ),
+                )
+            })?;
+            if slot.is_none() {
+                continue;
+            }
+            targets.push((study_id, trial_number, trial_id));
+        }
+        for (study_id, trial_number, _) in targets {
+            let trials = self.trials_by_study.get_mut(&study_id).ok_or_else(|| {
+                Error::with_reason(
+                    ErrorKind::StudyNotFound,
+                    format!("Study not found during discard: study_id={study_id}"),
+                )
+            })?;
+            let slot = trials.get_mut(trial_number as usize).ok_or_else(|| {
+                Error::with_reason(
+                    ErrorKind::TrialNotFound,
+                    format!(
+                        "Trial not found at position during discard: trial_number={trial_number}"
+                    ),
+                )
+            })?;
+            *slot = None;
+            self.study_caches.remove(&study_id);
         }
         Ok(())
     }
@@ -2030,6 +2166,39 @@ mod tests {
     }
 
     #[test]
+    fn duplicate_discard_trials_logs_do_not_poison_replay() -> Result<()> {
+        let (mut storage, logs) = new_storage()?;
+        let study_id = storage
+            .create_new_study("study", vec![Direction::Minimize])?
+            .id;
+        let trial_id = storage.create_new_trial(study_id)?.id;
+
+        storage.discard_trials(&[trial_id])?;
+        {
+            let mut guard = logs.lock().map_err(|_| {
+                Error::with_reason(
+                    ErrorKind::StorageError,
+                    "Failed to acquire lock on journal logs",
+                )
+            })?;
+            let discard_log = guard
+                .iter()
+                .find(|log| log.op_code == JournalOperation::DiscardTrials as i32)
+                .cloned()
+                .ok_or_else(|| {
+                    Error::with_reason(ErrorKind::StorageError, "Discard log not found")
+                })?;
+            guard.push(discard_log);
+        }
+
+        let backend = InMemoryJournalBackend { logs: logs.clone() };
+        let mut reloaded = JournalStorage::new(Box::new(backend))?;
+        let trials = reloaded.get_trials(study_id)?;
+        assert!(trials[0].is_none());
+        Ok(())
+    }
+
+    #[test]
     fn create_new_study_updates_cache() -> Result<()> {
         let (mut storage, _logs) = new_storage()?;
         let study = storage.create_new_study("example", vec![Direction::Minimize])?;
@@ -2127,6 +2296,27 @@ mod tests {
         let mut storage2 = JournalStorage::new(Box::new(backend))?;
         let trials = storage2.get_trials(study_id)?;
         assert_eq!(trials.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn load_discarded_trials_ignores_discard_logs() -> Result<()> {
+        let (mut storage, logs) = new_storage()?;
+        let study_id = storage.create_new_study("s", vec![Direction::Minimize])?.id;
+        let trial_id = storage.create_new_trial(study_id)?.id;
+        storage.discard_trials(&[trial_id])?;
+
+        let backend = InMemoryJournalBackend { logs: logs.clone() };
+        let mut storage2 = JournalStorage::new_with_options(
+            Box::new(backend),
+            JournalStorageOptions {
+                load_discarded_trials: true,
+            },
+        )?;
+        let trials = storage2.get_trials(study_id)?;
+        assert_eq!(trials.len(), 1);
+        assert_eq!(trials[0].as_ref().unwrap().id, trial_id);
+        assert_eq!(storage2.get_trial(trial_id)?.id, trial_id);
         Ok(())
     }
 


### PR DESCRIPTION
## Motivation

As studies grow, keeping all trial data in memory increases memory usage and can slow down storage access. Samplers need a way to discard trials that are no longer needed.

## Description of the changes

This change adds `discard_trials()` and `may_omit_trials()` to the storage API. It allows Samplers to discard trials that are no longer needed during optimization.