### PR TITLE
Change the return type of `storage.get_trials`

### DIFF
--- a/rustuna_core/src/error.rs
+++ b/rustuna_core/src/error.rs
@@ -56,6 +56,7 @@ pub enum ErrorKind {
     DuplicatedStudy,
     StudyNotFound,
     TrialNotFound,
+    TrialDiscarded,
     AttrNotFound,
     TrialQueueEmpty,
     AttrOverwriteNotAllowed,

--- a/rustuna_core/src/storage.rs
+++ b/rustuna_core/src/storage.rs
@@ -81,7 +81,7 @@ pub trait Storage: Send + Sync {
     /// Returns all trials that belong to a study.
     ///
     /// Trials are expected to be ordered by their trial number.
-    fn get_trials(&mut self, study_id: u32) -> Result<&Vec<PersistedTrial>>;
+    fn get_trials(&mut self, study_id: u32) -> Result<&Vec<Option<PersistedTrial>>>;
     /// Returns a trial by ID.
     fn get_trial(&mut self, trial_id: u32) -> Result<&PersistedTrial>;
     // Design Note:
@@ -157,7 +157,7 @@ pub trait Storage: Send + Sync {
 #[derive(Default)]
 pub struct InMemoryStorage {
     studies: Vec<PersistedStudy>,
-    trials: HashMap<u32, Vec<PersistedTrial>>,
+    trials: HashMap<u32, Vec<Option<PersistedTrial>>>,
     trial_id_to_study_number: HashMap<u32, (u32, u32)>,
     study_caches: HashMap<u32, StudyCache>,
     next_study_id: u32,
@@ -217,9 +217,7 @@ impl InMemoryStorage {
             return Err(Error::new(ErrorKind::StorageError));
         }
         if number < trials_len {
-            let trial = trials
-                .get(number as usize)
-                .ok_or(Error::new(ErrorKind::TrialNotFound))?;
+            let trial = discarded_if_none(trials.get(number as usize).and_then(Option::as_ref))?;
             if trial.id != trial_id {
                 return Err(Error::new(ErrorKind::StorageError));
             }
@@ -229,28 +227,28 @@ impl InMemoryStorage {
             return Err(Error::new(ErrorKind::StorageError));
         }
         let trial = PersistedTrial::new(trial_id, study_id, number);
-        trials.push(trial);
+        trials.push(Some(trial));
         self.trial_id_to_study_number
             .insert(trial_id, (study_id, number));
         if trial_id >= self.next_trial_id {
             self.next_trial_id = trial_id + 1;
         }
-        Ok(&trials[number as usize])
+        discarded_if_none(trials[number as usize].as_ref())
     }
 }
 fn get_trials_by_study_id(
-    all_trials: &HashMap<u32, Vec<PersistedTrial>>,
+    all_trials: &HashMap<u32, Vec<Option<PersistedTrial>>>,
     study_id: u32,
-) -> Result<&Vec<PersistedTrial>> {
+) -> Result<&Vec<Option<PersistedTrial>>> {
     let trials = all_trials
         .get(&study_id)
         .ok_or(Error::new(ErrorKind::StudyNotFound))?;
     Ok(trials)
 }
 fn get_mut_trials_by_study_id(
-    all_trials: &mut HashMap<u32, Vec<PersistedTrial>>,
+    all_trials: &mut HashMap<u32, Vec<Option<PersistedTrial>>>,
     study_id: u32,
-) -> Result<&mut Vec<PersistedTrial>> {
+) -> Result<&mut Vec<Option<PersistedTrial>>> {
     let trials = all_trials
         .get_mut(&study_id)
         .ok_or(Error::new(ErrorKind::StudyNotFound))?;
@@ -264,6 +262,10 @@ fn get_study_id_trial_number_by_trial_id(
         .get(&trial_id)
         .copied()
         .ok_or(Error::new(ErrorKind::TrialNotFound))
+}
+
+fn discarded_if_none<T>(value: Option<T>) -> Result<T> {
+    value.ok_or(Error::new(ErrorKind::TrialDiscarded))
 }
 impl Storage for InMemoryStorage {
     fn create_new_study(
@@ -295,7 +297,7 @@ impl Storage for InMemoryStorage {
 
         self.studies.retain(|s| s.id != study_id);
         if let Some(trials) = self.trials.remove(&study_id) {
-            for trial in trials {
+            for trial in trials.into_iter().flatten() {
                 self.trial_id_to_study_number.remove(&trial.id);
             }
         }
@@ -310,10 +312,10 @@ impl Storage for InMemoryStorage {
         self.next_trial_id += 1;
         let number = trials.len() as u32;
         let trial = PersistedTrial::new(trial_id, study_id, number);
-        trials.push(trial);
+        trials.push(Some(trial));
         self.trial_id_to_study_number
             .insert(trial_id, (study_id, number));
-        Ok(&trials[number as usize])
+        discarded_if_none(trials[number as usize].as_ref())
     }
 
     fn create_new_trial_from_template(
@@ -330,10 +332,10 @@ impl Storage for InMemoryStorage {
         trial.id = trial_id;
         trial.study_id = study_id;
         trial.number = number;
-        trials.push(trial);
+        trials.push(Some(trial));
         self.trial_id_to_study_number
             .insert(trial_id, (study_id, number));
-        Ok(&trials[number as usize])
+        discarded_if_none(trials[number as usize].as_ref())
     }
 
     fn set_trial_param(
@@ -345,9 +347,11 @@ impl Storage for InMemoryStorage {
     ) -> Result<()> {
         let (study_id, trial_number) =
             get_study_id_trial_number_by_trial_id(&self.trial_id_to_study_number, trial_id)?;
-        let trial = get_mut_trials_by_study_id(&mut self.trials, study_id)?
-            .get_mut(trial_number as usize)
-            .ok_or(Error::new(ErrorKind::TrialNotFound))?;
+        let trial = discarded_if_none(
+            get_mut_trials_by_study_id(&mut self.trials, study_id)?
+                .get_mut(trial_number as usize)
+                .and_then(Option::as_mut),
+        )?;
         check_trial_is_updatable(trial)?;
 
         // Check param distribution compatibility with previous trial(s).
@@ -375,9 +379,11 @@ impl Storage for InMemoryStorage {
     ) -> Result<()> {
         let (study_id, trial_number) =
             get_study_id_trial_number_by_trial_id(&self.trial_id_to_study_number, trial_id)?;
-        let trial = get_mut_trials_by_study_id(&mut self.trials, study_id)?
-            .get_mut(trial_number as usize)
-            .ok_or(Error::new(ErrorKind::TrialNotFound))?;
+        let trial = discarded_if_none(
+            get_mut_trials_by_study_id(&mut self.trials, study_id)?
+                .get_mut(trial_number as usize)
+                .and_then(Option::as_mut),
+        )?;
         check_trial_is_updatable(trial)?;
         trial.state_values = state_values;
         Ok(())
@@ -390,9 +396,11 @@ impl Storage for InMemoryStorage {
     ) -> Result<()> {
         let (study_id, trial_number) =
             get_study_id_trial_number_by_trial_id(&self.trial_id_to_study_number, trial_id)?;
-        let trial = get_mut_trials_by_study_id(&mut self.trials, study_id)?
-            .get_mut(trial_number as usize)
-            .ok_or(Error::new(ErrorKind::TrialNotFound))?;
+        let trial = discarded_if_none(
+            get_mut_trials_by_study_id(&mut self.trials, study_id)?
+                .get_mut(trial_number as usize)
+                .and_then(Option::as_mut),
+        )?;
         check_trial_is_updatable(trial)?;
         trial.intermediate_values.extend(intermediate_values);
         Ok(())
@@ -420,7 +428,7 @@ impl Storage for InMemoryStorage {
             .ok_or(Error::new(ErrorKind::AttrNotFound))
     }
 
-    fn get_trials(&mut self, study_id: u32) -> Result<&Vec<PersistedTrial>> {
+    fn get_trials(&mut self, study_id: u32) -> Result<&Vec<Option<PersistedTrial>>> {
         get_trials_by_study_id(&self.trials, study_id)
     }
 
@@ -431,9 +439,11 @@ impl Storage for InMemoryStorage {
     fn get_cached_trial(&self, trial_id: u32) -> Result<&PersistedTrial> {
         let (study_id, trial_number) =
             get_study_id_trial_number_by_trial_id(&self.trial_id_to_study_number, trial_id)?;
-        let trial = get_trials_by_study_id(&self.trials, study_id)?
-            .get(trial_number as usize)
-            .ok_or(Error::new(ErrorKind::TrialNotFound))?;
+        let trial = discarded_if_none(
+            get_trials_by_study_id(&self.trials, study_id)?
+                .get(trial_number as usize)
+                .and_then(Option::as_ref),
+        )?;
         Ok(trial)
     }
 
@@ -497,9 +507,11 @@ impl Storage for InMemoryStorage {
     ) -> Result<()> {
         let (study_id, trial_number) =
             get_study_id_trial_number_by_trial_id(&self.trial_id_to_study_number, trial_id)?;
-        let trial = get_mut_trials_by_study_id(&mut self.trials, study_id)?
-            .get_mut(trial_number as usize)
-            .ok_or(Error::new(ErrorKind::TrialNotFound))?;
+        let trial = discarded_if_none(
+            get_mut_trials_by_study_id(&mut self.trials, study_id)?
+                .get_mut(trial_number as usize)
+                .and_then(Option::as_mut),
+        )?;
         check_trial_is_updatable(trial)?;
         for (key, value) in attrs {
             if error_on_overwrite && trial.attrs.contains_key(&key) {
@@ -513,7 +525,8 @@ impl Storage for InMemoryStorage {
     fn get_joint_search_space(&mut self, study_id: u32) -> Result<HashMap<String, Distribution>> {
         let study_cache = self.study_caches.entry(study_id).or_default();
         let trials = get_trials_by_study_id(&self.trials, study_id)?;
-        study_cache.update(trials);
+        let visible_trials = trials.iter().flatten().cloned().collect::<Vec<_>>();
+        study_cache.update(&visible_trials);
         Ok(study_cache.get_joint_search_space())
     }
 }

--- a/rustuna_core/src/study.rs
+++ b/rustuna_core/src/study.rs
@@ -353,7 +353,7 @@ impl Study {
             )
         })?;
         let trials = guard.get_trials(self.id)?;
-        Ok(trials.clone())
+        Ok(trials.iter().flatten().cloned().collect())
     }
 
     /// Returns a user attribute stored on the study.
@@ -513,6 +513,7 @@ pub fn get_best_trial(study: &Study) -> Result<u32> {
 
     let best_trial = trials
         .iter()
+        .flatten()
         .filter(|trial| matches!(trial.state_values, TrialStateValues::Complete(_)))
         .min_by(|a, b| {
             let a_value = match a.state_values {
@@ -549,6 +550,7 @@ pub fn get_pareto_front(study: &Study) -> Result<Vec<u32>> {
     let trials = guard
         .get_trials(study.id)?
         .iter()
+        .flatten()
         .filter(|t| matches!(t.state_values, TrialStateValues::Complete(ref _v)))
         .collect::<Vec<_>>();
 

--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -155,6 +155,7 @@ pub(crate) fn get_filtered_trials(
     let completed_trials = guard
         .get_trials(study.id)?
         .iter()
+        .flatten()
         .filter(|t| matches!(t.state_values, TrialStateValues::Complete(_)))
         .filter(|t| target(t).is_finite())
         .cloned()

--- a/rustuna_importance/src/fanova.rs
+++ b/rustuna_importance/src/fanova.rs
@@ -16,9 +16,10 @@ pub fn get_param_importance(study: &Study) -> Result<Vec<Vec<f64>>> {
     // TODO(c-bata): Avoid to clone trials.
     let completed_trials: Vec<PersistedTrial> = guard
         .get_trials(study.id)?
-        .clone()
-        .into_iter()
+        .iter()
+        .flatten()
         .filter(|t| matches!(t.state_values, TrialStateValues::Complete(_)))
+        .cloned()
         .collect();
     drop(guard);
     if completed_trials.is_empty() {

--- a/rustuna_js/src/study.rs
+++ b/rustuna_js/src/study.rs
@@ -51,7 +51,12 @@ impl JsStudy {
                 .clone();
             (trials, study_attrs)
         };
-        let trial = JsPersistedTrial::new(trials[number as usize].clone(), study_attrs);
+        let trial = JsPersistedTrial::new(
+            trials[number as usize]
+                .clone()
+                .ok_or_else(|| JsError::new("Trial is missing"))?,
+            study_attrs,
+        );
         Ok(trial)
     }
 }

--- a/rustuna_pyo3/src/pyobject_storage.rs
+++ b/rustuna_pyo3/src/pyobject_storage.rs
@@ -568,7 +568,7 @@ impl Storage for PyObjectStorage {
     fn get_trials(
         &mut self,
         study_id: u32,
-    ) -> rustuna_core::Result<&Vec<rustuna_core::trial::PersistedTrial>> {
+    ) -> rustuna_core::Result<&Vec<Option<rustuna_core::trial::PersistedTrial>>> {
         // Ensure study mapping exists before sync_trials, which requires cache_study_to_src_study.
         self.sync_study_from_id(study_id, false)?;
         self.sync_trials(study_id)?;

--- a/rustuna_pyo3/src/storage.rs
+++ b/rustuna_pyo3/src/storage.rs
@@ -261,8 +261,9 @@ impl PyStorage {
         let trials = guard.get_trials(study_id).map_err(err_to_exceptions)?;
         let py_trials: Vec<PyPersistedTrial> = trials
             .iter()
+            .flatten()
             .filter(|trial| match &states {
-                Some(states) => states.contains(&PyTrialState::from(trial.state_values.clone())),
+                Some(s) => s.contains(&PyTrialState::from(trial.state_values.clone())),
                 None => true,
             })
             .map(|t| PyPersistedTrial::from_storage(self.storage.clone(), t))

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -595,6 +595,7 @@ impl PyStudy {
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to get trials: {:?}", e.kind)))?;
         let trials: Vec<PyPersistedTrial> = trials_vec
             .iter()
+            .flatten()
             .map(|t| PyPersistedTrial::from_storage(self.study.storage.clone(), t))
             .collect();
         Ok(trials)
@@ -616,11 +617,13 @@ impl PyStudy {
         let trials: Vec<PyPersistedTrial> = match states {
             Some(states) => trials_vec
                 .iter()
+                .flatten()
                 .filter(|trial| states.contains(&PyTrialState::from(trial.state_values.clone())))
                 .map(|trial| PyPersistedTrial::from_storage(self.study.storage.clone(), trial))
                 .collect(),
             None => trials_vec
                 .iter()
+                .flatten()
                 .map(|trial| PyPersistedTrial::from_storage(self.study.storage.clone(), trial))
                 .collect(),
         };
@@ -696,7 +699,12 @@ impl PyStudy {
         let best_trials = pareto_front_numbers
             .iter()
             .map(|n| {
-                PyPersistedTrial::from_storage(self.study.storage.clone(), &trials_vec[*n as usize])
+                PyPersistedTrial::from_storage(
+                    self.study.storage.clone(),
+                    trials_vec[*n as usize]
+                        .as_ref()
+                        .expect("pareto front trial should exist"),
+                )
             })
             .collect();
         Ok(best_trials)
@@ -828,7 +836,10 @@ pub fn py_copy_study(
     }
     for trial in trials {
         guard
-            .create_new_trial_from_template(to_study_id, &trial)
+            .create_new_trial_from_template(
+                to_study_id,
+                trial.as_ref().expect("copied trial should exist"),
+            )
             .map_err(err_to_exceptions)?;
     }
     Ok(())

--- a/rustuna_sampler/src/nsgaii.rs
+++ b/rustuna_sampler/src/nsgaii.rs
@@ -131,7 +131,7 @@ impl NSGAIISampler {
     fn get_parent_population_numbers(
         &mut self,
         ctx: &Context,
-        trials: &Vec<PersistedTrial>,
+        trials: &[PersistedTrial],
     ) -> Result<(i32, Vec<u32>)> {
         let mut generation_to_population_numbers =
             HashMap::<usize, Vec<u32>>::with_capacity(trials.len());
@@ -182,9 +182,10 @@ impl NSGAIISampler {
         let mut guard = storage
             .write()
             .map_err(|_e| Error::new(ErrorKind::Unexpected))?;
-        let trials = guard.get_trials(ctx.study_id)?;
+        let trials = guard.get_trials(ctx.study_id)?.clone();
         let population_params = trials
             .iter()
+            .flatten()
             .filter(|trial| population_numbers.contains(&trial.number))
             .map(|trial| {
                 let mut params = HashMap::new();
@@ -307,9 +308,14 @@ impl Sampler for NSGAIISampler {
         let mut guard = storage
             .write()
             .map_err(|_e| Error::new(ErrorKind::Unexpected))?;
-        let trials = guard.get_trials(ctx.study_id)?;
+        let trials = guard
+            .get_trials(ctx.study_id)?
+            .iter()
+            .flatten()
+            .cloned()
+            .collect::<Vec<_>>();
         let (parent_generation, parent_population_numbers) =
-            self.get_parent_population_numbers(ctx, trials)?;
+            self.get_parent_population_numbers(ctx, &trials)?;
         let child_generation = u32::try_from(parent_generation + 1).unwrap();
         let mut attrs = Attrs::with_capacity(1);
         attrs.insert(

--- a/rustuna_sampler/src/tpe/sampler.rs
+++ b/rustuna_sampler/src/tpe/sampler.rs
@@ -462,10 +462,11 @@ impl TpeSampler {
     /// finite-count-below-startup case the resulting empty / short list naturally
     /// falls through to the random sampler via the existing startup gate.
     fn usable_complete_trials(
-        trials: &[rustuna_core::trial::PersistedTrial],
+        trials: &[Option<rustuna_core::trial::PersistedTrial>],
     ) -> Vec<&rustuna_core::trial::PersistedTrial> {
         trials
             .iter()
+            .flatten()
             .filter(|t| match &t.state_values {
                 TrialStateValues::Complete(v) => !v.iter().any(|x| x.is_nan()),
                 _ => false,

--- a/rustuna_storage/src/cache.rs
+++ b/rustuna_storage/src/cache.rs
@@ -83,12 +83,11 @@ pub trait CachedStorageBackend: Send + Sync {
 /// references to callers.
 pub struct CachedStorage {
     studies: Vec<PersistedStudy>,
-    trials: HashMap<u32, HashMap<u32, PersistedTrial>>,
+    trials: HashMap<u32, Vec<Option<PersistedTrial>>>,
     trial_id_to_study_number: HashMap<u32, (u32, u32)>,
     study_caches: HashMap<u32, StudyCache>,
     unfinished_trials: HashMap<u32, Vec<u32>>,
     last_finished_trial_number: HashMap<u32, i32>,
-    trials_sorted_buffer: Vec<PersistedTrial>,
     // Cache for category labels: (study_id, param_name) -> labels
     // Since category labels cannot be overwritten once set, this cache never needs invalidation.
     category_labels_cache: HashMap<(u32, String), Vec<CategoryLabel>>,
@@ -106,7 +105,6 @@ impl CachedStorage {
             study_caches: HashMap::new(),
             unfinished_trials: HashMap::new(),
             last_finished_trial_number: HashMap::new(),
-            trials_sorted_buffer: Vec::new(),
             category_labels_cache: HashMap::new(),
             backend,
         }
@@ -135,17 +133,20 @@ impl CachedStorage {
         for trial in loaded {
             self.trial_id_to_study_number
                 .insert(trial.id, (study_id, trial.number));
-            trials.insert(trial.number, trial);
+            let trial_number = trial.number as usize;
+            if trials.len() <= trial_number {
+                trials.resize(trial_number + 1, None);
+            }
+            trials[trial_number] = Some(trial);
         }
 
         let study_cache = self.study_caches.entry(study_id).or_default();
-        let mut trials_vec: Vec<_> = trials.values().cloned().collect();
-        trials_vec.sort_by_key(|t| t.number);
+        let trials_vec: Vec<_> = trials.iter().flatten().cloned().collect();
         study_cache.update(&trials_vec);
 
         let mut unfinished_next = vec![];
         let mut last_finished_next = last_finished;
-        for trial in trials.values() {
+        for trial in trials.iter().flatten() {
             if trial.is_finished() {
                 last_finished_next = last_finished_next.max(trial.number as i32);
             } else {
@@ -166,10 +167,12 @@ impl CachedStorage {
         let trial = self.backend.get_trial(trial_id)?;
         let study_id = trial.study_id;
         let trial_number = trial.number;
-        self.trials
-            .entry(study_id)
-            .or_default()
-            .insert(trial_number, trial);
+        let trials = self.trials.entry(study_id).or_default();
+        let trial_index = trial_number as usize;
+        if trials.len() <= trial_index {
+            trials.resize(trial_index + 1, None);
+        }
+        trials[trial_index] = Some(trial);
         self.trial_id_to_study_number
             .insert(trial_id, (study_id, trial_number));
         Ok((study_id, trial_number))
@@ -178,7 +181,8 @@ impl CachedStorage {
     fn is_trial_finished_in_cache(&self, study_id: u32, trial_number: u32) -> bool {
         self.trials
             .get(&study_id)
-            .and_then(|trials| trials.get(&trial_number))
+            .and_then(|trials| trials.get(trial_number as usize))
+            .and_then(|trial| trial.as_ref())
             .is_some_and(|trial| trial.is_finished())
     }
 }
@@ -192,7 +196,7 @@ impl rustuna_core::storage::Storage for CachedStorage {
         let study = self.backend.create_new_study(study_name, directions)?;
         let study_id = study.id;
         self.studies.push(study);
-        self.trials.insert(study_id, HashMap::new());
+        self.trials.insert(study_id, Vec::new());
         self.study_caches.insert(study_id, StudyCache::new());
         self.unfinished_trials.insert(study_id, vec![]);
         self.last_finished_trial_number.insert(study_id, -1);
@@ -206,7 +210,7 @@ impl rustuna_core::storage::Storage for CachedStorage {
 
         self.studies.retain(|s| s.id != study_id);
         if let Some(trials) = self.trials.remove(&study_id) {
-            for trial in trials.values() {
+            for trial in trials.into_iter().flatten() {
                 self.trial_id_to_study_number.remove(&trial.id);
             }
         }
@@ -219,18 +223,22 @@ impl rustuna_core::storage::Storage for CachedStorage {
 
     fn create_new_trial(&mut self, study_id: u32) -> Result<&PersistedTrial> {
         let trial = self.backend.create_new_trial(study_id)?;
-        let trials = self.trials.entry(study_id).or_default();
         let number = trial.number;
         self.trial_id_to_study_number
             .insert(trial.id, (study_id, number));
-        trials.insert(number, trial);
+        let trials = self.trials.entry(study_id).or_default();
+        let trial_index = number as usize;
+        if trials.len() <= trial_index {
+            trials.resize(trial_index + 1, None);
+        }
+        trials[trial_index] = Some(trial);
         let trial_ref = trials
-            .get(&number)
+            .get(trial_index)
+            .and_then(|trial| trial.as_ref())
             .ok_or_else(|| Error::new(ErrorKind::TrialNotFound))?;
 
         let study_cache = self.study_caches.entry(study_id).or_default();
-        let mut trials_vec: Vec<_> = trials.values().cloned().collect();
-        trials_vec.sort_by_key(|t| t.number);
+        let trials_vec: Vec<_> = trials.iter().flatten().cloned().collect();
         study_cache.update(&trials_vec);
         self.unfinished_trials
             .entry(study_id)
@@ -247,20 +255,22 @@ impl rustuna_core::storage::Storage for CachedStorage {
         let trial = self
             .backend
             .create_new_trial_from_template(study_id, template)?;
-        let trials = self.trials.entry(study_id).or_default();
         let number = trial.number;
         self.trial_id_to_study_number
             .insert(trial.id, (study_id, number));
-        trials.insert(number, trial);
+        let trials = self.trials.entry(study_id).or_default();
+        let trial_index = number as usize;
+        if trials.len() <= trial_index {
+            trials.resize(trial_index + 1, None);
+        }
+        trials[trial_index] = Some(trial);
         let trial_ref = trials
-            .get(&number)
+            .get(trial_index)
+            .and_then(|trial| trial.as_ref())
             .ok_or_else(|| Error::new(ErrorKind::TrialNotFound))?;
 
         let study_cache = self.study_caches.entry(study_id).or_default();
-        // TODO(c-bata): Avoid cloning trials before study_cache.trial_number_cursor,
-        // since study_cache.update only processes trials from that index onward.
-        let mut trials_vec: Vec<_> = trials.values().cloned().collect();
-        trials_vec.sort_by_key(|t| t.number);
+        let trials_vec: Vec<_> = trials.iter().flatten().cloned().collect();
         study_cache.update(&trials_vec);
         if !trial_ref.is_finished() {
             self.unfinished_trials
@@ -292,7 +302,10 @@ impl rustuna_core::storage::Storage for CachedStorage {
         }
         self.refresh_trials(study_id)?;
         if let Some(trials) = self.trials.get(&study_id) {
-            if let Some(trial) = trials.get(&trial_number) {
+            if let Some(trial) = trials
+                .get(trial_number as usize)
+                .and_then(|trial| trial.as_ref())
+            {
                 if trial.is_finished() {
                     return Err(Error::new(ErrorKind::TrialAlreadyFinished));
                 }
@@ -322,15 +335,15 @@ impl rustuna_core::storage::Storage for CachedStorage {
             .get_mut(&study_id)
             .ok_or_else(|| Error::new(ErrorKind::StudyNotFound))?;
         let trial = trials
-            .get_mut(&trial_number)
-            .ok_or_else(|| Error::new(ErrorKind::TrialNotFound))?;
+            .get_mut(trial_number as usize)
+            .and_then(|trial| trial.as_mut())
+            .ok_or_else(|| Error::new(ErrorKind::TrialDiscarded))?;
         trial
             .distributions
             .insert(name.to_string(), distribution.clone());
         trial.internal_params.insert(name.to_string(), value);
 
-        let mut trials_vec: Vec<_> = trials.values().cloned().collect();
-        trials_vec.sort_by_key(|t| t.number);
+        let trials_vec: Vec<_> = trials.iter().flatten().cloned().collect();
         let study_cache = self.study_caches.entry(study_id).or_default();
         study_cache
             .param_distribution
@@ -359,12 +372,12 @@ impl rustuna_core::storage::Storage for CachedStorage {
             .get_mut(&study_id)
             .ok_or_else(|| Error::new(ErrorKind::StudyNotFound))?;
         let trial = trials
-            .get_mut(&trial_number)
-            .ok_or_else(|| Error::new(ErrorKind::TrialNotFound))?;
+            .get_mut(trial_number as usize)
+            .and_then(|trial| trial.as_mut())
+            .ok_or_else(|| Error::new(ErrorKind::TrialDiscarded))?;
         trial.state_values = state_values;
 
-        let mut trials_vec: Vec<_> = trials.values().cloned().collect();
-        trials_vec.sort_by_key(|t| t.number);
+        let trials_vec: Vec<_> = trials.iter().flatten().cloned().collect();
         self.study_caches
             .entry(study_id)
             .or_default()
@@ -395,8 +408,9 @@ impl rustuna_core::storage::Storage for CachedStorage {
             .get_mut(&study_id)
             .ok_or_else(|| Error::new(ErrorKind::StudyNotFound))?;
         let trial = trials
-            .get_mut(&trial_number)
-            .ok_or_else(|| Error::new(ErrorKind::TrialNotFound))?;
+            .get_mut(trial_number as usize)
+            .and_then(|trial| trial.as_mut())
+            .ok_or_else(|| Error::new(ErrorKind::TrialDiscarded))?;
         trial.intermediate_values.extend(intermediate_values);
         Ok(())
     }
@@ -420,21 +434,18 @@ impl rustuna_core::storage::Storage for CachedStorage {
             .ok_or_else(|| Error::new(ErrorKind::StudyNotFound))
     }
 
-    fn get_trials(&mut self, study_id: u32) -> Result<&Vec<PersistedTrial>> {
+    fn get_trials(&mut self, study_id: u32) -> Result<&Vec<Option<PersistedTrial>>> {
         self.refresh_trials(study_id)?;
-        let trials_map = self
+        let trials = self
             .trials
             .get(&study_id)
             .ok_or_else(|| Error::new(ErrorKind::StudyNotFound))?;
-        let mut trials_vec: Vec<_> = trials_map.values().cloned().collect();
-        trials_vec.sort_by_key(|t| t.number);
-        self.trials_sorted_buffer.clear();
-        self.trials_sorted_buffer.extend(trials_vec);
+        let trials_vec: Vec<_> = trials.iter().flatten().cloned().collect();
         self.study_caches
             .entry(study_id)
             .or_default()
-            .update(&self.trials_sorted_buffer);
-        Ok(&self.trials_sorted_buffer)
+            .update(&trials_vec);
+        Ok(trials)
     }
 
     fn get_trial(&mut self, trial_id: u32) -> Result<&PersistedTrial> {
@@ -460,8 +471,9 @@ impl rustuna_core::storage::Storage for CachedStorage {
             .get(&study_id)
             .ok_or_else(|| Error::new(ErrorKind::StudyNotFound))?;
         let trial = trials
-            .get(&trial_number)
-            .ok_or_else(|| Error::new(ErrorKind::TrialNotFound))?;
+            .get(trial_number as usize)
+            .and_then(|trial| trial.as_ref())
+            .ok_or_else(|| Error::new(ErrorKind::TrialDiscarded))?;
         Ok(trial)
     }
 
@@ -507,8 +519,9 @@ impl rustuna_core::storage::Storage for CachedStorage {
             .get(&study_id)
             .ok_or_else(|| Error::new(ErrorKind::StudyNotFound))?;
         let trial = trials
-            .get(&trial_number)
-            .ok_or_else(|| Error::new(ErrorKind::TrialNotFound))?;
+            .get(trial_number as usize)
+            .and_then(|trial| trial.as_ref())
+            .ok_or_else(|| Error::new(ErrorKind::TrialDiscarded))?;
         Ok(trial.id)
     }
 
@@ -549,8 +562,9 @@ impl rustuna_core::storage::Storage for CachedStorage {
                 .get(&study_id)
                 .ok_or_else(|| Error::new(ErrorKind::StudyNotFound))?;
             let trial = trials
-                .get(&trial_number)
-                .ok_or_else(|| Error::new(ErrorKind::TrialNotFound))?;
+                .get(trial_number as usize)
+                .and_then(|trial| trial.as_ref())
+                .ok_or_else(|| Error::new(ErrorKind::TrialDiscarded))?;
             if trial.is_finished() {
                 return Err(Error::new(ErrorKind::TrialAlreadyFinished));
             }
@@ -563,8 +577,9 @@ impl rustuna_core::storage::Storage for CachedStorage {
             .get_mut(&study_id)
             .ok_or_else(|| Error::new(ErrorKind::StudyNotFound))?;
         let trial = trials
-            .get_mut(&trial_number)
-            .ok_or_else(|| Error::new(ErrorKind::TrialNotFound))?;
+            .get_mut(trial_number as usize)
+            .and_then(|trial| trial.as_mut())
+            .ok_or_else(|| Error::new(ErrorKind::TrialDiscarded))?;
         for (k, v) in attrs {
             trial.attrs.insert(k, v);
         }
@@ -574,7 +589,7 @@ impl rustuna_core::storage::Storage for CachedStorage {
     fn get_joint_search_space(&mut self, study_id: u32) -> Result<HashMap<String, Distribution>> {
         let trials_vec = {
             let trials = self.get_trials(study_id)?;
-            let mut v = trials.clone();
+            let mut v = trials.iter().flatten().cloned().collect::<Vec<_>>();
             v.sort_by_key(|t| t.number);
             v
         };
@@ -679,7 +694,7 @@ mod tests {
         ) -> Result<Vec<PersistedTrial>> {
             let all = self.inner.get_trials(study_id)?.clone();
             let mut trials = Vec::new();
-            for t in all {
+            for t in all.into_iter().flatten() {
                 if included_numbers.contains(&t.number)
                     || (t.number as i32) > trial_number_greater_than
                 {
@@ -961,7 +976,7 @@ mod tests {
             step: None,
             log: false,
         };
-        let trial_id = storage.get_trials(study_id)?[0].id;
+        let trial_id = storage.get_trials(study_id)?[0].as_ref().unwrap().id;
         storage.set_trial_param(trial_id, "x", &dist, 0.5)?;
 
         let trial = storage.get_trial(trial_id)?;

--- a/rustuna_storage/src/journal/storage.rs
+++ b/rustuna_storage/src/journal/storage.rs
@@ -172,12 +172,15 @@ impl Storage for JournalStorage {
                 format!("Failed to find trials for study: study_id={study_id}"),
             )
         })?;
-        trials.get(trial_number as usize).ok_or_else(|| {
-            Error::with_reason(
-                ErrorKind::TrialNotFound,
-                format!("Failed to find trial at given number: trial_number={trial_number}"),
-            )
-        })
+        trials
+            .get(trial_number as usize)
+            .and_then(|trial| trial.as_ref())
+            .ok_or_else(|| {
+                Error::with_reason(
+                    ErrorKind::TrialNotFound,
+                    format!("Failed to find trial at given number: trial_number={trial_number}"),
+                )
+            })
     }
 
     fn create_new_trial_from_template(
@@ -295,12 +298,15 @@ impl Storage for JournalStorage {
                 format!("Failed to find trials for study: study_id={study_id}"),
             )
         })?;
-        trials.get(trial_number as usize).ok_or_else(|| {
-            Error::with_reason(
-                ErrorKind::TrialNotFound,
-                format!("Failed to find trial at given number: trial_number={trial_number}"),
-            )
-        })
+        trials
+            .get(trial_number as usize)
+            .and_then(|trial| trial.as_ref())
+            .ok_or_else(|| {
+                Error::with_reason(
+                    ErrorKind::TrialNotFound,
+                    format!("Failed to find trial at given number: trial_number={trial_number}"),
+                )
+            })
     }
 
     fn set_trial_param(
@@ -452,15 +458,14 @@ impl Storage for JournalStorage {
         })
     }
 
-    fn get_trials(&mut self, study_id: u32) -> Result<&Vec<PersistedTrial>> {
+    fn get_trials(&mut self, study_id: u32) -> Result<&Vec<Option<PersistedTrial>>> {
         self.sync_with_backend()?;
-        let trials = self.replay.trials_by_study.get(&study_id).ok_or_else(|| {
+        self.replay.trials_by_study.get(&study_id).ok_or_else(|| {
             Error::with_reason(
                 ErrorKind::StudyNotFound,
                 format!("Failed to get trials for study: study_id={study_id}"),
             )
-        })?;
-        Ok(trials)
+        })
     }
 
     fn get_trial(&mut self, trial_id: u32) -> Result<&PersistedTrial> {
@@ -495,16 +500,19 @@ impl Storage for JournalStorage {
                 format!("Failed to get trials for study: study_id={study_id}"),
             )
         })?;
-        trials.get(trial_number as usize).ok_or_else(|| {
-            Error::with_reason(
-                ErrorKind::TrialNotFound,
-                format!(
-                    "Trial number out of bounds: trial_number={}, num_trials={}",
-                    trial_number,
-                    trials.len()
-                ),
-            )
-        })
+        trials
+            .get(trial_number as usize)
+            .and_then(|trial| trial.as_ref())
+            .ok_or_else(|| {
+                Error::with_reason(
+                    ErrorKind::TrialDiscarded,
+                    format!(
+                        "Trial number out of bounds or discarded: trial_number={}, num_trials={}",
+                        trial_number,
+                        trials.len()
+                    ),
+                )
+            })
     }
 
     fn get_category_labels(
@@ -650,8 +658,9 @@ impl Storage for JournalStorage {
                 format!("Failed to get trials for study: study_id={study_id}"),
             )
         })?;
+        let visible_trials = trials.iter().flatten().cloned().collect::<Vec<_>>();
         let cache = self.replay.study_caches.entry(study_id).or_default();
-        cache.update(trials);
+        cache.update(&visible_trials);
         Ok(cache.get_joint_search_space())
     }
 }
@@ -660,7 +669,7 @@ struct JournalReplayState {
     log_number_read: usize,
     worker_id_prefix: String,
     studies: HashMap<u32, PersistedStudy>,
-    trials_by_study: HashMap<u32, Vec<PersistedTrial>>,
+    trials_by_study: HashMap<u32, Vec<Option<PersistedTrial>>>,
     trial_id_to_study_number: HashMap<u32, (u32, u32)>,
     trial_id_to_study_id: HashMap<u32, u32>,
     study_id_to_trial_ids: HashMap<u32, Vec<u32>>,
@@ -760,9 +769,10 @@ impl JournalReplayState {
             .trials_by_study
             .get(&study_id)
             .and_then(|trials| trials.get(trial_number as usize))
+            .and_then(|trial| trial.as_ref())
             .ok_or_else(|| {
                 Error::with_reason(
-                    ErrorKind::TrialNotFound,
+                    ErrorKind::TrialDiscarded,
                     format!("Trial not found at position: trial_number={trial_number}"),
                 )
             })?;
@@ -963,7 +973,7 @@ impl JournalReplayState {
         self.trials_by_study
             .entry(study_id)
             .or_default()
-            .push(trial);
+            .push(Some(trial));
         self.study_id_to_trial_ids
             .entry(study_id)
             .or_default()
@@ -1038,6 +1048,12 @@ impl JournalReplayState {
                 ),
             )
         })?;
+        let trial = trial.as_mut().ok_or_else(|| {
+            Error::with_reason(
+                ErrorKind::TrialDiscarded,
+                format!("Trial discarded during set param: trial_number={trial_number}"),
+            )
+        })?;
         trial
             .internal_params
             .insert(param_name.clone(), param_value);
@@ -1089,6 +1105,12 @@ impl JournalReplayState {
                 format!(
                     "Trial not found at position during set state: trial_number={trial_number}"
                 ),
+            )
+        })?;
+        let trial = trial.as_mut().ok_or_else(|| {
+            Error::with_reason(
+                ErrorKind::TrialDiscarded,
+                format!("Trial discarded during set state: trial_number={trial_number}"),
             )
         })?;
 
@@ -1164,6 +1186,14 @@ impl JournalReplayState {
                 ),
             )
         })?;
+        let trial = trial.as_mut().ok_or_else(|| {
+            Error::with_reason(
+                ErrorKind::TrialDiscarded,
+                format!(
+                    "Trial discarded during set intermediate value: trial_number={trial_number}"
+                ),
+            )
+        })?;
         trial.intermediate_values.insert(step, value);
         Ok(())
     }
@@ -1196,6 +1226,12 @@ impl JournalReplayState {
                 format!(
                     "Trial not found at position during set user attr: trial_number={trial_number}"
                 ),
+            )
+        })?;
+        let trial = trial.as_mut().ok_or_else(|| {
+            Error::with_reason(
+                ErrorKind::TrialDiscarded,
+                format!("Trial discarded during set user attr: trial_number={trial_number}"),
             )
         })?;
         for (key, value) in attrs {
@@ -1232,6 +1268,12 @@ impl JournalReplayState {
                 format!(
                     "Trial not found at position during set system attr: trial_number={trial_number}"
                 ),
+            )
+        })?;
+        let trial = trial.as_mut().ok_or_else(|| {
+            Error::with_reason(
+                ErrorKind::TrialDiscarded,
+                format!("Trial discarded during set system attr: trial_number={trial_number}"),
             )
         })?;
         let is_finished = trial.is_finished();
@@ -1273,9 +1315,10 @@ impl JournalReplayState {
         self.trials_by_study
             .get(&study_id)
             .and_then(|trials| trials.get(trial_number as usize))
+            .and_then(|trial| trial.as_ref())
             .ok_or_else(|| {
                 Error::with_reason(
-                    ErrorKind::TrialNotFound,
+                    ErrorKind::TrialDiscarded,
                     format!(
                         "Trial not found at position: study_id={study_id}, trial_number={trial_number}"
                     ),
@@ -1298,9 +1341,10 @@ impl JournalReplayState {
             .trials_by_study
             .get(&study_id)
             .and_then(|trials| trials.get(trial_number as usize))
+            .and_then(|trial| trial.as_ref())
             .ok_or_else(|| {
                 Error::with_reason(
-                    ErrorKind::TrialNotFound,
+                    ErrorKind::TrialDiscarded,
                     format!(
                         "Trial not found at position during updatable check: trial_number={trial_number}"
                     ),
@@ -1336,8 +1380,10 @@ impl JournalReplayState {
     fn existing_distribution(&self, study_id: u32, param_name: &str) -> Option<&Distribution> {
         let trials = self.trials_by_study.get(&study_id)?;
         for trial in trials {
-            if let Some(dist) = trial.distributions.get(param_name) {
-                return Some(dist);
+            if let Some(trial) = trial.as_ref() {
+                if let Some(dist) = trial.distributions.get(param_name) {
+                    return Some(dist);
+                }
             }
         }
         None
@@ -2260,7 +2306,7 @@ mod tests {
 
         let trials = storage.get_trials(study_id)?;
         assert_eq!(trials.len(), 1);
-        assert_eq!(trials[0].id, trial_id);
+        assert_eq!(trials[0].as_ref().unwrap().id, trial_id);
         Ok(())
     }
 
@@ -2276,7 +2322,7 @@ mod tests {
             step: None,
             log: false,
         };
-        let trial_id = storage.get_trials(study_id)?[0].id;
+        let trial_id = storage.get_trials(study_id)?[0].as_ref().unwrap().id;
         storage.set_trial_param(trial_id, "x", &dist, 0.5)?;
 
         let trial = storage.get_trial(trial_id)?;

--- a/rustuna_storage/tests/journal.rs
+++ b/rustuna_storage/tests/journal.rs
@@ -120,7 +120,7 @@ study.optimize(objective, n_trials=10)
         studies[0].id
     };
 
-    let trial_id = storage.get_trials(study_id)?[0].id;
+    let trial_id = storage.get_trials(study_id)?[0].as_ref().unwrap().id;
     let trial0 = storage.get_trial(trial_id)?;
     assert_eq!(trial0.number, 0);
 
@@ -222,9 +222,9 @@ study.optimize(objective, n_trials=10)
     let mut storage = JournalStorage::new(Box::new(JournalFileBackend::new(&journal_path, None)?))?;
     let trials = storage.get_trials(study_id)?;
     assert_eq!(trials.len(), 20);
-    assert_eq!(trials[0].distributions.len(), 3);
+    assert_eq!(trials[0].as_ref().unwrap().distributions.len(), 3);
     assert_eq!(
-        trials[0].distributions["x"],
+        trials[0].as_ref().unwrap().distributions["x"],
         Distribution::Float {
             low: 1.0,
             high: 10.0,
@@ -233,7 +233,7 @@ study.optimize(objective, n_trials=10)
         }
     );
     assert_eq!(
-        trials[0].distributions["y"],
+        trials[0].as_ref().unwrap().distributions["y"],
         Distribution::Int {
             low: -10,
             high: 10,
@@ -242,18 +242,20 @@ study.optimize(objective, n_trials=10)
         }
     );
     assert_eq!(
-        trials[0].distributions["z"],
+        trials[0].as_ref().unwrap().distributions["z"],
         Distribution::Categorical { cardinality: 4 }
     );
-    assert_eq!(trials[0].internal_params.len(), 3);
+    assert_eq!(trials[0].as_ref().unwrap().internal_params.len(), 3);
     let user_attrs_count = trials[0]
+        .as_ref()
+        .unwrap()
         .attrs
         .keys()
         .filter(|k| matches!(k, rustuna_core::attr::AttrKey::User(_)))
         .count();
     assert_eq!(user_attrs_count, 1);
     assert!(matches!(
-        trials[0].state_values,
+        trials[0].as_ref().unwrap().state_values,
         TrialStateValues::Complete(_)
     ));
     Ok(())

--- a/rustuna_storage/tests/sqlite3.rs
+++ b/rustuna_storage/tests/sqlite3.rs
@@ -164,9 +164,9 @@ study.optimize(objective, n_trials=10)
     run_optuna_script(&python, &db_path, script)?;
     let trials = storage.get_trials(study_id)?;
     assert_eq!(trials.len(), 20);
-    assert_eq!(trials[0].distributions.len(), 3);
+    assert_eq!(trials[0].as_ref().unwrap().distributions.len(), 3);
     assert_eq!(
-        trials[0].distributions["x"],
+        trials[0].as_ref().unwrap().distributions["x"],
         Distribution::Float {
             low: 1.0,
             high: 10.0,
@@ -175,7 +175,7 @@ study.optimize(objective, n_trials=10)
         }
     );
     assert_eq!(
-        trials[0].distributions["y"],
+        trials[0].as_ref().unwrap().distributions["y"],
         Distribution::Int {
             low: -10,
             high: 10,
@@ -184,18 +184,20 @@ study.optimize(objective, n_trials=10)
         }
     );
     assert_eq!(
-        trials[0].distributions["z"],
+        trials[0].as_ref().unwrap().distributions["z"],
         Distribution::Categorical { cardinality: 4 }
     );
-    assert_eq!(trials[0].internal_params.len(), 3);
+    assert_eq!(trials[0].as_ref().unwrap().internal_params.len(), 3);
     let user_attrs_count = trials[0]
+        .as_ref()
+        .unwrap()
         .attrs
         .keys()
         .filter(|k| matches!(k, rustuna_core::attr::AttrKey::User(_)))
         .count();
     assert_eq!(user_attrs_count, 1);
     assert!(matches!(
-        trials[0].state_values,
+        trials[0].as_ref().unwrap().state_values,
         TrialStateValues::Complete(_)
     ));
     Ok(())


### PR DESCRIPTION
## Motivation and Context

To support `storage.discard_trials()` in #131, this PR updates the return type of `get_trials()` as follows.

```diff
-fn get_trials(&mut self, study_id: u32) -> Result<&Vec<PersistedTrial>>;
+fn get_trials(&mut self, study_id: u32) -> Result<&Vec<Option<PersistedTrial>>>;
```

## Description

- Change the return type from `&Vec<PersistedTrial>` to `&Vec<Option<PersistedTrial>>`.
- Update storage implementations and callers to handle discarded trials.