### PR TITLE
Rename Python sampler and trial queue adapters to ToRust

### DIFF
--- a/rustuna_pyo3/src/sampler/mod.rs
+++ b/rustuna_pyo3/src/sampler/mod.rs
@@ -13,8 +13,8 @@ use crate::storage::to_rust::PyToRustStorage;
 pub mod cmaes;
 mod context;
 pub mod nsgaii;
-pub mod python;
 pub mod random;
+pub mod to_rust;
 pub mod tpe;
 pub use context::PySamplerContext;
 

--- a/rustuna_pyo3/src/sampler/to_rust.rs
+++ b/rustuna_pyo3/src/sampler/to_rust.rs
@@ -14,15 +14,18 @@ use crate::sampler::PySamplerContext;
 use crate::storage::to_python::ToPythonStorage;
 use crate::trial::PyTrialState;
 
-pub struct PythonSamplerAdapter {
+// ToRustSampler adapts a Python object implementing rustuna.SamplerProtocol to
+// rustuna_core::sampler::Sampler. Rustuna can therefore use Python samplers through the same
+// interface as native Rust samplers.
+pub struct ToRustSampler {
     obj: Py<PyAny>,
 }
-impl PythonSamplerAdapter {
+impl ToRustSampler {
     pub fn new(obj: Py<PyAny>) -> Self {
-        PythonSamplerAdapter { obj }
+        ToRustSampler { obj }
     }
 }
-impl Sampler for PythonSamplerAdapter {
+impl Sampler for ToRustSampler {
     fn sample_independent(
         &mut self,
         ctx: &SamplerContext,

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -21,8 +21,8 @@ use crate::attrs::{convert_pydict_to_fixed_params, pyobj_to_attrs_with_kind, Att
 use crate::exception::err_to_exceptions;
 use crate::sampler::cmaes::PyCmaEsSampler;
 use crate::sampler::nsgaii::PyNSGAIISampler;
-use crate::sampler::python::PythonSamplerAdapter;
 use crate::sampler::random::PyRandomSampler;
+use crate::sampler::to_rust::ToRustSampler;
 use crate::sampler::tpe::PyTpeSampler;
 use crate::storage::in_memory::PyInMemoryStorage;
 use crate::storage::journal::PyJournalFileStorage;
@@ -31,8 +31,8 @@ use crate::storage::to_rust::ToRustStorage;
 use crate::trial::{PyPersistedTrial, PyTrial, PyTrialState};
 use crate::trial_queue::directory::PyDirectoryTrialQueue;
 use crate::trial_queue::inmemory::PyInMemoryTrialQueue;
-use crate::trial_queue::python::PythonTrialQueueAdapter;
 use crate::trial_queue::sqlite3::PySQLite3TrialQueue;
+use crate::trial_queue::to_rust::ToRustTrialQueue;
 
 type SharedStorage = Arc<RwLock<dyn Storage>>;
 type SharedSampler = Arc<Mutex<dyn Sampler>>;
@@ -139,7 +139,7 @@ fn into_trial_queue_pyobj(
                     trial_queue.clone_ref(py),
                 ))
             } else {
-                let queue: SharedTrialQueue = Arc::new(RwLock::new(PythonTrialQueueAdapter::new(
+                let queue: SharedTrialQueue = Arc::new(RwLock::new(ToRustTrialQueue::new(
                     trial_queue.clone_ref(py),
                 )));
                 Ok((queue, trial_queue.clone_ref(py)))
@@ -204,7 +204,7 @@ fn resolve_sampler_pyobj(
     } else if let Ok(py_random_sampler) = sampler_ref.extract::<PyRandomSampler>() {
         Ok((py_random_sampler.sampler.clone(), sampler_pyobj))
     } else {
-        let sampler: SharedSampler = Arc::new(Mutex::new(PythonSamplerAdapter::new(sampler)));
+        let sampler: SharedSampler = Arc::new(Mutex::new(ToRustSampler::new(sampler)));
         Ok((sampler, sampler_pyobj))
     }
 }

--- a/rustuna_pyo3/src/trial_queue/mod.rs
+++ b/rustuna_pyo3/src/trial_queue/mod.rs
@@ -1,4 +1,4 @@
 pub mod directory;
 pub mod inmemory;
-pub mod python;
 pub mod sqlite3;
+pub mod to_rust;

--- a/rustuna_pyo3/src/trial_queue/to_rust.rs
+++ b/rustuna_pyo3/src/trial_queue/to_rust.rs
@@ -2,11 +2,14 @@ use pyo3::prelude::*;
 use rustuna_core::trial_queue::TrialQueue;
 use rustuna_core::{Error, ErrorKind, Result};
 
-pub struct PythonTrialQueueAdapter {
+// ToRustTrialQueue adapts a Python object implementing rustuna.TrialQueueProtocol to
+// rustuna_core::trial_queue::TrialQueue. Rustuna can therefore use Python trial queues through the
+// same interface as native queues.
+pub struct ToRustTrialQueue {
     obj: Py<PyAny>,
 }
 
-impl PythonTrialQueueAdapter {
+impl ToRustTrialQueue {
     pub fn new(obj: Py<PyAny>) -> Self {
         Self { obj }
     }
@@ -21,7 +24,7 @@ impl PythonTrialQueueAdapter {
     }
 }
 
-impl TrialQueue for PythonTrialQueueAdapter {
+impl TrialQueue for ToRustTrialQueue {
     fn enqueue(&mut self, trial_id: u32) -> Result<()> {
         Python::attach(|py| {
             self.obj


### PR DESCRIPTION
## Summary

- Rename `PythonSamplerAdapter` to `ToRustSampler`
- Rename `PythonTrialQueueAdapter` to `ToRustTrialQueue`
- Move the implementations to `sampler/to_rust.rs` and `trial_queue/to_rust.rs`
- Document that the adapters accept objects implementing `rustuna.SamplerProtocol` and `rustuna.TrialQueueProtocol`

## Motivation

Align the adapter names with `ToRustStorage` and make the conversion direction explicit: these adapters convert Python protocol implementations into Rust trait implementations.