### PR TITLE
Rename `load_discarded_trials` to `apply_discard`

### DIFF
--- a/rustuna_core/src/storage.rs
+++ b/rustuna_core/src/storage.rs
@@ -153,6 +153,12 @@ pub trait Storage: Send + Sync {
     fn may_omit_trials(&self) -> bool;
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+/// Options for [`InMemoryStorage`].
+pub struct InMemoryStorageOptions {
+    pub apply_discard: bool,
+}
+
 /// In-memory storage implementation used by default in Rust code and tests.
 ///
 /// This implementation keeps all studies, trials, and caches in process memory.
@@ -164,6 +170,7 @@ pub struct InMemoryStorage {
     study_caches: HashMap<u32, StudyCache>,
     next_study_id: u32,
     next_trial_id: u32,
+    option: InMemoryStorageOptions,
 }
 impl InMemoryStorage {
     /// Creates an empty in-memory storage.
@@ -175,6 +182,20 @@ impl InMemoryStorage {
             study_caches: HashMap::new(),
             next_study_id: 0,
             next_trial_id: 0,
+            option: InMemoryStorageOptions::default(),
+        }
+    }
+
+    /// Creates an empty in-memory storage.
+    pub fn new_with_option(option: InMemoryStorageOptions) -> InMemoryStorage {
+        InMemoryStorage {
+            studies: vec![],
+            trials: HashMap::new(),
+            trial_id_to_study_number: HashMap::new(),
+            study_caches: HashMap::new(),
+            next_study_id: 0,
+            next_trial_id: 0,
+            option,
         }
     }
 
@@ -532,6 +553,9 @@ impl Storage for InMemoryStorage {
     }
 
     fn discard_trials(&mut self, trial_ids: &[u32]) -> Result<()> {
+        if !self.option.apply_discard {
+            return Ok(());
+        }
         for trial_id in trial_ids {
             let (study_id, trial_number) =
                 get_study_id_trial_number_by_trial_id(&self.trial_id_to_study_number, *trial_id)?;
@@ -546,9 +570,7 @@ impl Storage for InMemoryStorage {
     }
 
     fn may_omit_trials(&self) -> bool {
-        self.trials
-            .values()
-            .any(|trials| trials.iter().any(Option::is_none))
+        self.option.apply_discard
     }
 }
 
@@ -676,7 +698,9 @@ mod tests {
 
     #[test]
     fn discard_trials_omits_trials() -> Result<()> {
-        let mut storage = InMemoryStorage::new();
+        let mut storage = InMemoryStorage::new_with_option(InMemoryStorageOptions {
+            apply_discard: true,
+        });
         let study_id = storage
             .create_new_study("study", vec![Direction::Minimize])?
             .id;

--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -760,19 +760,16 @@ class ToRustStorage:
     This class wraps a Python object implementing StorageProtocol and makes it
     usable as a Rust Storage trait implementation.
 
+    Args:
+        storage: A Python object implementing StorageProtocol.
+
     Note:
         This class is not intended for direct use by end users. It is used internally
         by rustuna converters (e.g., ToOptunaSampler) to bridge Python StorageProtocol
         implementations with Rust components.
     """
 
-    def __init__(self, storage: StorageProtocol) -> None:
-        """Create a ToRustStorage from a StorageProtocol instance.
-
-        Args:
-            storage: A Python object implementing StorageProtocol.
-        """
-
+    def __init__(self, storage: StorageProtocol) -> None: ...
     def create_new_study(
         self, study_name: str, directions: list[StudyDirection]
     ) -> PersistedStudy: ...
@@ -830,8 +827,12 @@ class ToRustStorage:
     def may_omit_trials(self) -> bool: ...
 
 class InMemoryStorage:
-    """Create an in-memory storage."""
-    def __init__(self) -> None: ...
+    """Create an in-memory storage.
+
+    Args:
+        apply_discard: If True, apply discard_trials() and omit discarded trials from subsequent reads.
+    """
+    def __init__(self, *, apply_discard: bool = False) -> None: ...
     def create_new_study(
         self, study_name: str, directions: list[StudyDirection]
     ) -> PersistedStudy: ...
@@ -893,13 +894,13 @@ class JournalFileStorage:
 
     Args:
         file_path: Path to the journal log file.
-        load_discarded_trials: If True, ignore discard logs and load all trials.
+        apply_discard: If True, apply discard operations when reading the storage. Journal logs are written regardless of this option.
     """
     def __init__(
         self,
         file_path: str,
         *,
-        load_discarded_trials: bool = False,
+        apply_discard: bool = False,
     ) -> None: ...
     def create_new_study(
         self, study_name: str, directions: list[StudyDirection]

--- a/rustuna_pyo3/src/storage/in_memory.rs
+++ b/rustuna_pyo3/src/storage/in_memory.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, RwLock};
 
 use pyo3::prelude::*;
 
-use rustuna_core::storage::{InMemoryStorage, Storage};
+use rustuna_core::storage::{InMemoryStorage, InMemoryStorageOptions, Storage};
 
 use crate::distribution::PyDistribution;
 use crate::storage::binding::StorageBinding;
@@ -18,13 +18,15 @@ pub struct PyInMemoryStorage {
 
 impl Default for PyInMemoryStorage {
     fn default() -> Self {
-        Self::new()
+        Self::new(InMemoryStorageOptions::default())
     }
 }
 
 impl PyInMemoryStorage {
-    pub fn new() -> Self {
-        let binding = StorageBinding::new(Arc::new(RwLock::new(InMemoryStorage::new())));
+    pub fn new(option: InMemoryStorageOptions) -> Self {
+        let binding = StorageBinding::new(Arc::new(RwLock::new(InMemoryStorage::new_with_option(
+            option,
+        ))));
         PyInMemoryStorage { binding }
     }
 
@@ -36,8 +38,9 @@ impl PyInMemoryStorage {
 #[pymethods]
 impl PyInMemoryStorage {
     #[new]
-    fn py_new() -> Self {
-        PyInMemoryStorage::new()
+    #[pyo3(signature = (*, apply_discard = false))]
+    fn py_new(apply_discard: bool) -> Self {
+        PyInMemoryStorage::new(InMemoryStorageOptions { apply_discard })
     }
 
     fn create_new_study(

--- a/rustuna_pyo3/src/storage/journal.rs
+++ b/rustuna_pyo3/src/storage/journal.rs
@@ -28,8 +28,8 @@ impl PyJournalFileStorage {
 #[pymethods]
 impl PyJournalFileStorage {
     #[new]
-    #[pyo3(signature = (file_path, *, load_discarded_trials = false))]
-    fn py_new(file_path: &str, load_discarded_trials: bool) -> PyResult<Self> {
+    #[pyo3(signature = (file_path, *, apply_discard = false))]
+    fn py_new(file_path: &str, apply_discard: bool) -> PyResult<Self> {
         // TODO(c-bata): Add lock_obj argument to use JournalFileOpenLock.
         let lock_obj = Box::new(JournalFileSymlinkLock::new(file_path));
         let backend = JournalFileBackend::new(file_path, Some(lock_obj)).map_err(|e| {
@@ -37,9 +37,7 @@ impl PyJournalFileStorage {
         })?;
         let storage = JournalStorage::new_with_options(
             Box::new(backend),
-            JournalStorageOptions {
-                load_discarded_trials,
-            },
+            JournalStorageOptions { apply_discard },
         )
         .map_err(|e| PyRuntimeError::new_err(format!("Failed to create journal storage: {e:?}")))?;
         let binding = StorageBinding::new(Arc::new(RwLock::new(storage)));

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -181,7 +181,7 @@ fn into_storage_pyobj(
     match storage {
         Some(storage) => resolve_storage_pyobj(py, storage),
         None => {
-            let storage = PyInMemoryStorage::new();
+            let storage = PyInMemoryStorage::default();
             let storage_arc = storage.storage();
             let storage_pyobj = Py::new(py, storage)?.into_any();
             Ok((storage_arc, storage_pyobj))

--- a/rustuna_pyo3/tests/storage_tests/test_journal_storage.py
+++ b/rustuna_pyo3/tests/storage_tests/test_journal_storage.py
@@ -86,7 +86,7 @@ def test_create_new_trial_from_template_optuna_compatibility() -> None:
         assert trials[0].state == optuna.trial.TrialState.WAITING
 
 
-def test_journal_file_storage_can_load_discarded_trials() -> None:
+def test_journal_file_storage_can_apply_discard() -> None:
     with tempfile.TemporaryDirectory() as workdir:
         file_path = f"{workdir}/discarded.journal"
         storage = rustuna.storages.JournalFileStorage(file_path)
@@ -99,21 +99,19 @@ def test_journal_file_storage_can_load_discarded_trials() -> None:
 
         storage.discard_trials([first_persisted._trial_id])
 
-        default_trials = storage.get_trials(study._study_id)
-        assert [trial._trial_id for trial in default_trials] == [
-            second_persisted._trial_id
+        retained_trials = storage.get_trials(study._study_id)
+        assert [trial._trial_id for trial in retained_trials] == [
+            first_persisted._trial_id,
+            second_persisted._trial_id,
         ]
 
         analysis_storage = rustuna.storages.JournalFileStorage(
             file_path,
-            load_discarded_trials=True,
+            apply_discard=True,
         )
-        analysis_trials = analysis_storage.get_trials(study._study_id)
-        assert [trial._trial_id for trial in analysis_trials] == [
-            first_persisted._trial_id,
+        omitted_trials = analysis_storage.get_trials(study._study_id)
+        assert [trial._trial_id for trial in omitted_trials] == [
             second_persisted._trial_id,
         ]
-        assert (
-            analysis_storage.get_trial(first_persisted._trial_id)._trial_id
-            == first_persisted._trial_id
-        )
+        with pytest.raises(rustuna.exceptions.TrialDiscarded, match="Trial discarded"):
+            analysis_storage.get_trial(first_persisted._trial_id)

--- a/rustuna_storage/src/journal/storage.rs
+++ b/rustuna_storage/src/journal/storage.rs
@@ -21,8 +21,9 @@ use super::{JournalBackend, JournalLog, JournalOperation};
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 /// Options for [`JournalStorage`].
 pub struct JournalStorageOptions {
-    /// If `true`, discard logs are ignored during replay and all trials are loaded.
-    pub load_discarded_trials: bool,
+    /// If `true`, discarded trials are omitted when replaying the journal.
+    /// Discard logs are written regardless of this option.
+    pub apply_discard: bool,
 }
 
 /// Storage implementation backed by an append-only journal log.
@@ -48,7 +49,7 @@ impl JournalStorage {
         let worker_id_prefix = format!("{}-{}-", unique_prefix(), std::process::id());
         let mut storage = JournalStorage {
             backend,
-            replay: JournalReplayState::new(worker_id_prefix, options.load_discarded_trials),
+            replay: JournalReplayState::new(worker_id_prefix, options.apply_discard),
         };
         storage.sync_with_backend()?;
         Ok(storage)
@@ -735,11 +736,11 @@ struct JournalReplayState {
     last_created_trial_id_by_this_process: Option<u32>,
     studies_sorted: Vec<PersistedStudy>,
     study_caches: HashMap<u32, StudyCache>,
-    load_discarded_trials: bool,
+    apply_discard: bool,
 }
 
 impl JournalReplayState {
-    fn new(worker_id_prefix: String, load_discarded_trials: bool) -> Self {
+    fn new(worker_id_prefix: String, apply_discard: bool) -> Self {
         JournalReplayState {
             log_number_read: 0,
             worker_id_prefix,
@@ -753,7 +754,7 @@ impl JournalReplayState {
             last_created_trial_id_by_this_process: None,
             studies_sorted: Vec::new(),
             study_caches: HashMap::new(),
-            load_discarded_trials,
+            apply_discard,
         }
     }
 
@@ -785,7 +786,7 @@ impl JournalReplayState {
                     self.apply_set_trial_system_attr(log, worker_id)?
                 }
                 JournalOperation::DiscardTrials => {
-                    if !self.load_discarded_trials {
+                    if self.apply_discard {
                         self.apply_discard_trials(log, worker_id)?
                     }
                 }
@@ -2170,7 +2171,12 @@ mod tests {
         }
 
         let backend = InMemoryJournalBackend { logs: logs.clone() };
-        let mut reloaded = JournalStorage::new(Box::new(backend))?;
+        let mut reloaded = JournalStorage::new_with_options(
+            Box::new(backend),
+            JournalStorageOptions {
+                apply_discard: true,
+            },
+        )?;
         let trials = reloaded.get_trials(study_id)?;
         assert!(trials[0].is_none());
         Ok(())
@@ -2278,7 +2284,7 @@ mod tests {
     }
 
     #[test]
-    fn load_discarded_trials_ignores_discard_logs() -> Result<()> {
+    fn apply_discard_false_keeps_discarded_trials() -> Result<()> {
         let (mut storage, logs) = new_storage()?;
         let study_id = storage.create_new_study("s", vec![Direction::Minimize])?.id;
         let trial_id = storage.create_new_trial(study_id)?.id;
@@ -2288,7 +2294,7 @@ mod tests {
         let mut storage2 = JournalStorage::new_with_options(
             Box::new(backend),
             JournalStorageOptions {
-                load_discarded_trials: true,
+                apply_discard: false,
             },
         )?;
         let trials = storage2.get_trials(study_id)?;


### PR DESCRIPTION
## Summary

Rename the discard-related storage options to `omit_discarded_trials`.

## Changes

- Rename `load_discarded_trials` to `omit_discarded_trials` for `JournalFileStorage`.
- Introduce `omit_discarded_trials` in `InMemoryStorage`.
- Use `omit_discarded_trials=False` as the default.
