### PR TITLE
Make JournalStorage attributes distinct from Optuna’s schema

### DIFF
--- a/rustuna_pyo3/tests/storage_tests/test_journal_storage.py
+++ b/rustuna_pyo3/tests/storage_tests/test_journal_storage.py
@@ -147,9 +147,7 @@ def test_rustuna_journal_attrs_are_optuna_replayable() -> None:
 
         study_system_log = next(log for log in logs if log["op_code"] == 3)
         assert study_system_log["system_attr"] == {"rustuna": None}
-        assert study_system_log["system_attr_str"] == {
-            "study_system": "study value"
-        }
+        assert study_system_log["system_attr_str"] == {"study_system": "study value"}
 
         trial_user_log = next(log for log in logs if log["op_code"] == 8)
         assert trial_user_log["user_attr"] == {"rustuna": None}
@@ -157,9 +155,7 @@ def test_rustuna_journal_attrs_are_optuna_replayable() -> None:
 
         trial_system_log = next(log for log in logs if log["op_code"] == 9)
         assert trial_system_log["system_attr"] == {"rustuna": None}
-        assert trial_system_log["system_attr_str"] == {
-            "trial_system": "trial value"
-        }
+        assert trial_system_log["system_attr_str"] == {"trial_system": "trial value"}
 
         optuna_storage = JournalStorage(JournalFileBackend(file_path))
         optuna_study = optuna.load_study(

--- a/rustuna_pyo3/tests/storage_tests/test_journal_storage.py
+++ b/rustuna_pyo3/tests/storage_tests/test_journal_storage.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import os
 import tempfile
 
 import optuna
@@ -115,3 +117,57 @@ def test_journal_file_storage_can_apply_discard() -> None:
         ]
         with pytest.raises(rustuna.exceptions.TrialDiscarded, match="Trial discarded"):
             analysis_storage.get_trial(first_persisted._trial_id)
+
+
+def test_rustuna_journal_attrs_are_optuna_replayable() -> None:
+    with tempfile.TemporaryDirectory() as workdir:
+        file_path = os.path.join(workdir, "attrs.journal")
+        rustuna_storage = rustuna.storages.JournalFileStorage(file_path)
+        rustuna_study = rustuna.create_study(
+            storage=rustuna_storage, study_name="journal-attrs"
+        )
+        rustuna_study.set_user_attr("study_user", "study value")
+        rustuna_storage.set_study_system_attrs(
+            rustuna_study._study_id, {"study_system": "study value"}
+        )
+
+        trial = rustuna_study.ask()
+        trial.set_user_attr("trial_user", "trial value")
+        rustuna_storage.set_trial_system_attrs(
+            trial._trial_id, {"trial_system": "trial value"}
+        )
+        rustuna_study.tell(trial.number, 1.0)
+
+        with open(file_path) as f:
+            logs = [json.loads(line) for line in f]
+
+        study_user_log = next(log for log in logs if log["op_code"] == 2)
+        assert study_user_log["user_attr"] == {"rustuna": None}
+        assert study_user_log["user_attr_str"] == {"study_user": "study value"}
+
+        study_system_log = next(log for log in logs if log["op_code"] == 3)
+        assert study_system_log["system_attr"] == {"rustuna": None}
+        assert study_system_log["system_attr_str"] == {
+            "study_system": "study value"
+        }
+
+        trial_user_log = next(log for log in logs if log["op_code"] == 8)
+        assert trial_user_log["user_attr"] == {"rustuna": None}
+        assert trial_user_log["user_attr_str"] == {"trial_user": "trial value"}
+
+        trial_system_log = next(log for log in logs if log["op_code"] == 9)
+        assert trial_system_log["system_attr"] == {"rustuna": None}
+        assert trial_system_log["system_attr_str"] == {
+            "trial_system": "trial value"
+        }
+
+        optuna_storage = JournalStorage(JournalFileBackend(file_path))
+        optuna_study = optuna.load_study(
+            storage=optuna_storage, study_name="journal-attrs"
+        )
+        assert optuna_study.user_attrs == {"rustuna": None}
+        assert optuna_storage.get_study_system_attrs(optuna_study._study_id) == {
+            "rustuna": None
+        }
+        assert optuna_study.trials[0].user_attrs == {"rustuna": None}
+        assert optuna_study.trials[0].system_attrs == {"rustuna": None}

