### PR TITLE
Release the GIL while trial_queue access

### DIFF
--- a/rustuna_pyo3/src/trial_queue/directory.rs
+++ b/rustuna_pyo3/src/trial_queue/directory.rs
@@ -17,33 +17,39 @@ pub struct PyDirectoryTrialQueue {
 #[pymethods]
 impl PyDirectoryTrialQueue {
     #[new]
-    fn py_new(base_dir: &str) -> PyResult<Self> {
-        let queue = DirectoryTrialQueue::new(base_dir).map_err(|error| {
-            PyRuntimeError::new_err(format!(
-                "Failed to create DirectoryTrialQueue: {}",
-                error.reason
-            ))
-        })?;
+    fn py_new(py: Python<'_>, base_dir: String) -> PyResult<Self> {
+        let queue = py
+            .detach(|| DirectoryTrialQueue::new(base_dir))
+            .map_err(|error| {
+                PyRuntimeError::new_err(format!(
+                    "Failed to create DirectoryTrialQueue: {}",
+                    error.reason
+                ))
+            })?;
         Ok(Self {
             queue: Arc::new(RwLock::new(queue)),
         })
     }
 
-    fn enqueue(&self, trial_id: u32) -> PyResult<()> {
-        let mut guard = self.queue.write().map_err(|error| {
-            PyRuntimeError::new_err(format!("Failed to acquire trial queue lock: {error}"))
-        })?;
-        guard.enqueue(trial_id).map_err(err_to_exceptions)
+    fn enqueue(&self, py: Python<'_>, trial_id: u32) -> PyResult<()> {
+        py.detach(|| {
+            let mut guard = self.queue.write().map_err(|error| {
+                PyRuntimeError::new_err(format!("Failed to acquire trial queue lock: {error}"))
+            })?;
+            guard.enqueue(trial_id).map_err(err_to_exceptions)
+        })
     }
 
-    fn dequeue(&self) -> PyResult<Option<u32>> {
-        let mut guard = self.queue.write().map_err(|error| {
-            PyRuntimeError::new_err(format!("Failed to acquire trial queue lock: {error}"))
-        })?;
-        match guard.dequeue() {
-            Ok(trial_id) => Ok(Some(trial_id)),
-            Err(error) if matches!(error.kind, ErrorKind::TrialQueueEmpty) => Ok(None),
-            Err(error) => Err(err_to_exceptions(error)),
-        }
+    fn dequeue(&self, py: Python<'_>) -> PyResult<Option<u32>> {
+        py.detach(|| {
+            let mut guard = self.queue.write().map_err(|error| {
+                PyRuntimeError::new_err(format!("Failed to acquire trial queue lock: {error}"))
+            })?;
+            match guard.dequeue() {
+                Ok(trial_id) => Ok(Some(trial_id)),
+                Err(error) if matches!(error.kind, ErrorKind::TrialQueueEmpty) => Ok(None),
+                Err(error) => Err(err_to_exceptions(error)),
+            }
+        })
     }
 }

--- a/rustuna_pyo3/src/trial_queue/inmemory.rs
+++ b/rustuna_pyo3/src/trial_queue/inmemory.rs
@@ -34,21 +34,25 @@ impl PyInMemoryTrialQueue {
         Self::new()
     }
 
-    fn enqueue(&self, trial_id: u32) -> PyResult<()> {
-        let mut guard = self.queue.write().map_err(|error| {
-            PyRuntimeError::new_err(format!("Failed to acquire trial queue lock: {error}"))
-        })?;
-        guard.enqueue(trial_id).map_err(err_to_exceptions)
+    fn enqueue(&self, py: Python<'_>, trial_id: u32) -> PyResult<()> {
+        py.detach(|| {
+            let mut guard = self.queue.write().map_err(|error| {
+                PyRuntimeError::new_err(format!("Failed to acquire trial queue lock: {error}"))
+            })?;
+            guard.enqueue(trial_id).map_err(err_to_exceptions)
+        })
     }
 
-    fn dequeue(&self) -> PyResult<Option<u32>> {
-        let mut guard = self.queue.write().map_err(|error| {
-            PyRuntimeError::new_err(format!("Failed to acquire trial queue lock: {error}"))
-        })?;
-        match guard.dequeue() {
-            Ok(trial_id) => Ok(Some(trial_id)),
-            Err(error) if matches!(error.kind, ErrorKind::TrialQueueEmpty) => Ok(None),
-            Err(error) => Err(err_to_exceptions(error)),
-        }
+    fn dequeue(&self, py: Python<'_>) -> PyResult<Option<u32>> {
+        py.detach(|| {
+            let mut guard = self.queue.write().map_err(|error| {
+                PyRuntimeError::new_err(format!("Failed to acquire trial queue lock: {error}"))
+            })?;
+            match guard.dequeue() {
+                Ok(trial_id) => Ok(Some(trial_id)),
+                Err(error) if matches!(error.kind, ErrorKind::TrialQueueEmpty) => Ok(None),
+                Err(error) => Err(err_to_exceptions(error)),
+            }
+        })
     }
 }

--- a/rustuna_pyo3/src/trial_queue/sqlite3.rs
+++ b/rustuna_pyo3/src/trial_queue/sqlite3.rs
@@ -17,33 +17,39 @@ pub struct PySQLite3TrialQueue {
 #[pymethods]
 impl PySQLite3TrialQueue {
     #[new]
-    fn py_new(db_path: &str, namespace: &str) -> PyResult<Self> {
-        let queue = SQLite3TrialQueue::new(db_path, namespace).map_err(|error| {
-            PyRuntimeError::new_err(format!(
-                "Failed to create SQLite3TrialQueue: {}",
-                error.reason
-            ))
-        })?;
+    fn py_new(py: Python<'_>, db_path: String, namespace: String) -> PyResult<Self> {
+        let queue = py
+            .detach(|| SQLite3TrialQueue::new(db_path, namespace))
+            .map_err(|error| {
+                PyRuntimeError::new_err(format!(
+                    "Failed to create SQLite3TrialQueue: {}",
+                    error.reason
+                ))
+            })?;
         Ok(Self {
             queue: Arc::new(RwLock::new(queue)),
         })
     }
 
-    fn enqueue(&self, trial_id: u32) -> PyResult<()> {
-        let mut guard = self.queue.write().map_err(|error| {
-            PyRuntimeError::new_err(format!("Failed to acquire trial queue lock: {error}"))
-        })?;
-        guard.enqueue(trial_id).map_err(err_to_exceptions)
+    fn enqueue(&self, py: Python<'_>, trial_id: u32) -> PyResult<()> {
+        py.detach(|| {
+            let mut guard = self.queue.write().map_err(|error| {
+                PyRuntimeError::new_err(format!("Failed to acquire trial queue lock: {error}"))
+            })?;
+            guard.enqueue(trial_id).map_err(err_to_exceptions)
+        })
     }
 
-    fn dequeue(&self) -> PyResult<Option<u32>> {
-        let mut guard = self.queue.write().map_err(|error| {
-            PyRuntimeError::new_err(format!("Failed to acquire trial queue lock: {error}"))
-        })?;
-        match guard.dequeue() {
-            Ok(trial_id) => Ok(Some(trial_id)),
-            Err(error) if matches!(error.kind, ErrorKind::TrialQueueEmpty) => Ok(None),
-            Err(error) => Err(err_to_exceptions(error)),
-        }
+    fn dequeue(&self, py: Python<'_>) -> PyResult<Option<u32>> {
+        py.detach(|| {
+            let mut guard = self.queue.write().map_err(|error| {
+                PyRuntimeError::new_err(format!("Failed to acquire trial queue lock: {error}"))
+            })?;
+            match guard.dequeue() {
+                Ok(trial_id) => Ok(Some(trial_id)),
+                Err(error) if matches!(error.kind, ErrorKind::TrialQueueEmpty) => Ok(None),
+                Err(error) => Err(err_to_exceptions(error)),
+            }
+        })
     }
 }


### PR DESCRIPTION
Call `py.detach()` to release the GIL while calling the TrialQueue methods.

See https://pyo3.rs/main/parallelism.html#parallelism-under-the-python-gil