### PR TITLE
Improve error propagation across crates

### DIFF
--- a/rustuna_core/src/trial.rs
+++ b/rustuna_core/src/trial.rs
@@ -67,10 +67,12 @@ impl Trial {
         if let Some(fixed_value) = self.fixed_params.get(name) {
             let result = if let Distribution::Categorical { cardinality } = distribution {
                 // CategoricalDistribution
-                let mut storage_guard = self
-                    .storage
-                    .write()
-                    .map_err(|_| Error::new(ErrorKind::StorageError))?;
+                let mut storage_guard = self.storage.write().map_err(|e| {
+                    Error::with_reason(
+                        ErrorKind::StorageError,
+                        format!("Failed to acquire storage guard: {e}"),
+                    )
+                })?;
                 let labels =
                     storage_guard.get_category_labels(self.study_id, name, *cardinality)?;
                 drop(storage_guard);
@@ -95,10 +97,12 @@ impl Trial {
             };
 
             if let Some(internal_value) = result {
-                let mut storage_guard = self
-                    .storage
-                    .write()
-                    .map_err(|_| Error::new(ErrorKind::StorageError))?;
+                let mut storage_guard = self.storage.write().map_err(|e| {
+                    Error::with_reason(
+                        ErrorKind::StorageError,
+                        format!("Failed to acquire storage guard: {e}"),
+                    )
+                })?;
                 storage_guard.set_trial_param(self.id, name, distribution, internal_value)?;
                 drop(storage_guard);
 
@@ -116,10 +120,12 @@ impl Trial {
         if let Some((d, val)) = self.joint_params.get(name) {
             if *d == *distribution {
                 let param_value = *val;
-                let mut storage_guard = self
-                    .storage
-                    .write()
-                    .map_err(|_| Error::new(ErrorKind::StorageError))?;
+                let mut storage_guard = self.storage.write().map_err(|e| {
+                    Error::with_reason(
+                        ErrorKind::StorageError,
+                        format!("Failed to acquire storage guard: {e}"),
+                    )
+                })?;
                 storage_guard.set_trial_param(self.id, name, distribution, param_value)?;
                 drop(storage_guard);
                 return Ok(param_value);
@@ -132,18 +138,22 @@ impl Trial {
             trial_id: self.id,
             directions: self.directions.clone(),
         };
-        let mut sampler_guard = self
-            .sampler
-            .lock()
-            .map_err(|_| Error::new(ErrorKind::SamplerError))?;
+        let mut sampler_guard = self.sampler.lock().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::SamplerError,
+                format!("Failed to acquire sampler guard: {e}"),
+            )
+        })?;
         let param_value =
             sampler_guard.sample_independent(&context, self.storage.clone(), name, distribution)?;
         drop(sampler_guard);
 
-        let mut storage_guard = self
-            .storage
-            .write()
-            .map_err(|_| Error::new(ErrorKind::StorageError))?;
+        let mut storage_guard = self.storage.write().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::StorageError,
+                format!("Failed to acquire storage guard: {e}"),
+            )
+        })?;
         storage_guard.set_trial_param(self.id, name, distribution, param_value)?;
         drop(storage_guard);
 
@@ -186,9 +196,12 @@ impl Trial {
         // Save labels in the study system attr before calling suggest(),
         // so that fixed_params can look up category labels during suggest().
         let category_labels = category_labels_to_attrs(name, choices);
-        let mut guard = storage
-            .write()
-            .map_err(|_| Error::new(ErrorKind::Unexpected))?;
+        let mut guard = storage.write().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::Unexpected,
+                format!("Failed to acquire storage guard: {e}"),
+            )
+        })?;
         guard.set_study_attrs(study_id, category_labels, false)?;
         drop(guard);
 
