### PR TITLE
Release the GIL while sampler access

### DIFF
--- a/rustuna_pyo3/src/sampler/nsgaii.rs
+++ b/rustuna_pyo3/src/sampler/nsgaii.rs
@@ -52,62 +52,68 @@ impl PyNSGAIISampler {
     }
 
     #[getter]
-    fn support_joint_sampling(&self) -> PyResult<bool> {
-        let guard = self
-            .sampler
-            .lock()
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to acquire sampler lock: {e}")))?;
-        Ok(guard.support_joint_sampling())
+    fn support_joint_sampling(&self, py: Python<'_>) -> PyResult<bool> {
+        py.detach(|| {
+            let guard = self.sampler.lock().map_err(|e| {
+                PyRuntimeError::new_err(format!("Failed to acquire sampler lock: {e}"))
+            })?;
+            Ok(guard.support_joint_sampling())
+        })
     }
 
     fn sample_independent(
         &self,
+        py: Python<'_>,
         ctx: &PySamplerContext,
         storage: Py<PyAny>,
         name: &str,
         distribution: &PyDistribution,
     ) -> PyResult<f64> {
         let arc_storage = extract_storage(storage)?;
-        self.sampler
-            .lock()
-            .map_err(|e| {
-                PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-            })?
-            .sample_independent(
-                &ctx.context.clone(),
-                arc_storage,
-                name,
-                &distribution.distribution,
-            )
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to sample independent: {e:?}")))
+        let context = ctx.context.clone();
+        let name = name.to_owned();
+        let distribution = distribution.distribution.clone();
+        py.detach(|| {
+            self.sampler
+                .lock()
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
+                })?
+                .sample_independent(&context, arc_storage, &name, &distribution)
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to sample independent: {e:?}"))
+                })
+        })
     }
 
     fn sample_joint(
         &self,
+        py: Python<'_>,
         ctx: &PySamplerContext,
         storage: Py<PyAny>,
         search_space: HashMap<String, PyDistribution>,
     ) -> PyResult<HashMap<String, f64>> {
         let arc_storage = extract_storage(storage)?;
-        self.sampler
-            .lock()
-            .map_err(|e| {
-                PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-            })?
-            .sample_joint(
-                &ctx.context.clone(),
-                arc_storage,
-                &search_space
-                    .into_iter()
-                    .map(|(k, v)| (k, v.distribution))
-                    .collect(),
-            )
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to sample joint: {e:?}")))
+        let context = ctx.context.clone();
+        let search_space = search_space
+            .into_iter()
+            .map(|(k, v)| (k, v.distribution))
+            .collect();
+        py.detach(|| {
+            self.sampler
+                .lock()
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
+                })?
+                .sample_joint(&context, arc_storage, &search_space)
+                .map_err(|e| PyRuntimeError::new_err(format!("Failed to sample joint: {e:?}")))
+        })
     }
 
     #[pyo3(signature = (ctx, storage, state, values = None))]
     fn after_trial(
         &self,
+        py: Python<'_>,
         ctx: &PySamplerContext,
         storage: Py<PyAny>,
         state: PyTrialState,
@@ -123,12 +129,15 @@ impl PyNSGAIISampler {
             PyTrialState::WAITING => TrialStateValues::Waiting,
             PyTrialState::FAIL => TrialStateValues::Fail,
         };
-        self.sampler
-            .lock()
-            .map_err(|e| {
-                PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-            })?
-            .after_trial(&ctx.context, arc_storage, &state_values)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to call after_trial: {e:?}")))
+        let context = ctx.context.clone();
+        py.detach(|| {
+            self.sampler
+                .lock()
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
+                })?
+                .after_trial(&context, arc_storage, &state_values)
+                .map_err(|e| PyRuntimeError::new_err(format!("Failed to call after_trial: {e:?}")))
+        })
     }
 }

