### PR TITLE
Make CMA-ES sampler faster

### DIFF
--- a/rustuna_pyo3/rustuna/converter/_sampler.py
+++ b/rustuna_pyo3/rustuna/converter/_sampler.py
@@ -52,6 +52,13 @@ class ToOptunaSampler(BaseSampler):
             directions=to_rustuna_directions(study._directions),
         )
         storage = self._get_storage(study._storage)
+        # PyObjectStorage syncs its Rustuna-side cache with the underlying Optuna storage
+        # only when get_trials() is called. In this flow, trials are created and completed
+        # through the Optuna storage directly, so sync explicitly here; otherwise Rustuna
+        # samplers reading the cache (e.g. get_cached_trial) would observe stale or missing
+        # trials.
+        # TODO(c-bata): Consider how to remove this redundant storage.get_trials() call.
+        storage.get_trials(study._study_id, states=[rustuna.trial.TrialState.COMPLETE])
         rustuna_search_space = to_rustuna_distributions(search_space)
         internal_params = self._sampler.sample_joint(ctx, storage, rustuna_search_space)
         external_params: dict[str, Any] = {}

--- a/rustuna_pyo3/src/pyobject_storage.rs
+++ b/rustuna_pyo3/src/pyobject_storage.rs
@@ -741,4 +741,27 @@ impl PyPyObjectStorage {
             })
         })
     }
+
+    #[pyo3(signature = (study_id, *, states = None))]
+    fn get_trials(
+        &mut self,
+        study_id: u32,
+        states: Option<Vec<PyTrialState>>,
+    ) -> PyResult<Vec<PyPersistedTrial>> {
+        let storage: Arc<RwLock<dyn Storage>> = self.storage.clone();
+        let mut guard = storage.write().map_err(|e| {
+            PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
+        })?;
+        let trials = guard.get_trials(study_id).map_err(err_to_exceptions)?;
+        let py_trials: Vec<PyPersistedTrial> = trials
+            .iter()
+            .flatten()
+            .filter(|trial| match &states {
+                Some(s) => s.contains(&PyTrialState::from(trial.state_values.clone())),
+                None => true,
+            })
+            .map(|t| PyPersistedTrial::from_storage(storage.clone(), t))
+            .collect();
+        Ok(py_trials)
+    }
 }

--- a/rustuna_pyo3/src/sampler/cmaes.rs
+++ b/rustuna_pyo3/src/sampler/cmaes.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
 
 use pyo3::exceptions::PyRuntimeError;
@@ -32,7 +32,7 @@ pub struct CmaEsSampler {
     population_size: Option<usize>,
     search_space: Option<HashMap<String, Distribution>>,
     transform: Option<SearchSpaceTransform>,
-    solution_trial_numbers: HashSet<u32>,
+    solution_trial_ids: Vec<u32>,
 }
 
 impl CmaEsSampler {
@@ -49,7 +49,7 @@ impl CmaEsSampler {
             population_size: None,
             search_space: None,
             transform: None,
-            solution_trial_numbers: HashSet::new(),
+            solution_trial_ids: Vec::new(),
         }
     }
 
@@ -184,26 +184,20 @@ impl Sampler for CmaEsSampler {
             .population_size
             .ok_or_else(|| Error::new(ErrorKind::Unexpected))?;
 
-        // Following Optuna's CmaEsSampler, solutions of the current generation are
-        // reconstructed from completed trials in the storage. Trials that never complete are
-        // never told, and their numbers are discarded when the generation switches.
         let solutions = {
             let transform = self
                 .transform
                 .as_ref()
                 .ok_or_else(|| Error::new(ErrorKind::Unexpected))?;
-            let mut guard = storage
-                .write()
+            let guard = storage
+                .read()
                 .map_err(|_| Error::new(ErrorKind::Unexpected))?;
-            let trials = guard.get_trials(ctx.study_id)?;
             let mut solutions = Vec::with_capacity(population_size);
-            for trial in trials.iter().flatten() {
+            for trial_id in self.solution_trial_ids.iter() {
                 if solutions.len() == population_size {
                     break;
                 }
-                if !self.solution_trial_numbers.contains(&trial.number) {
-                    continue;
-                }
+                let trial = guard.get_cached_trial(*trial_id)?;
                 let TrialStateValues::Complete(values) = &trial.state_values else {
                     continue;
                 };
@@ -223,11 +217,16 @@ impl Sampler for CmaEsSampler {
         };
         if solutions.len() >= population_size {
             self.tell(solutions)?;
-            self.solution_trial_numbers.clear();
+            // TODO(c-bata): Consider calling discard_trials here.
+            // let mut guard = storage
+            //     .write()
+            //     .map_err(|_| Error::new(ErrorKind::Unexpected))?;
+            // guard.discard_trials(&self.solution_trial_ids)?;
+            self.solution_trial_ids.clear();
         }
 
         let x = self.ask()?;
-        self.solution_trial_numbers.insert(ctx.trial_number);
+        self.solution_trial_ids.push(ctx.trial_id);
         self.transform
             .as_ref()
             .ok_or_else(|| Error::new(ErrorKind::Unexpected))?


### PR DESCRIPTION
## Motivation

Follow-up #134 

## Description of changes

This PR improves the following benchmark from `1.6311s` to `0.8235s`.

```python
import time
import rustuna

n_params = 10
n_trials = 10000

sampler = rustuna.samplers.CmaEsSampler()
storage = rustuna.storages.InMemoryStorage()
study = rustuna.create_study(sampler=sampler, storage=storage)


def objective(trial: rustuna.Trial) -> float:
    sum = 0.0
    for i in range(n_params):
        sum += trial.suggest_float(f"x{i}", -10, 10) ** 2
    if trial.number % 1000 == 0:
        print(f"{trial.number=}: {sum=}")
    return sum


start = time.time()
study.optimize(objective, n_trials=n_trials)
elapsed = time.time() - start

print(f"{len(study.trials)=}")
print(f"{elapsed:.4f}")
```