### PR TITLE
Fix broken formatting in Python API documentation

### DIFF
--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -82,7 +82,7 @@ class Trial:
 
     Note that the direct use of this constructor is not recommended.
     This object is seamlessly instantiated and passed to the objective function behind
-    the :func:`Study.optimize` method; hence library users do not care about
+    the [Study.optimize][rustuna.study.Study.optimize] method; hence library users do not care about
     instantiation of this object.
     """
 
@@ -149,7 +149,7 @@ class Trial:
     def set_user_attr(self, key: str, value: str) -> None:
         """Set a user attribute to the trial.
 
-        .. note::
+        Note:
             Unlike Optuna, Rustuna accepts only str values for user attributes.
 
         Args:
@@ -159,7 +159,7 @@ class Trial:
     def set_user_attrs(self, attrs: dict[str, str]) -> None:
         """Set user attributes to the trial.
 
-        .. note::
+        Note:
             Unlike Optuna, Rustuna accepts only str values for user attributes.
 
         Args:
@@ -398,8 +398,8 @@ class Study:
     def ask(self) -> Trial:
         """Create a new trial from which hyperparameters can be suggested.
 
-        This method is part of an alternative to :func:`~Study.optimize` that allows controlling
-        the execution of trials from user code.
+        This method is part of an alternative to [Study.optimize][rustuna.study.Study.optimize]
+        that allows controlling the execution of trials from user code.
 
         Returns:
             A Trial object.
@@ -410,7 +410,7 @@ class Study:
         values: int | float | Sequence[int | float] | None = None,
         state: TrialState | None = None,
     ) -> PersistedTrial:
-        """Finish a trial created with :func:`~Study.ask`.
+        """Finish a trial created with [Study.ask][rustuna.study.Study.ask].
 
         Args:
             number: Trial number returned by the trial.
@@ -461,7 +461,7 @@ class Study:
     ) -> None:
         """Set a user attribute to the study.
 
-        .. note::
+        Note:
             Unlike Optuna, Rustuna accepts only str values for user attributes.
 
         Args:
@@ -486,7 +486,7 @@ class Study:
     ) -> None:
         """Set user attributes to the study.
 
-        .. note::
+        Note:
             Unlike Optuna, Rustuna accepts only str values for user attributes.
 
         Args:

--- a/rustuna_pyo3/rustuna/converter/_trial.py
+++ b/rustuna_pyo3/rustuna/converter/_trial.py
@@ -260,7 +260,7 @@ class FrozenTrialLike(FrozenTrial):
 
     @property
     def last_step(self) -> int | None:
-        """Return the maximum step of :attr:`intermediate_values` in the trial.
+        """Return the maximum step of `intermediate_values` in the trial.
 
         Returns:
             The maximum step of intermediates.

--- a/rustuna_pyo3/rustuna/exceptions.py
+++ b/rustuna_pyo3/rustuna/exceptions.py
@@ -44,14 +44,14 @@ class DuplicatedStudyError(RustunaError):
     already exists in the storage. Study names must be unique within a storage.
 
     Example:
-        .. code-block:: python
+        ```python
+        import rustuna
 
-            import rustuna
-
-            storage = rustuna.Storage.in_memory()
-            rustuna.create_study(study_name="my-study", storage=storage)
-            # Raises DuplicatedStudyError
-            rustuna.create_study(study_name="my-study", storage=storage)
+        storage = rustuna.Storage.in_memory()
+        rustuna.create_study(study_name="my-study", storage=storage)
+        # Raises DuplicatedStudyError
+        rustuna.create_study(study_name="my-study", storage=storage)
+        ```
     """
 
     pass
@@ -66,7 +66,8 @@ class UpdateFinishedTrialError(RustunaError, RuntimeError):
 
     Example:
         This exception might be raised when:
-        - Calling :func:`~rustuna.Trial.suggest_float` after the trial has finished
+        - Calling [Trial.suggest_float][rustuna.trial.Trial.suggest_float] after the trial has
+          finished
         - Attempting to report values to a completed trial
     """
 


### PR DESCRIPTION
## Motivation

Some Python docstrings contained Sphinx/reStructuredText markup inherited from Optuna, such as `:func:`, `:attr:`, `.. note::`, and `.. code-block::`.

Rustuna uses MkDocs with mkdocstrings and Google-style docstrings. As a result, this markup was not interpreted and appeared as literal text or incorrectly formatted code blocks in the generated documentation.