@@ -219,10 +232,12 @@ impl Trial {
 
     /// Sets a single user attribute on the trial.
     pub fn set_user_attr(&mut self, key: &str, value: String) -> Result<()> {
-        let mut guard = self
-            .storage
-            .write()
-            .map_err(|_| Error::new(ErrorKind::StorageError))?;
+        let mut guard = self.storage.write().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::StorageError,
+                format!("Failed to acquire storage guard: {e}"),
+            )
+        })?;
         let mut attrs = Attrs::new();
 
         let key = AttrKey::User(key.into());
@@ -238,10 +253,12 @@ impl Trial {
         for (key, value) in &user_attrs {
             attrs.insert(AttrKey::User(key.as_str().into()), value.clone());
         }
-        let mut guard = self
-            .storage
-            .write()
-            .map_err(|_| Error::new(ErrorKind::StorageError))?;
+        let mut guard = self.storage.write().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::StorageError,
+                format!("Failed to acquire storage guard: {e}"),
+            )
+        })?;
         guard.set_trial_attrs(self.id, attrs, false)?;
         drop(guard);
 
@@ -470,9 +487,12 @@ mod tests {
         trial.set_user_attr("key", "user".to_string())?;
 
         // Set system attributes
-        let mut guard = storage
-            .write()
-            .map_err(|_| Error::new(ErrorKind::StorageError))?;
+        let mut guard = storage.write().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::StorageError,
+                format!("Failed to acquire storage guard: {e}"),
+            )
+        })?;
         let mut attrs = Attrs::new();
         attrs.insert(AttrKey::System("key".into()), "system".to_string());
         guard.set_trial_attrs(trial.id, attrs, false)?;

--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -147,10 +147,12 @@ pub(crate) fn get_filtered_trials(
     study: &Study,
     target: &dyn Fn(&PersistedTrial) -> f64,
 ) -> Result<Vec<PersistedTrial>> {
-    let mut guard = study
-        .storage
-        .write()
-        .map_err(|_e| Error::new(ErrorKind::Unexpected))?;
+    let mut guard = study.storage.write().map_err(|e| {
+        Error::with_reason(
+            ErrorKind::Unexpected,
+            format!("Failed to acquire storage guard: {e}"),
+        )
+    })?;
     // TODO(c-bata): Avoid to clone trials.
     let completed_trials = guard
         .get_trials(study.id)?

--- a/rustuna_js/src/study.rs
+++ b/rustuna_js/src/study.rs
@@ -24,7 +24,10 @@ impl JsStudy {
                         Ok(js_value) => js_value
                             .as_f64()
                             .ok_or(Error::new(ErrorKind::ObjectiveError)),
-                        Err(_) => Err(Error::new(ErrorKind::ObjectiveError)),
+                        Err(err) => Err(Error::with_reason(
+                            ErrorKind::ObjectiveError,
+                            format!("Objective function failed: {err:?}"),
+                        )),
                     }?;
                     Ok(vec![val])
                 },

