### PR TITLE
Handle single-value distributions in Random, TPE, and NSGA-II samplers

### DIFF
--- a/rustuna_core/src/distribution.rs
+++ b/rustuna_core/src/distribution.rs
@@ -160,7 +160,10 @@ impl Distribution {
         if !self.is_single() {
             return Err(Error::with_reason(
                 ErrorKind::Unexpected,
-                format!("Cannot get single value from non-single distribution: {:?}", self),
+                format!(
+                    "Cannot get single value from non-single distribution: {:?}",
+                    self
+                ),
             ));
         }
 

--- a/rustuna_core/src/distribution.rs
+++ b/rustuna_core/src/distribution.rs
@@ -145,6 +145,31 @@ impl Distribution {
         }
     }
 
+    /// Returns the single value that this distribution produces.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `is_single()` returns `false`.
+    ///
+    /// # Returns
+    ///
+    /// - For `Float` distributions: the `low` value
+    /// - For `Int` distributions: the `low` value as f64
+    /// - For `Categorical` distributions: `0.0` (index of the first and only choice)
+    pub fn get_single_value(&self) -> f64 {
+        assert!(
+            self.is_single(),
+            "get_single_value called on a non-single distribution: {:?}",
+            self
+        );
+
+        match self {
+            Distribution::Float { low, .. } => *low,
+            Distribution::Int { low, .. } => *low as f64,
+            Distribution::Categorical { .. } => 0.0,
+        }
+    }
+
     /// Returns whether the internal representation is contained in this distribution.
     pub fn contains(&self, internal_value: f64) -> bool {
         match self {

--- a/rustuna_core/src/distribution.rs
+++ b/rustuna_core/src/distribution.rs
@@ -147,10 +147,6 @@ impl Distribution {
 
     /// Returns the single value that this distribution produces.
     ///
-    /// # Panics
-    ///
-    /// Panics if `is_single()` returns `false`.
-    ///
     /// # Returns
     ///
     /// - For `Float` distributions: the `low` value

--- a/rustuna_core/src/distribution.rs
+++ b/rustuna_core/src/distribution.rs
@@ -156,18 +156,19 @@ impl Distribution {
     /// - For `Float` distributions: the `low` value
     /// - For `Int` distributions: the `low` value as f64
     /// - For `Categorical` distributions: `0.0` (index of the first and only choice)
-    pub fn get_single_value(&self) -> f64 {
-        assert!(
-            self.is_single(),
-            "get_single_value called on a non-single distribution: {:?}",
-            self
-        );
+    pub fn get_single_value(&self) -> Result<f64> {
+        if !self.is_single() {
+            return Err(Error::with_reason(
+                ErrorKind::Unexpected,
+                format!("Cannot get single value from non-single distribution: {:?}", self),
+            ));
+        }
 
-        match self {
+        Ok(match self {
             Distribution::Float { low, .. } => *low,
             Distribution::Int { low, .. } => *low as f64,
             Distribution::Categorical { .. } => 0.0,
-        }
+        })
     }
 
     /// Returns whether the internal representation is contained in this distribution.

--- a/rustuna_core/src/sampler.rs
+++ b/rustuna_core/src/sampler.rs
@@ -167,6 +167,11 @@ impl Sampler for RandomSampler {
         _name: &str,
         distribution: &Distribution,
     ) -> Result<f64> {
+        // Single-value distributions have only one possible value.
+        if distribution.is_single() {
+            return Ok(distribution.get_single_value());
+        }
+
         match distribution {
             Distribution::Float {
                 low,

--- a/rustuna_core/src/sampler.rs
+++ b/rustuna_core/src/sampler.rs
@@ -169,7 +169,7 @@ impl Sampler for RandomSampler {
     ) -> Result<f64> {
         // Single-value distributions have only one possible value.
         if distribution.is_single() {
-            return Ok(distribution.get_single_value());
+            return distribution.get_single_value();
         }
 
         match distribution {

--- a/rustuna_core/src/study_cache.rs
+++ b/rustuna_core/src/study_cache.rs
@@ -31,7 +31,11 @@ impl StudyCache {
 
     pub fn get_joint_search_space(&self) -> HashMap<String, Distribution> {
         match self.joint_search_space {
-            Some(ref search_space) => search_space.clone(),
+            Some(ref search_space) => search_space
+                .iter()
+                .filter(|(_, dist)| !dist.is_single())
+                .map(|(name, dist)| (name.clone(), dist.clone()))
+                .collect(),
             None => HashMap::new(),
         }
     }

--- a/rustuna_pyo3/tests/sampler_tests/test_cmaes.py
+++ b/rustuna_pyo3/tests/sampler_tests/test_cmaes.py
@@ -113,5 +113,7 @@ def test_cmaes_sampler_with_single_value_parameters() -> None:
 
     # Verify single-value parameters were always constant
     for trial in study.trials:
-        assert trial.params["z"] == 5.0, f"z should always be 5.0, got {trial.params['z']}"
-        assert trial.params["w"] == 3, f"w should always be 3, got {trial.params['w']}"
+        z_val = trial.params["z"]
+        w_val = trial.params["w"]
+        assert z_val == 5.0, f"z should always be 5.0, got {z_val}"
+        assert w_val == 3, f"w should always be 3, got {w_val}"

--- a/rustuna_pyo3/tests/sampler_tests/test_cmaes.py
+++ b/rustuna_pyo3/tests/sampler_tests/test_cmaes.py
@@ -82,3 +82,36 @@ def test_cmaes_sampler_missing_dependency_raises_import_error(
 
     with pytest.raises(ImportError, match="cmaes"):
         study.optimize(objective, n_trials=2)
+
+
+def test_cmaes_sampler_with_single_value_parameters() -> None:
+    """Test that CMAES correctly handles single-value parameters.
+
+    Single-value parameters should be included in the search space and
+    correctly transformed/untransformed by SearchSpaceTransform.
+    """
+    sampler = rustuna.samplers.CmaEsSampler(seed=42, popsize=4)
+    study = rustuna.create_study(sampler=sampler)
+
+    def objective(trial: rustuna.Trial) -> float:
+        # Normal parameters
+        x = trial.suggest_float("x", -10, 10)
+        y = trial.suggest_float("y", -10, 10)
+
+        # Single-value parameters (should be handled correctly)
+        z = trial.suggest_float("z", 5.0, 5.0)  # single value: 5.0
+        w = trial.suggest_int("w", 3, 3)  # single value: 3
+
+        return x**2 + y**2 + z + w
+
+    study.optimize(objective, n_trials=10)
+
+    assert len(study.trials) == 10
+    assert all(
+        trial.state == rustuna.trial.TrialState.COMPLETE for trial in study.trials
+    )
+
+    # Verify single-value parameters were always constant
+    for trial in study.trials:
+        assert trial.params["z"] == 5.0, f"z should always be 5.0, got {trial.params['z']}"
+        assert trial.params["w"] == 3, f"w should always be 3, got {trial.params['w']}"

--- a/rustuna_sampler/src/nsgaii.rs
+++ b/rustuna_sampler/src/nsgaii.rs
@@ -232,6 +232,10 @@ impl Sampler for NSGAIISampler {
         _name: &str,
         distribution: &Distribution,
     ) -> Result<f64> {
+        if distribution.is_single() {
+            return Ok(distribution.get_single_value());
+        }
+
         match distribution {
             Distribution::Float {
                 low,
@@ -305,6 +309,13 @@ impl Sampler for NSGAIISampler {
         storage: Arc<RwLock<dyn Storage>>,
         search_space: &HashMap<String, Distribution>,
     ) -> Result<HashMap<String, f64>> {
+        // Exclude single-value distributions from the search space.
+        let filtered_search_space: HashMap<String, Distribution> = search_space
+            .iter()
+            .filter(|(_, dist)| !dist.is_single())
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+
         let mut guard = storage
             .write()
             .map_err(|_e| Error::new(ErrorKind::Unexpected))?;
@@ -331,10 +342,10 @@ impl Sampler for NSGAIISampler {
         }
 
         let (parent0, parent1) =
-            self.select_parents(ctx, storage, parent_population_numbers, search_space)?;
+            self.select_parents(ctx, storage, parent_population_numbers, &filtered_search_space)?;
 
         let child = if self.rng.gen_bool(self.crossover_prob) {
-            self.crossover(parent0, parent1, search_space)
+            self.crossover(parent0, parent1, &filtered_search_space)
         } else {
             parent0
         };
@@ -343,7 +354,7 @@ impl Sampler for NSGAIISampler {
             .mutation_prob
             .unwrap_or(1.0 / 1.0_f64.max(child.len() as f64));
         let mut params = HashMap::new();
-        for name in search_space.keys() {
+        for name in filtered_search_space.keys() {
             if !self.rng.gen_bool(mutation_prob) {
                 let param_value = *child.get(name).unwrap();
                 params.insert(name.clone(), param_value);
@@ -537,5 +548,61 @@ mod tests {
             )
             .unwrap();
         assert!(study.get_trials().unwrap().len() == n_trials);
+    }
+
+    #[test]
+    fn test_single_value_parameters() {
+        let storage = InMemoryStorage::new();
+        let directions = vec![Direction::Minimize, Direction::Minimize];
+        let study = create_study(
+            "single-value-test",
+            storage,
+            NSGAIISampler::new(3, None, 0.9, 0.5),
+            directions,
+        )
+        .unwrap();
+
+        let result = study.optimize(
+            |mut t| {
+                // Normal parameters
+                let x = t.suggest_float("x", 0.0, 10.0)?;
+                let y = t.suggest_float("y", 0.0, 10.0)?;
+
+                // Single-value parameters (should be excluded from genetic algorithm)
+                let z = t.suggest_float("z", 5.0, 5.0)?; // single value: 5.0
+                let w = t.suggest_int("w", 3, 3)?; // single value: 3
+
+                let value0 = (x - 3.0).powi(2) + (y - 5.0).powi(2) + z + w as f64;
+                let value1 = (x - 5.0).powi(2) + (y - 3.0).powi(2) + z - w as f64;
+
+                println!(
+                    "{:2} x: {}, y: {}, z: {}, w: {}, v0: {}, v1: {}",
+                    t.number, x, y, z, w, value0, value1
+                );
+                Ok(vec![value0, value1])
+            },
+            30,
+        );
+
+        assert!(result.is_ok(), "Optimization should complete without panicking");
+
+        // Verify single-value params were always constant
+        let trials = study.get_trials().unwrap();
+        for trial in trials.iter() {
+            if let Some(z_val) = trial.internal_params.get("z") {
+                assert!(
+                    (z_val - 5.0).abs() < 1e-10,
+                    "z should always be 5.0, got {}",
+                    z_val
+                );
+            }
+            if let Some(w_val) = trial.internal_params.get("w") {
+                assert!(
+                    (w_val - 3.0).abs() < 1e-10,
+                    "w should always be 3.0, got {}",
+                    w_val
+                );
+            }
+        }
     }
 }

--- a/rustuna_sampler/src/nsgaii.rs
+++ b/rustuna_sampler/src/nsgaii.rs
@@ -338,11 +338,11 @@ impl Sampler for NSGAIISampler {
             ctx,
             storage,
             parent_population_numbers,
-            &search_space,
+            search_space,
         )?;
 
         let child = if self.rng.gen_bool(self.crossover_prob) {
-            self.crossover(parent0, parent1, &search_space)
+            self.crossover(parent0, parent1, search_space)
         } else {
             parent0
         };

--- a/rustuna_sampler/src/nsgaii.rs
+++ b/rustuna_sampler/src/nsgaii.rs
@@ -309,13 +309,6 @@ impl Sampler for NSGAIISampler {
         storage: Arc<RwLock<dyn Storage>>,
         search_space: &HashMap<String, Distribution>,
     ) -> Result<HashMap<String, f64>> {
-        // Exclude single-value distributions from the search space.
-        let filtered_search_space: HashMap<String, Distribution> = search_space
-            .iter()
-            .filter(|(_, dist)| !dist.is_single())
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
-
         let mut guard = storage
             .write()
             .map_err(|_e| Error::new(ErrorKind::Unexpected))?;
@@ -345,11 +338,11 @@ impl Sampler for NSGAIISampler {
             ctx,
             storage,
             parent_population_numbers,
-            &filtered_search_space,
+            &search_space,
         )?;
 
         let child = if self.rng.gen_bool(self.crossover_prob) {
-            self.crossover(parent0, parent1, &filtered_search_space)
+            self.crossover(parent0, parent1, &search_space)
         } else {
             parent0
         };
@@ -358,7 +351,7 @@ impl Sampler for NSGAIISampler {
             .mutation_prob
             .unwrap_or(1.0 / 1.0_f64.max(child.len() as f64));
         let mut params = HashMap::new();
-        for name in filtered_search_space.keys() {
+        for name in search_space.keys() {
             if !self.rng.gen_bool(mutation_prob) {
                 let param_value = *child.get(name).unwrap();
                 params.insert(name.clone(), param_value);

--- a/rustuna_sampler/src/nsgaii.rs
+++ b/rustuna_sampler/src/nsgaii.rs
@@ -233,7 +233,7 @@ impl Sampler for NSGAIISampler {
         distribution: &Distribution,
     ) -> Result<f64> {
         if distribution.is_single() {
-            return Ok(distribution.get_single_value());
+            return distribution.get_single_value();
         }
 
         match distribution {

--- a/rustuna_sampler/src/nsgaii.rs
+++ b/rustuna_sampler/src/nsgaii.rs
@@ -334,12 +334,8 @@ impl Sampler for NSGAIISampler {
             return Ok(params);
         }
 
-        let (parent0, parent1) = self.select_parents(
-            ctx,
-            storage,
-            parent_population_numbers,
-            search_space,
-        )?;
+        let (parent0, parent1) =
+            self.select_parents(ctx, storage, parent_population_numbers, search_space)?;
 
         let child = if self.rng.gen_bool(self.crossover_prob) {
             self.crossover(parent0, parent1, search_space)

--- a/rustuna_sampler/src/nsgaii.rs
+++ b/rustuna_sampler/src/nsgaii.rs
@@ -341,8 +341,12 @@ impl Sampler for NSGAIISampler {
             return Ok(params);
         }
 
-        let (parent0, parent1) =
-            self.select_parents(ctx, storage, parent_population_numbers, &filtered_search_space)?;
+        let (parent0, parent1) = self.select_parents(
+            ctx,
+            storage,
+            parent_population_numbers,
+            &filtered_search_space,
+        )?;
 
         let child = if self.rng.gen_bool(self.crossover_prob) {
             self.crossover(parent0, parent1, &filtered_search_space)
@@ -584,7 +588,10 @@ mod tests {
             30,
         );
 
-        assert!(result.is_ok(), "Optimization should complete without panicking");
+        assert!(
+            result.is_ok(),
+            "Optimization should complete without panicking"
+        );
 
         // Verify single-value params were always constant
         let trials = study.get_trials().unwrap();

--- a/rustuna_sampler/src/tpe/sampler.rs
+++ b/rustuna_sampler/src/tpe/sampler.rs
@@ -560,7 +560,7 @@ impl Sampler for TpeSampler {
         distribution: &Distribution,
     ) -> Result<f64> {
         if distribution.is_single() {
-            return Ok(distribution.get_single_value());
+            return distribution.get_single_value();
         }
 
         {

--- a/rustuna_sampler/src/tpe/sampler.rs
+++ b/rustuna_sampler/src/tpe/sampler.rs
@@ -559,8 +559,6 @@ impl Sampler for TpeSampler {
         name: &str,
         distribution: &Distribution,
     ) -> Result<f64> {
-        // Single-value distributions cannot be modeled by Parzen estimators.
-        // Return the single value directly.
         if distribution.is_single() {
             return Ok(distribution.get_single_value());
         }

--- a/rustuna_sampler/src/tpe/sampler.rs
+++ b/rustuna_sampler/src/tpe/sampler.rs
@@ -600,14 +600,7 @@ impl Sampler for TpeSampler {
             return Ok(HashMap::new());
         }
 
-        // Exclude single-value distributions from the search space.
-        let filtered_search_space: HashMap<String, Distribution> = search_space
-            .iter()
-            .filter(|(_, dist)| !dist.is_single())
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
-
-        self.sample(ctx, &complete_trials, &filtered_search_space)
+        self.sample(ctx, &complete_trials, search_space)
     }
 
     fn after_trial(

--- a/rustuna_sampler/src/tpe/sampler.rs
+++ b/rustuna_sampler/src/tpe/sampler.rs
@@ -945,7 +945,10 @@ mod tests {
             30,
         );
 
-        assert!(result.is_ok(), "Optimization should complete without panicking");
+        assert!(
+            result.is_ok(),
+            "Optimization should complete without panicking"
+        );
 
         // Verify single-value params were always constant
         let trials = study.get_trials().unwrap();

--- a/rustuna_sampler/src/tpe/sampler.rs
+++ b/rustuna_sampler/src/tpe/sampler.rs
@@ -559,6 +559,12 @@ impl Sampler for TpeSampler {
         name: &str,
         distribution: &Distribution,
     ) -> Result<f64> {
+        // Single-value distributions cannot be modeled by Parzen estimators.
+        // Return the single value directly.
+        if distribution.is_single() {
+            return Ok(distribution.get_single_value());
+        }
+
         {
             let mut guard = storage
                 .write()
@@ -595,7 +601,15 @@ impl Sampler for TpeSampler {
         if complete_trials.len() < self.n_startup_trials {
             return Ok(HashMap::new());
         }
-        self.sample(ctx, &complete_trials, search_space)
+
+        // Exclude single-value distributions from the search space.
+        let filtered_search_space: HashMap<String, Distribution> = search_space
+            .iter()
+            .filter(|(_, dist)| !dist.is_single())
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+
+        self.sample(ctx, &complete_trials, &filtered_search_space)
     }
 
     fn after_trial(
@@ -895,5 +909,61 @@ mod tests {
                 40,
             )
             .unwrap();
+    }
+
+    /// Test with single-value parameters to check if bandwidth=0 issue occurs.
+    /// Single-value parameters should be excluded from the search space to avoid
+    /// creating Parzen estimators with zero bandwidth.
+    #[test]
+    fn test_single_value_parameters() {
+        let storage = InMemoryStorage::new();
+        let directions = vec![Direction::Minimize];
+        let study = create_study(
+            "single-value-test",
+            storage,
+            TpeSampler::seed_from_u64(42),
+            directions,
+        )
+        .unwrap();
+
+        let result = study.optimize(
+            |mut t| {
+                // Normal parameter
+                let x = t.suggest_float("x", -10.0, 10.0)?;
+
+                // Single-value parameters (should be excluded from search space)
+                let y = t.suggest_float("y", 5.0, 5.0)?; // single value: 5.0
+                let z = t.suggest_int("z", 3, 3)?; // single value: 3
+
+                let value = (x - 2.0).powi(2) + y + z as f64;
+                println!(
+                    "{:2} x: {}, y: {}, z: {}, value: {}",
+                    t.number, x, y, z, value
+                );
+                Ok(vec![value])
+            },
+            30,
+        );
+
+        assert!(result.is_ok(), "Optimization should complete without panicking");
+
+        // Verify single-value params were always constant
+        let trials = study.get_trials().unwrap();
+        for trial in trials.iter() {
+            if let Some(y_val) = trial.internal_params.get("y") {
+                assert!(
+                    (y_val - 5.0).abs() < 1e-10,
+                    "y should always be 5.0, got {}",
+                    y_val
+                );
+            }
+            if let Some(z_val) = trial.internal_params.get("z") {
+                assert!(
+                    (z_val - 3.0).abs() < 1e-10,
+                    "z should always be 3.0, got {}",
+                    z_val
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Added proper handling for single-value distributions (where `low == high`) in Random, TPE, and NSGA-II samplers. These samplers previously included single-value parameters in their search spaces, causing issues:

- Random: empty `gen_range()` panics
- TPE: `bandwidth=0` Parzen estimators leading to EI=+inf and `gen_range()` panics
- NSGA-II: attempting to mutate constant parameters in the genetic algorithm

## Changes

- Added `Distribution::get_single_value()` method (`rustuna_core/src/distribution.rs`)
- sample_independent() in Random/TPE/NSGAII: Early return with single value
- sample_joint() in TPE/NSGAII: Filter out single-value distributions

Note that CMA-ES can handle single distributions through a search space transform (cf. https://github.com/optuna/rustuna/blob/main/rustuna_core/src/transform.rs#L191-L204).

## <s>Design Decision: Sampler-wise vs. study_cache Approach</s>

<s>I decided to employ the sampler-wise search space handling design, which is the same as Optuna, instead of filtering in `study_cache`. Because the sampler-wise approach allows samplers to handle single-distributed parameters more flexibly. A sampler like CMA-ES naturally handles single-distributed parameters without any modifications, and for such a sampler, filtering single-distributed parameters is not required.</s>