--- a/rustuna_pyo3/src/sampler/random.rs
+++ b/rustuna_pyo3/src/sampler/random.rs
@@ -37,19 +37,27 @@ impl PyRandomSampler {
 
     fn sample_independent(
         &self,
+        py: Python<'_>,
         ctx: &PySamplerContext,
         storage: Py<PyAny>,
         name: &str,
         distribution: &PyDistribution,
     ) -> PyResult<f64> {
         let arc_storage = extract_storage(storage)?;
-        self.sampler
-            .lock()
-            .map_err(|e| {
-                PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-            })?
-            .sample_independent(&ctx.context, arc_storage, name, &distribution.distribution)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to sample independent: {e:?}")))
+        let context = ctx.context.clone();
+        let name = name.to_owned();
+        let distribution = distribution.distribution.clone();
+        py.detach(|| {
+            self.sampler
+                .lock()
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
+                })?
+                .sample_independent(&context, arc_storage, &name, &distribution)
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to sample independent: {e:?}"))
+                })
+        })
     }
 
     fn sample_joint(

--- a/rustuna_pyo3/src/sampler/tpe.rs
+++ b/rustuna_pyo3/src/sampler/tpe.rs
@@ -35,62 +35,68 @@ impl PyTpeSampler {
     }
 
     #[getter]
-    fn support_joint_sampling(&self) -> PyResult<bool> {
-        let guard = self
-            .sampler
-            .lock()
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to acquire sampler lock: {e}")))?;
-        Ok(guard.support_joint_sampling())
+    fn support_joint_sampling(&self, py: Python<'_>) -> PyResult<bool> {
+        py.detach(|| {
+            let guard = self.sampler.lock().map_err(|e| {
+                PyRuntimeError::new_err(format!("Failed to acquire sampler lock: {e}"))
+            })?;
+            Ok(guard.support_joint_sampling())
+        })
     }
 
     fn sample_independent(
         &self,
+        py: Python<'_>,
         ctx: &PySamplerContext,
         storage: Py<PyAny>,
         name: &str,
         distribution: &PyDistribution,
     ) -> PyResult<f64> {
         let arc_storage = extract_storage(storage)?;
-        self.sampler
-            .lock()
-            .map_err(|e| {
-                PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-            })?
-            .sample_independent(
-                &ctx.context.clone(),
-                arc_storage,
-                name,
-                &distribution.distribution,
-            )
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to sample independent: {e:?}")))
+        let context = ctx.context.clone();
+        let name = name.to_owned();
+        let distribution = distribution.distribution.clone();
+        py.detach(|| {
+            self.sampler
+                .lock()
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
+                })?
+                .sample_independent(&context, arc_storage, &name, &distribution)
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to sample independent: {e:?}"))
+                })
+        })
     }
 
     fn sample_joint(
         &self,
+        py: Python<'_>,
         ctx: &PySamplerContext,
         storage: Py<PyAny>,
         search_space: HashMap<String, PyDistribution>,
     ) -> PyResult<HashMap<String, f64>> {
         let arc_storage = extract_storage(storage)?;
-        self.sampler
-            .lock()
-            .map_err(|e| {
-                PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-            })?
-            .sample_joint(
-                &ctx.context.clone(),
-                arc_storage,
-                &search_space
-                    .into_iter()
-                    .map(|(k, v)| (k, v.distribution))
-                    .collect(),
-            )
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to sample joint: {e:?}")))
+        let context = ctx.context.clone();
+        let search_space = search_space
+            .into_iter()
+            .map(|(k, v)| (k, v.distribution))
+            .collect();
+        py.detach(|| {
+            self.sampler
+                .lock()
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
+                })?
+                .sample_joint(&context, arc_storage, &search_space)
+                .map_err(|e| PyRuntimeError::new_err(format!("Failed to sample joint: {e:?}")))
+        })
     }
 
     #[pyo3(signature = (ctx, storage, state, values = None))]
     fn after_trial(
         &self,
+        py: Python<'_>,
         ctx: &PySamplerContext,
         storage: Py<PyAny>,
         state: PyTrialState,
@@ -106,12 +112,15 @@ impl PyTpeSampler {
             PyTrialState::WAITING => TrialStateValues::Waiting,
             PyTrialState::FAIL => TrialStateValues::Fail,
         };
-        self.sampler
-            .lock()
-            .map_err(|e| {
-                PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-            })?
-            .after_trial(&ctx.context, arc_storage, &state_values)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to call after_trial: {e:?}")))
+        let context = ctx.context.clone();
+        py.detach(|| {
+            self.sampler
+                .lock()
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
+                })?
+                .after_trial(&context, arc_storage, &state_values)
+                .map_err(|e| PyRuntimeError::new_err(format!("Failed to call after_trial: {e:?}")))
+        })
     }
 }


### PR DESCRIPTION
Call `py.detach()` to release the GIL while calling the Sampler methods.

See https://pyo3.rs/main/parallelism.html#parallelism-under-the-python-gil