--- a/rustuna_js/src/trial.rs
+++ b/rustuna_js/src/trial.rs
@@ -48,7 +48,10 @@ impl JsTrial {
         for i in 0..choices.length() {
             let c = choices.get(i);
             if c.is_string() {
-                category_labels.push(CategoryLabel::String(c.as_string().unwrap()));
+                category_labels
+                    .push(CategoryLabel::String(c.as_string().ok_or(JsError::new(
+                        "Failed to read string category value",
+                    ))?));
                 continue;
             } else if c.is_null() {
                 category_labels.push(CategoryLabel::None);
@@ -59,9 +62,15 @@ impl JsTrial {
                 .as_string()
                 .ok_or(JsError::new("Unsupported category value type"))?;
             if js_ty == "number" {
-                category_labels.push(CategoryLabel::Float(c.as_f64().unwrap()));
+                category_labels
+                    .push(CategoryLabel::Float(c.as_f64().ok_or(JsError::new(
+                        "Failed to read numeric category value",
+                    ))?));
             } else if js_ty == "boolean" {
-                category_labels.push(CategoryLabel::Bool(c.as_bool().unwrap()));
+                category_labels
+                    .push(CategoryLabel::Bool(c.as_bool().ok_or(JsError::new(
+                        "Failed to read boolean category value",
+                    ))?));
             } else {
                 return Err(JsError::new("Unsupported category value type"));
             }

--- a/rustuna_pyo3/src/pyobject_storage.rs
+++ b/rustuna_pyo3/src/pyobject_storage.rs
@@ -253,9 +253,7 @@ impl PyObjectStorage {
     }
 
     pub fn sync_studies(&mut self, sync_attrs: bool) -> rustuna_core::Result<()> {
-        let studies = self
-            .obj_get_studies()
-            .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::StorageError))?;
+        let studies = self.obj_get_studies().map_err(Self::map_pyerr)?;
         for src_study in studies {
             self.register_src_study_to_cache(src_study, sync_attrs)?
         }
@@ -270,9 +268,7 @@ impl PyObjectStorage {
         match self.cache_study_to_src_study.get(&cache_study_id) {
             Some(src_study_id) => {
                 if sync_attrs {
-                    let src_study = self.obj_get_study(*src_study_id).map_err(|_| {
-                        rustuna_core::Error::new(rustuna_core::ErrorKind::StorageError)
-                    })?;
+                    let src_study = self.obj_get_study(*src_study_id).map_err(Self::map_pyerr)?;
                     self.cache
                         .set_study_attrs(cache_study_id, src_study.attrs, false)?;
                 }
@@ -353,7 +349,7 @@ impl PyObjectStorage {
 
         let mut src_trials = self
             .obj_get_trials(*src_study_id)
-            .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::StorageError))?;
+            .map_err(Self::map_pyerr)?;
         src_trials.sort_by_key(|trial| trial.number);
 
         let mut cache_n_trials = self.cache.get_trials(cache_study_id)?.len() as u32;
@@ -375,19 +371,24 @@ impl PyObjectStorage {
 
     fn map_pyerr(err: PyErr) -> Error {
         let reason = err.to_string();
-        let kind = Python::attach(|py| {
-            let class_name = err
-                .get_type(py)
+        let class_name = match Python::attach(|py| {
+            err.get_type(py)
                 .name()
-                .ok()
                 .map(|name| name.to_string_lossy().into_owned())
-                .unwrap_or_default();
-            if class_name == "DuplicatedStudyError" {
-                ErrorKind::DuplicatedStudy
-            } else {
-                ErrorKind::StorageError
+        }) {
+            Ok(class_name) => class_name,
+            Err(type_error) => {
+                return Error::with_reason(
+                    ErrorKind::StorageError,
+                    format!("{reason}; failed to inspect Python exception type: {type_error}"),
+                )
             }
-        });
+        };
+        let kind = if class_name == "DuplicatedStudyError" {
+            ErrorKind::DuplicatedStudy
+        } else {
+            ErrorKind::StorageError
+        };
         Error::with_reason(kind, reason)
     }
 }
@@ -420,7 +421,7 @@ impl Storage for PyObjectStorage {
                     rustuna_core::ErrorKind::StudyNotFound,
                 ))?;
         self.obj_delete_study(src_study_id)
-            .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::StorageError))?;
+            .map_err(Self::map_pyerr)?;
         self.cache.delete_study(study_id)?;
         self.cache_study_to_src_study.remove(&study_id);
         self.src_study_to_cache_study.remove(&src_study_id);
@@ -510,7 +511,7 @@ impl Storage for PyObjectStorage {
     ) -> rustuna_core::Result<()> {
         let state_values_clone = state_values.clone();
         self.obj_set_trial_state_values(trial_id, &state_values_clone)
-            .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::StorageError))?;
+            .map_err(Self::map_pyerr)?;
 
         match self.cache.set_trial_state_values(trial_id, state_values) {
             Ok(_) => Ok(()),
@@ -652,7 +653,7 @@ impl Storage for PyObjectStorage {
                     rustuna_core::ErrorKind::StudyNotFound,
                 ))?;
         self.obj_set_study_attrs(*src_study_id, attrs.clone())
-            .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::StorageError))?;
+            .map_err(Self::map_pyerr)?;
         match self.cache.set_study_attrs(study_id, attrs, false) {
             Ok(_) => Ok(()),
             Err(e) => match e.kind {
@@ -675,7 +676,7 @@ impl Storage for PyObjectStorage {
         let attrs_for_obj = attrs.clone();
         let attrs_for_retry = attrs.clone();
         self.obj_set_trial_attrs(trial_id, attrs_for_obj)
-            .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::StorageError))?;
+            .map_err(Self::map_pyerr)?;
         match self.cache.set_trial_attrs(trial_id, attrs, false) {
             Ok(_) => Ok(()),
             Err(e) => match e.kind {

--- a/rustuna_pyo3/src/sampler/cmaes.rs
+++ b/rustuna_pyo3/src/sampler/cmaes.rs
@@ -189,9 +189,12 @@ impl Sampler for CmaEsSampler {
                 .transform
                 .as_ref()
                 .ok_or_else(|| Error::new(ErrorKind::Unexpected))?;
-            let guard = storage
-                .read()
-                .map_err(|_| Error::new(ErrorKind::Unexpected))?;
+            let guard = storage.read().map_err(|e| {
+                Error::with_reason(
+                    ErrorKind::Unexpected,
+                    format!("Failed to acquire storage guard: {e}"),
+                )
+            })?;
             let mut solutions = Vec::with_capacity(population_size);
             for trial_id in self.solution_trial_ids.iter() {
                 if solutions.len() == population_size {
@@ -285,7 +288,9 @@ impl PyCmaEsSampler {
         py.detach(|| {
             self.sampler
                 .lock()
-                .map_err(|_| PyRuntimeError::new_err("Failed to acquire the sampler guard"))?
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
+                })?
                 .sample_independent(&context, arc_storage, &name, &distribution)
                 .map_err(|e| {
                     PyRuntimeError::new_err(format!("Failed to sample independent: {e:?}"))
@@ -309,7 +314,9 @@ impl PyCmaEsSampler {
         py.detach(|| {
             self.sampler
                 .lock()
-                .map_err(|_| PyRuntimeError::new_err("Failed to acquire the sampler guard"))?
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
+                })?
                 .sample_joint(&context, arc_storage, &search_space)
                 .map_err(err_to_exceptions)
         })
@@ -338,7 +345,9 @@ impl PyCmaEsSampler {
         py.detach(|| {
             self.sampler
                 .lock()
-                .map_err(|_| PyRuntimeError::new_err("Failed to acquire the sampler guard"))?
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
+                })?
                 .after_trial(&context, arc_storage, &state_values)
                 .map_err(|e| PyRuntimeError::new_err(format!("Failed to call after_trial: {e:?}")))
         })

--- a/rustuna_pyo3/src/sampler/nsgaii.rs
+++ b/rustuna_pyo3/src/sampler/nsgaii.rs
@@ -56,7 +56,7 @@ impl PyNSGAIISampler {
         let guard = self
             .sampler
             .lock()
-            .map_err(|_| PyRuntimeError::new_err("Failed to acquire sampler lock"))?;
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to acquire sampler lock: {e}")))?;
         Ok(guard.support_joint_sampling())
     }
 
@@ -70,7 +70,9 @@ impl PyNSGAIISampler {
         let arc_storage = extract_storage(storage)?;
         self.sampler
             .lock()
-            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the sampler guard"))?
+            .map_err(|e| {
+                PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
+            })?
             .sample_independent(
                 &ctx.context.clone(),
                 arc_storage,
@@ -89,7 +91,9 @@ impl PyNSGAIISampler {
         let arc_storage = extract_storage(storage)?;
         self.sampler
             .lock()
-            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the sampler guard"))?
+            .map_err(|e| {
+                PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
+            })?
             .sample_joint(
                 &ctx.context.clone(),
                 arc_storage,
@@ -121,7 +125,9 @@ impl PyNSGAIISampler {
         };
         self.sampler
             .lock()
-            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the sampler guard"))?
+            .map_err(|e| {
+                PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
+            })?
             .after_trial(&ctx.context, arc_storage, &state_values)
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to call after_trial: {e:?}")))
     }

--- a/rustuna_pyo3/src/sampler/python.rs
+++ b/rustuna_pyo3/src/sampler/python.rs
@@ -30,9 +30,12 @@ impl Sampler for PythonSamplerAdapter {
         name: &str,
         distribution: &rustuna_core::distribution::Distribution,
     ) -> rustuna_core::Result<f64> {
-        let mut guard = storage
-            .write()
-            .map_err(|_| rustuna_core::Error::new(rustuna_core::ErrorKind::StorageError))?;
+        let mut guard = storage.write().map_err(|e| {
+            rustuna_core::Error::with_reason(
+                rustuna_core::ErrorKind::StorageError,
+                format!("Failed to acquire storage guard: {e}"),
+            )
+        })?;
         let study = guard.get_study(ctx.study_id)?;
         let study_attrs = study.attrs.clone();
         drop(guard);

--- a/rustuna_pyo3/src/sampler/random.rs
+++ b/rustuna_pyo3/src/sampler/random.rs
@@ -45,7 +45,9 @@ impl PyRandomSampler {
         let arc_storage = extract_storage(storage)?;
         self.sampler
             .lock()
-            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the sampler guard"))?
+            .map_err(|e| {
+                PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
+            })?
             .sample_independent(&ctx.context, arc_storage, name, &distribution.distribution)
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to sample independent: {e:?}")))
     }

--- a/rustuna_pyo3/src/sampler/tpe.rs
+++ b/rustuna_pyo3/src/sampler/tpe.rs
@@ -39,7 +39,7 @@ impl PyTpeSampler {
         let guard = self
             .sampler
             .lock()
-            .map_err(|_| PyRuntimeError::new_err("Failed to acquire sampler lock"))?;
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to acquire sampler lock: {e}")))?;
         Ok(guard.support_joint_sampling())
     }
 
@@ -53,7 +53,9 @@ impl PyTpeSampler {
         let arc_storage = extract_storage(storage)?;
         self.sampler
             .lock()
-            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the sampler guard"))?
+            .map_err(|e| {
+                PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
+            })?
             .sample_independent(
                 &ctx.context.clone(),
                 arc_storage,
@@ -72,7 +74,9 @@ impl PyTpeSampler {
         let arc_storage = extract_storage(storage)?;
         self.sampler
             .lock()
-            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the sampler guard"))?
+            .map_err(|e| {
+                PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
+            })?
             .sample_joint(
                 &ctx.context.clone(),
                 arc_storage,
@@ -104,7 +108,9 @@ impl PyTpeSampler {
         };
         self.sampler
             .lock()
-            .map_err(|_| PyRuntimeError::new_err("Failed to acquire the sampler guard"))?
+            .map_err(|e| {
+                PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
+            })?
             .after_trial(&ctx.context, arc_storage, &state_values)
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to call after_trial: {e:?}")))
     }

--- a/rustuna_sampler/src/tpe/sampler.rs
+++ b/rustuna_sampler/src/tpe/sampler.rs
@@ -560,9 +560,12 @@ impl Sampler for TpeSampler {
         distribution: &Distribution,
     ) -> Result<f64> {
         {
-            let mut guard = storage
-                .write()
-                .map_err(|_e| Error::new(ErrorKind::Unexpected))?;
+            let mut guard = storage.write().map_err(|e| {
+                Error::with_reason(
+                    ErrorKind::Unexpected,
+                    format!("Failed to acquire storage guard: {e}"),
+                )
+            })?;
             let trials = guard.get_trials(ctx.study_id)?;
             let complete_trials: Vec<&rustuna_core::trial::PersistedTrial> =
                 Self::usable_complete_trials(trials);
@@ -586,9 +589,12 @@ impl Sampler for TpeSampler {
         storage: Arc<RwLock<dyn Storage>>,
         search_space: &HashMap<String, Distribution>,
     ) -> Result<HashMap<String, f64>> {
-        let mut guard = storage
-            .write()
-            .map_err(|_e| Error::new(ErrorKind::Unexpected))?;
+        let mut guard = storage.write().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::Unexpected,
+                format!("Failed to acquire storage guard: {e}"),
+            )
+        })?;
         let trials = guard.get_trials(ctx.study_id)?;
         let complete_trials: Vec<&rustuna_core::trial::PersistedTrial> =
             Self::usable_complete_trials(trials);

--- a/rustuna_storage/src/sqlite3_queue.rs
+++ b/rustuna_storage/src/sqlite3_queue.rs
@@ -64,10 +64,12 @@ impl SQLite3TrialQueue {
 
 impl TrialQueue for SQLite3TrialQueue {
     fn enqueue(&mut self, trial_id: u32) -> Result<()> {
-        let conn = self
-            .conn
-            .lock()
-            .map_err(|_| Error::new(ErrorKind::StorageError))?;
+        let conn = self.conn.lock().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::StorageError,
+                format!("Failed to acquire SQLite connection: {e}"),
+            )
+        })?;
 
         // Use current timestamp in microseconds for ordering
         let enqueued_at = std::time::SystemTime::now()
@@ -84,7 +86,12 @@ impl TrialQueue for SQLite3TrialQueue {
                 params![self.namespace, enqueued_at],
                 |row| row.get(0),
             )
-            .unwrap_or(0);
+            .map_err(|e| {
+                Error::with_reason(
+                    ErrorKind::StorageError,
+                    format!("Failed to determine trial queue sequence: {e}"),
+                )
+            })?;
 
         conn.execute(
             "INSERT INTO trial_queue (namespace, trial_id, enqueued_at, sequence) 
@@ -102,10 +109,12 @@ impl TrialQueue for SQLite3TrialQueue {
     }
 
     fn dequeue(&mut self) -> Result<u32> {
-        let conn = self
-            .conn
-            .lock()
-            .map_err(|_| Error::new(ErrorKind::StorageError))?;
+        let conn = self.conn.lock().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::StorageError,
+                format!("Failed to acquire SQLite connection: {e}"),
+            )
+        })?;
 
         // Use a transaction with IMMEDIATE to ensure exclusive access
         conn.execute("BEGIN IMMEDIATE", []).map_err(|e| {
@@ -143,15 +152,23 @@ impl TrialQueue for SQLite3TrialQueue {
                 Ok(trial_id)
             }
             Err(rusqlite::Error::QueryReturnedNoRows) => {
-                let _ = conn.execute("ROLLBACK", []);
+                conn.execute("ROLLBACK", []).map_err(|e| {
+                    Error::with_reason(
+                        ErrorKind::StorageError,
+                        format!("Failed to roll back empty dequeue transaction: {e}"),
+                    )
+                })?;
                 Err(Error::new(ErrorKind::TrialQueueEmpty))
             }
             Err(e) => {
-                let _ = conn.execute("ROLLBACK", []);
-                Err(Error::with_reason(
-                    ErrorKind::StorageError,
-                    format!("Failed to dequeue trial: {e}"),
-                ))
+                let rollback_result = conn.execute("ROLLBACK", []);
+                let reason = match rollback_result {
+                    Ok(_) => format!("Failed to dequeue trial: {e}"),
+                    Err(rollback_error) => format!(
+                        "Failed to dequeue trial: {e}; failed to roll back transaction: {rollback_error}"
+                    ),
+                };
+                Err(Error::with_reason(ErrorKind::StorageError, reason))
             }
         }
     }


### PR DESCRIPTION
## Summary

- Preserve lock, Python, SQLite, and filesystem error details
- Stop ignoring directory entry and SQLite transaction errors
- Propagate SQLite query failures with their original causes
- Preserve errors encountered during journal replay
- Replace JavaScript-side `unwrap()` calls with proper errors
- Remove unnecessary cleanup error suppression