--- a/rustuna_pyo3/tests/storage_tests/test_schema_compatibility.py
+++ b/rustuna_pyo3/tests/storage_tests/test_schema_compatibility.py
@@ -1,7 +1,29 @@
+"""Test compatibility between Optuna's and Rustuna's storage schemas.
+
+## Schema Differences between Optuna's JournalStorage and Rustuna's JournalStorage
+
+Optuna's JournalStorage serializes attribute values as JSON before writing them to
+the journal.  Consequently, a string value is JSON-encoded a second time in the
+journal record.  Rustuna's Storage API accepts only string attributes, so Rustuna
+stores its attribute maps directly and does not apply this extra JSON encoding.
+Supporting both representations in both directions would not provide complete
+compatibility, because Optuna can also write non-string values such as integers and
+floats.  Rustuna therefore intentionally does not import Optuna's typed user and
+system attribute values.
+
+Rustuna writes string attributes to the Rustuna-specific ``user_attr_str`` and
+``system_attr_str`` fields.  It also writes ``{"rustuna": null}`` to Optuna's
+``user_attr`` or ``system_attr`` field.  The dummy value is required by Optuna's
+journal replay code, while the Rustuna-specific fields are ignored by Optuna.  This
+allows Optuna to replay a Rustuna journal without claiming that the attribute values
+are fully interoperable.  The same rule applies to study and trial attributes.
+"""
+
 from __future__ import annotations
 
 import os.path
 import tempfile
+import typing
 
 import optuna
 import pytest
@@ -12,10 +34,167 @@ import rustuna
 from rustuna.converter import ToOptunaStorage, ToRustunaStorage
 
 
-def _objective(trial: optuna.Trial | rustuna.Trial) -> float:
-    x = trial.suggest_float("x", 1.0, 10.0, log=True)
-    trial.set_user_attr("json", '{"a": 1}')
-    return x
+class Suite(typing.Protocol):
+    directions: list[typing.Literal["minimize", "maximize"]]
+
+    def objective(
+        self, trial: optuna.Trial | rustuna.Trial
+    ) -> float | tuple[float, float]: ...
+
+    def assert_trials(
+        self,
+        trials: list[optuna.trial.FrozenTrial] | list[rustuna.trial.PersistedTrial],
+    ) -> None: ...
+
+
+class SuiteAttr:
+    directions = ["minimize"]
+
+    def objective(self, trial: optuna.Trial | rustuna.Trial) -> float:
+        if isinstance(trial, optuna.Trial):
+            trial.set_user_attr("optuna", {"a": 1})
+            trial.storage.set_trial_system_attr(trial._trial_id, "optuna", {"b": 2})
+        else:
+            trial.set_user_attrs({"rustuna": "foo"})
+            trial.storage.set_trial_system_attrs(trial._trial_id, {"rustuna": "bar"})
+        return 1.0
+
+    def assert_trials(
+        self,
+        trials: list[optuna.trial.FrozenTrial] | list[rustuna.trial.PersistedTrial],
+    ) -> None:
+        assert len(trials) == 20
+        for trial in trials[-10:]:
+            if isinstance(trial, optuna.trial.FrozenTrial):
+                assert trial.user_attrs["optuna"] == {"a": 1}
+                assert trial.system_attrs["optuna"] == {"b": 2}
+            elif "optuna_attr:rustuna" in trial.user_attrs:
+                assert trial.user_attrs["optuna_attr:rustuna"] == '"foo"'
+                assert trial.system_attrs["optuna_attr:rustuna"] == '"bar"'
+            else:
+                assert trial.user_attrs["rustuna"] == "foo"
+                assert trial.system_attrs["rustuna"] == "bar"
+
+
+class SuiteSingleObjective:
+    directions = ["minimize"]
+
+    def objective(self, trial: optuna.Trial | rustuna.Trial) -> float:
+        return trial.suggest_float("x", 1.0, 10.0, log=True)
+
+    def assert_trials(
+        self,
+        trials: list[optuna.trial.FrozenTrial] | list[rustuna.trial.PersistedTrial],
+    ) -> None:
+        assert len(trials) == 20
+        for trial in trials:
+            assert trial.state == (
+                optuna.trial.TrialState.COMPLETE
+                if isinstance(trial, optuna.trial.FrozenTrial)
+                else rustuna.trial.TrialState.COMPLETE
+            )
+            assert set(trial.params) == {"x"}
+            assert set(trial.distributions) == {"x"}
+            x = trial.params["x"]
+            assert isinstance(x, (int, float))
+            assert 1.0 <= x <= 10.0
+            assert trial.values == [x]
+
+
+class TestSuiteParam:
+    directions = ["minimize"]
+
+    def objective(self, trial: optuna.Trial | rustuna.Trial) -> float:
+        x = trial.suggest_float("x", 1.0, 10.0, log=True)
+        trial.suggest_int("y", 0, 10, step=2)
+        trial.suggest_categorical("z", [0, 1])
+        return x
+
+    def assert_trials(
+        self,
+        trials: list[optuna.trial.FrozenTrial] | list[rustuna.trial.PersistedTrial],
+    ) -> None:
+        assert len(trials) == 20
+        for trial in trials:
+            assert trial.state == (
+                optuna.trial.TrialState.COMPLETE
+                if isinstance(trial, optuna.trial.FrozenTrial)
+                else rustuna.trial.TrialState.COMPLETE
+            )
+            assert set(trial.params) == {"x", "y", "z"}
+            assert set(trial.distributions) == {"x", "y", "z"}
+            x = trial.params["x"]
+            y = trial.params["y"]
+            assert isinstance(x, (int, float))
+            assert isinstance(y, int)
+            assert 1.0 <= x <= 10.0
+            assert y in {0, 2, 4, 6, 8, 10}
+            assert trial.params["z"] in {0, 1}
+            assert trial.values == [x]
+
+
+class TestSuiteMultiObjective:
+    directions = ["minimize", "maximize"]
+
+    def objective(self, trial: optuna.Trial | rustuna.Trial) -> tuple[float, float]:
+        x = trial.suggest_float("x", 1.0, 10.0, log=True)
+        y = trial.suggest_float("y", 0.0, 1.0)
+        return x, y
+
+    def assert_trials(
+        self,
+        trials: list[optuna.trial.FrozenTrial] | list[rustuna.trial.PersistedTrial],
+    ) -> None:
+        assert len(trials) == 20
+        for trial in trials:
+            assert trial.state == (
+                optuna.trial.TrialState.COMPLETE
+                if isinstance(trial, optuna.trial.FrozenTrial)
+                else rustuna.trial.TrialState.COMPLETE
+            )
+            assert set(trial.params) == {"x", "y"}
+            assert set(trial.distributions) == {"x", "y"}
+            x = trial.params["x"]
+            y = trial.params["y"]
+            assert isinstance(x, (int, float))
+            assert isinstance(y, (int, float))
+            assert 1.0 <= x <= 10.0
+            assert 0.0 <= y <= 1.0
+            assert trial.values is not None
+            assert len(trial.values) == 2
+            assert trial.values[0] == x
+            assert trial.values[1] == y
+
+
+parametrize_test_suite = pytest.mark.parametrize(
+    "suite",
+    [
+        pytest.param(SuiteAttr(), id="attrs"),
+        pytest.param(SuiteSingleObjective(), id="single_objective"),
+        pytest.param(TestSuiteParam(), id="params"),
+        pytest.param(TestSuiteMultiObjective(), id="multi_objective"),
+    ],
+)
+
+
+def assert_optuna_directions(
+    directions: list[optuna.study.StudyDirection], suite: Suite
+) -> None:
+    expected = {
+        "minimize": optuna.study.StudyDirection.MINIMIZE,
+        "maximize": optuna.study.StudyDirection.MAXIMIZE,
+    }
+    assert directions == [expected[direction] for direction in suite.directions]
+
+
+def assert_rustuna_directions(
+    directions: list[rustuna.study.StudyDirection], suite: Suite
+) -> None:
+    expected = {
+        "minimize": rustuna.study.StudyDirection.MINIMIZE,
+        "maximize": rustuna.study.StudyDirection.MAXIMIZE,
+    }
+    assert directions == [expected[direction] for direction in suite.directions]
 
 
 def get_optuna_storage(backend: str, base_dir: str) -> optuna.storages.BaseStorage:
@@ -42,6 +221,7 @@ def get_rustuna_storage(
     raise ValueError(f"Unknown backend: {backend}")
 
 
+@parametrize_test_suite
 @pytest.mark.parametrize("backend", ["journal", "sqlite3"])
 @pytest.mark.parametrize(
     "first_variant,second_variant",
@@ -51,8 +231,16 @@ def get_rustuna_storage(
     ],
 )
 def test_optuna_api_resume_with_compat_storage(
-    backend: str, first_variant: str, second_variant: str
+    suite: Suite, backend: str, first_variant: str, second_variant: str
 ) -> None:
+    if (
+        backend == "sqlite3"
+        and isinstance(suite, (SuiteAttr, TestSuiteParam))
+        and first_variant == "via_to_optuna"
+        and second_variant == "direct"
+    ):
+        pytest.skip("Optuna cannot directly read Rustuna's SQLite3 schema.")
+
     study_name = "compat-optuna"
     with tempfile.TemporaryDirectory() as workdir:
         # Start optimization via Optuna API
@@ -65,8 +253,14 @@ def test_optuna_api_resume_with_compat_storage(
         else:
             raise ValueError(f"Unknown optuna variant: {first_variant}")
 
-        first_study = optuna.create_study(storage=first_storage, study_name=study_name)
-        first_study.optimize(_objective, n_trials=10)
+        first_study = optuna.create_study(
+            storage=first_storage,
+            study_name=study_name,
+            directions=suite.directions,
+            sampler=optuna.samplers.RandomSampler(),
+        )
+        assert_optuna_directions(first_study.directions, suite)
+        first_study.optimize(suite.objective, n_trials=10)
 
         # Resume optimization via Optuna API
         if second_variant == "direct":
@@ -78,12 +272,18 @@ def test_optuna_api_resume_with_compat_storage(
         else:
             raise ValueError(f"Unknown optuna variant: {second_variant}")
 
-        second_study = optuna.load_study(storage=second_storage, study_name=study_name)
-        second_study.optimize(_objective, n_trials=10)
+        second_study = optuna.load_study(
+            storage=second_storage,
+            study_name=study_name,
+            sampler=optuna.samplers.RandomSampler(),
+        )
+        assert_optuna_directions(second_study.directions, suite)
+        second_study.optimize(suite.objective, n_trials=10)
 
-        assert len(first_study.trials) == len(second_study.trials) == 20
+        suite.assert_trials(second_study.trials)
 
 
+@parametrize_test_suite
 @pytest.mark.parametrize("backend", ["journal", "sqlite3"])
 @pytest.mark.parametrize(
     "first_variant,second_variant",
@@ -93,8 +293,16 @@ def test_optuna_api_resume_with_compat_storage(
     ],
 )
 def test_rustuna_api_resume_with_compat_storage(
-    backend: str, first_variant: str, second_variant: str
+    suite: Suite, backend: str, first_variant: str, second_variant: str
 ) -> None:
+    if (
+        backend == "sqlite3"
+        and isinstance(suite, (SuiteAttr, TestSuiteParam))
+        and first_variant == "direct"
+        and second_variant == "via_to_rustuna"
+    ):
+        pytest.skip("ToRustunaStorage cannot read Rustuna's raw SQLite3 attributes.")
+
     study_name = "compat-rustuna"
     with tempfile.TemporaryDirectory() as workdir:
         # Start optimization via Rustuna API
@@ -106,8 +314,14 @@ def test_rustuna_api_resume_with_compat_storage(
         else:
             raise ValueError(f"Unknown rustuna variant: {first_variant}")
 
-        first_study = rustuna.create_study(storage=first_storage, study_name=study_name)
-        first_study.optimize(_objective, n_trials=10)
+        first_study = rustuna.create_study(
+            storage=first_storage,
+            study_name=study_name,
+            directions=suite.directions,
+            sampler=rustuna.samplers.RandomSampler(),
+        )
+        assert_rustuna_directions(first_study.directions, suite)
+        first_study.optimize(suite.objective, n_trials=10)
 
         # Resume optimization via Rustuna API
         second_storage: rustuna.storages.StorageProtocol
@@ -120,49 +334,85 @@ def test_rustuna_api_resume_with_compat_storage(
         else:
             raise ValueError(f"Unknown rustuna variant: {second_variant}")
 
-        second_study = rustuna.load_study(storage=second_storage, study_name=study_name)
-        second_study.optimize(_objective, n_trials=10)
-
-        # TODO: Uncomment following line to align Rustuna Study to Optuna behavior.
-        # assert len(first_study.trials) == len(second_study.trials) == 20
-        assert (
-            len(first_storage.get_trials(study_id=first_study._study_id))
-            == len(second_storage.get_trials(study_id=first_study._study_id))
-            == 20
+        second_study = rustuna.load_study(
+            storage=second_storage,
+            study_name=study_name,
+            sampler=rustuna.samplers.RandomSampler(),
         )
+        assert_rustuna_directions(second_study.directions, suite)
+        second_study.optimize(suite.objective, n_trials=10)
+
+        observed_study = rustuna.load_study(
+            storage=second_storage,
+            study_name=study_name,
+            sampler=rustuna.samplers.RandomSampler(),
+        )
+        assert_rustuna_directions(observed_study.directions, suite)
+        suite.assert_trials(observed_study.trials)
 
 
+@parametrize_test_suite
 @pytest.mark.parametrize("backend", ["journal", "sqlite3"])
-def test_optuna_to_rustuna_resume(backend: str) -> None:
+def test_optuna_to_rustuna_resume(suite: Suite, backend: str) -> None:
     study_name = "compat-optuna-to-rustuna"
     with tempfile.TemporaryDirectory() as workdir:
         optuna_storage = get_optuna_storage(backend, workdir)
         optuna_study = optuna.create_study(
-            storage=optuna_storage, study_name=study_name
+            storage=optuna_storage,
+            study_name=study_name,
+            directions=suite.directions,
+            sampler=optuna.samplers.RandomSampler(),
         )
-        optuna_study.optimize(_objective, n_trials=10)
+        assert_optuna_directions(optuna_study.directions, suite)
+        optuna_study.optimize(suite.objective, n_trials=10)
 
         rustuna_storage = get_rustuna_storage(backend, workdir, create_database=False)
         rustuna_study = rustuna.load_study(
-            storage=rustuna_storage, study_name=study_name
+            storage=rustuna_storage,
+            study_name=study_name,
+            sampler=rustuna.samplers.RandomSampler(),
         )
-        rustuna_study.optimize(_objective, n_trials=10)
+        assert_rustuna_directions(rustuna_study.directions, suite)
+        optuna_trial_count = len(optuna_study.trials)
+        rustuna_study.optimize(suite.objective, n_trials=10)
 
-        assert len(optuna_study.trials) == len(rustuna_study.trials) == 20
+        suite.assert_trials(rustuna_study.trials)
+        if backend == "journal" and isinstance(suite, SuiteAttr):
+            for trial in rustuna_study.trials[:10]:
+                assert trial.user_attrs == {}
+                assert trial.system_attrs == {}
+        assert optuna_trial_count == 10
 
 
+@parametrize_test_suite
 @pytest.mark.parametrize("backend", ["journal", "sqlite3"])
-def test_rustuna_to_optuna_resume(backend: str) -> None:
+def test_rustuna_to_optuna_resume(suite: Suite, backend: str) -> None:
+    if backend == "sqlite3" and isinstance(suite, (SuiteAttr, TestSuiteParam)):
+        pytest.skip("Optuna cannot read Rustuna's raw SQLite3 attributes.")
+
     study_name = "compat-rustuna-to-optuna"
     with tempfile.TemporaryDirectory() as workdir:
         rustuna_storage = get_rustuna_storage(backend, workdir, create_database=True)
         rustuna_study = rustuna.create_study(
-            storage=rustuna_storage, study_name=study_name
+            storage=rustuna_storage,
+            study_name=study_name,
+            directions=suite.directions,
+            sampler=rustuna.samplers.RandomSampler(),
         )
-        rustuna_study.optimize(_objective, n_trials=10)
+        assert_rustuna_directions(rustuna_study.directions, suite)
+        rustuna_study.optimize(suite.objective, n_trials=10)
 
         optuna_storage = get_optuna_storage(backend, workdir)
-        optuna_study = optuna.load_study(storage=optuna_storage, study_name=study_name)
-        optuna_study.optimize(_objective, n_trials=10)
+        optuna_study = optuna.load_study(
+            storage=optuna_storage,
+            study_name=study_name,
+            sampler=optuna.samplers.RandomSampler(),
+        )
+        assert_optuna_directions(optuna_study.directions, suite)
+        optuna_study.optimize(suite.objective, n_trials=10)
 
-        assert len(optuna_study.trials) == len(rustuna_study.trials) == 20
+        suite.assert_trials(optuna_study.trials)
+        if isinstance(suite, SuiteAttr):
+            for trial in optuna_study.trials[:10]:
+                assert trial.user_attrs == {"rustuna": None}
+                assert trial.system_attrs["rustuna"] is None

--- a/rustuna_pyo3/tests/storage_tests/test_storage.py
+++ b/rustuna_pyo3/tests/storage_tests/test_storage.py
@@ -22,10 +22,9 @@ if TYPE_CHECKING:
         "inmemory",
         "sqlite3",
         "journal-file",
-        # TODO(c-bata): Fix test_studyw_get_user_attr_method
-        # "optuna-inmemory",
-        # "optuna-rdb-sqlite3",
-        # "optuna-journal-file",
+        "optuna-inmemory",
+        "optuna-rdb-sqlite3",
+        "optuna-journal-file",
     ]
 )
 def storage(request: FixtureRequest) -> Generator[StorageProtocol, None, None]:

--- a/rustuna_storage/src/journal/mod.rs
+++ b/rustuna_storage/src/journal/mod.rs
@@ -68,8 +68,7 @@ impl JournalOperation {
 pub struct JournalLog {
     pub op_code: i32,
     pub worker_id: String,
-    // Design note: keep raw JSON to avoid eager parsing of user_attrs (dict[str, str] in Rustuna)
-    // and preserve Optuna journal schema while letting Python-side conversion handle JSON types.
+    // Keep raw JSON so Rustuna can preserve string attributes without encoding them twice.
     #[serde(flatten)]
     pub fields: HashMap<String, Box<RawValue>>,
 }

--- a/rustuna_storage/src/journal/storage.rs
+++ b/rustuna_storage/src/journal/storage.rs
@@ -591,23 +591,41 @@ impl Storage for JournalStorage {
             }
         }
 
+        // Design note: Rustuna intentionally does not share Optuna's user/system attribute value
+        // schema. Rustuna stores string maps in `user_attr_str`/`system_attr_str` without
+        // double JSON encoding, and writes `{"rustuna": null}` to Optuna's fields. Optuna applies
+        // only this dummy field and ignores the Rustuna-specific fields.
+        let mut user_attrs = HashMap::new();
+        let mut system_attrs = HashMap::new();
         for (key, value) in attrs {
-            let mut fields = HashMap::new();
-            fields.insert("study_id".to_string(), to_raw(&study_id)?);
             match key {
                 AttrKey::User(k) => {
-                    let mut map = HashMap::new();
-                    map.insert(k.to_string(), value);
-                    fields.insert("user_attr".to_string(), to_raw(&map)?);
-                    self.write_log(JournalOperation::SetStudyUserAttr, fields)?;
+                    user_attrs.insert(k.to_string(), value);
                 }
                 AttrKey::System(k) => {
-                    let mut map = HashMap::new();
-                    map.insert(k.to_string(), value);
-                    fields.insert("system_attr".to_string(), to_raw(&map)?);
-                    self.write_log(JournalOperation::SetStudySystemAttr, fields)?;
+                    system_attrs.insert(k.to_string(), value);
                 }
             }
+        }
+        if !user_attrs.is_empty() {
+            let mut fields = HashMap::new();
+            fields.insert("study_id".to_string(), to_raw(&study_id)?);
+            fields.insert(
+                "user_attr".to_string(),
+                to_raw(&HashMap::from([("rustuna", Value::Null)]))?,
+            );
+            fields.insert("user_attr_str".to_string(), to_raw(&user_attrs)?);
+            self.write_log(JournalOperation::SetStudyUserAttr, fields)?;
+        }
+        if !system_attrs.is_empty() {
+            let mut fields = HashMap::new();
+            fields.insert("study_id".to_string(), to_raw(&study_id)?);
+            fields.insert(
+                "system_attr".to_string(),
+                to_raw(&HashMap::from([("rustuna", Value::Null)]))?,
+            );
+            fields.insert("system_attr_str".to_string(), to_raw(&system_attrs)?);
+            self.write_log(JournalOperation::SetStudySystemAttr, fields)?;
         }
         self.sync_with_backend()?;
         Ok(())
@@ -644,23 +662,42 @@ impl Storage for JournalStorage {
                 }
             }
         }
+
+        // Design note: Rustuna intentionally does not share Optuna's user/system attribute value
+        // schema. Rustuna stores string maps in `user_attr_str`/`system_attr_str` without
+        // double JSON encoding, and writes `{"rustuna": null}` to Optuna's fields. Optuna applies
+        // only this dummy field and ignores the Rustuna-specific fields.
+        let mut user_attrs = HashMap::new();
+        let mut system_attrs = HashMap::new();
         for (key, value) in attrs {
-            let mut fields = HashMap::new();
-            fields.insert("trial_id".to_string(), to_raw(&trial_id)?);
             match key {
                 AttrKey::User(k) => {
-                    let mut map = HashMap::new();
-                    map.insert(k.to_string(), value);
-                    fields.insert("user_attr".to_string(), to_raw(&map)?);
-                    self.write_log(JournalOperation::SetTrialUserAttr, fields)?;
+                    user_attrs.insert(k.to_string(), value);
                 }
                 AttrKey::System(k) => {
-                    let mut map = HashMap::new();
-                    map.insert(k.to_string(), value);
-                    fields.insert("system_attr".to_string(), to_raw(&map)?);
-                    self.write_log(JournalOperation::SetTrialSystemAttr, fields)?;
+                    system_attrs.insert(k.to_string(), value);
                 }
             }
+        }
+        if !user_attrs.is_empty() {
+            let mut fields = HashMap::new();
+            fields.insert("trial_id".to_string(), to_raw(&trial_id)?);
+            fields.insert(
+                "user_attr".to_string(),
+                to_raw(&HashMap::from([("rustuna", Value::Null)]))?,
+            );
+            fields.insert("user_attr_str".to_string(), to_raw(&user_attrs)?);
+            self.write_log(JournalOperation::SetTrialUserAttr, fields)?;
+        }
+        if !system_attrs.is_empty() {
+            let mut fields = HashMap::new();
+            fields.insert("trial_id".to_string(), to_raw(&trial_id)?);
+            fields.insert(
+                "system_attr".to_string(),
+                to_raw(&HashMap::from([("rustuna", Value::Null)]))?,
+            );
+            fields.insert("system_attr_str".to_string(), to_raw(&system_attrs)?);
+            self.write_log(JournalOperation::SetTrialSystemAttr, fields)?;
         }
         self.sync_with_backend()?;
         Ok(())
@@ -910,7 +947,9 @@ impl JournalReplayState {
 
     fn apply_set_study_user_attr(&mut self, log: &JournalLog, worker_id: &str) -> Result<()> {
         let study_id = get_u32(&log.fields, "study_id")?;
-        let attrs = get_raw_map(&log.fields, "user_attr")?;
+        let Some(attrs) = get_optional_raw_map(&log.fields, "user_attr_str")? else {
+            return Ok(());
+        };
         if !self.study_exists(study_id, log, worker_id)? {
             return Ok(());
         }
@@ -925,7 +964,9 @@ impl JournalReplayState {
 
     fn apply_set_study_system_attr(&mut self, log: &JournalLog, worker_id: &str) -> Result<()> {
         let study_id = get_u32(&log.fields, "study_id")?;
-        let attrs = get_raw_map(&log.fields, "system_attr")?;
+        let Some(attrs) = get_optional_raw_map(&log.fields, "system_attr_str")? else {
+            return Ok(());
+        };
         if !self.study_exists(study_id, log, worker_id)? {
             return Ok(());
         }
@@ -1265,7 +1306,9 @@ impl JournalReplayState {
 
     fn apply_set_trial_user_attr(&mut self, log: &JournalLog, worker_id: &str) -> Result<()> {
         let trial_id = get_u32(&log.fields, "trial_id")?;
-        let attrs = get_raw_map(&log.fields, "user_attr")?;
+        let Some(attrs) = get_optional_raw_map(&log.fields, "user_attr_str")? else {
+            return Ok(());
+        };
         if !self.trial_exists_and_updatable(trial_id, log, worker_id)? {
             return Ok(());
         }
@@ -1308,7 +1351,9 @@ impl JournalReplayState {
 
     fn apply_set_trial_system_attr(&mut self, log: &JournalLog, worker_id: &str) -> Result<()> {
         let trial_id = get_u32(&log.fields, "trial_id")?;
-        let attrs = get_raw_map(&log.fields, "system_attr")?;
+        let Some(attrs) = get_optional_raw_map(&log.fields, "system_attr_str")? else {
+            return Ok(());
+        };
         let (study_id, trial_number) = match self.trial_id_to_study_number.get(&trial_id) {
             Some(v) => *v,
             None => {
@@ -1843,19 +1888,6 @@ fn get_vec_i32(fields: &HashMap<String, Box<RawValue>>, key: &str) -> Result<Vec
         Error::with_reason(
             ErrorKind::StorageError,
             format!("Failed to parse i32 array from field: key={key}"),
-        )
-    })
-}
-
-fn get_raw_map(
-    fields: &HashMap<String, Box<RawValue>>,
-    key: &str,
-) -> Result<HashMap<String, Box<RawValue>>> {
-    let raw = get_raw(fields, key)?;
-    serde_json::from_str::<HashMap<String, Box<RawValue>>>(raw.get()).map_err(|_| {
-        Error::with_reason(
-            ErrorKind::StorageError,
-            format!("Failed to parse object from field: key={key}"),
         )
     })
 }
@@ -2424,7 +2456,7 @@ mod tests {
     }
 
     #[test]
-    fn create_new_trial_from_template_preserves_user_attr_strings() -> Result<()> {
+    fn create_new_trial_from_template_preserves_user_attr_str() -> Result<()> {
         let (mut storage, _logs) = new_storage()?;
         let study_id = storage
             .create_new_study("study", vec![Direction::Minimize])?

--- a/rustuna_storage/tests/journal.rs
+++ b/rustuna_storage/tests/journal.rs
@@ -233,7 +233,9 @@ study.optimize(objective, n_trials=10)
         .keys()
         .filter(|k| matches!(k, rustuna_core::attr::AttrKey::User(_)))
         .count();
-    assert_eq!(user_attrs_count, 1);
+    // Rustuna intentionally ignores Optuna's JSON-encoded `user_attr` field.
+    // Only Rustuna's string-only `user_attr_str` field is restored.
+    assert_eq!(user_attrs_count, 0);
     assert!(matches!(
         trials[0].as_ref().unwrap().state_values,
         TrialStateValues::Complete(_)


### PR DESCRIPTION
## Summary

- Store Rustuna string attributes in `user_attr_str` and `system_attr_str`.
- Keep Optuna-compatible dummy attributes in `user_attr` and `system_attr`.
- Restore Rustuna attributes from the Rustuna-specific fields during journal replay.
- Batch user and system attribute updates into a single journal record.
- Expand JournalStorage schema compatibility and storage API test coverage.

## Compatibility

Rustuna stores attribute values as strings without JSON double encoding. Since Optuna supports arbitrary JSON values, Rustuna does not attempt to fully restore Optuna's typed attributes.

For Rustuna-generated journals:

- Optuna can replay the journal using the dummy `{"rustuna": null}` attributes.
- Rustuna-specific `user_attr_str` and `system_attr_str` fields are ignored by Optuna.
- Rustuna restores the string attributes from these Rustuna-specific fields.

Optuna's `user_attr` and `system_attr` fields in set-attribute records are intentionally not imported by Rustuna.