### PR TITLE
Preserve categorical choices in ToRustStorage

### DIFF
--- a/rustuna_pyo3/src/storage/to_rust.rs
+++ b/rustuna_pyo3/src/storage/to_rust.rs
@@ -15,7 +15,9 @@ use rustuna_core::{Error, ErrorKind};
 use crate::distribution::PyDistribution;
 use crate::exception::err_to_exceptions;
 use crate::study::{pyobject_to_persisted_study, PyDirection};
-use crate::trial::{pyobject_to_persisted_trial, PyPersistedTrial, PyTrialState};
+use crate::trial::{
+    pyobject_to_persisted_trial_with_category_labels, PyPersistedTrial, PyTrialState,
+};
 
 // ToRustStorage wraps an Optuna storage object and maintains an in-memory cache.
 //
@@ -91,11 +93,11 @@ impl ToRustStorage {
         })
     }
 
-    fn obj_create_new_trial(&mut self, study_id: u32) -> PyResult<PersistedTrial> {
+    fn obj_create_new_trial(&mut self, study_id: u32) -> PyResult<(PersistedTrial, Attrs)> {
         Python::attach(|py| {
             let py_trial = self.obj.call_method1(py, "create_new_trial", (study_id,))?;
             let py_trial = py_trial.bind(py);
-            pyobject_to_persisted_trial(py_trial, study_id)
+            pyobject_to_persisted_trial_with_category_labels(py_trial, study_id)
         })
     }
 
@@ -103,14 +105,14 @@ impl ToRustStorage {
         &mut self,
         study_id: u32,
         template: &PersistedTrial,
-    ) -> PyResult<PersistedTrial> {
+    ) -> PyResult<(PersistedTrial, Attrs)> {
         Python::attach(|py| {
             let py_template = Py::new(py, PyPersistedTrial::new(template.clone(), Attrs::new()))?;
             let py_trial =
                 self.obj
                     .call_method1(py, "create_new_trial", (study_id, py_template))?;
             let py_trial = py_trial.bind(py);
-            pyobject_to_persisted_trial(py_trial, study_id)
+            pyobject_to_persisted_trial_with_category_labels(py_trial, study_id)
         })
     }
 
@@ -121,10 +123,39 @@ impl ToRustStorage {
         distribution: &Distribution,
         value: f64,
     ) -> PyResult<()> {
+        let category_labels = match distribution {
+            Distribution::Categorical { cardinality } => {
+                let study_id = self
+                    .cache
+                    .get_cached_trial(trial_id)
+                    .map_err(|e| {
+                        PyRuntimeError::new_err(format!(
+                            "Failed to find trial while setting categorical parameter: {:?}",
+                            e.kind
+                        ))
+                    })?
+                    .study_id;
+                let labels = self
+                    .cache
+                    .get_category_labels(study_id, name, *cardinality)
+                    .map_err(|e| {
+                        PyRuntimeError::new_err(format!(
+                            "Failed to get categorical labels for parameter '{name}': {:?}",
+                            e.kind
+                        ))
+                    })?
+                    .ok_or_else(|| {
+                        PyRuntimeError::new_err(format!(
+                            "Categorical labels are not available for parameter '{name}'"
+                        ))
+                    })?;
+                Some(labels)
+            }
+            _ => None,
+        };
         Python::attach(|py| {
-            // TODO(c-bata): Consider how to set category_labels.
-            let attrs = Attrs::new();
-            let py_distribution = PyDistribution::new(distribution.clone(), name, &attrs);
+            let py_distribution =
+                PyDistribution::new_with_category_labels(distribution.clone(), category_labels);
             self.obj.call_method1(
                 py,
                 "set_trial_param",
@@ -236,7 +267,7 @@ impl ToRustStorage {
         })
     }
 
-    fn obj_get_trials(&self, study_id: u32) -> PyResult<Vec<PersistedTrial>> {
+    fn obj_get_trials(&self, study_id: u32) -> PyResult<Vec<(PersistedTrial, Attrs)>> {
         Python::attach(|py| {
             let trials = self.obj.call_method1(py, "get_trials", (study_id,))?;
             let trials_ref = trials.bind(py);
@@ -244,9 +275,12 @@ impl ToRustStorage {
                 return Err(PyRuntimeError::new_err("studies must be a list"));
             }
             let trials = trials_ref.cast::<PyList>()?;
-            let mut persisted_trials: Vec<PersistedTrial> = Vec::with_capacity(trials.len());
+            let mut persisted_trials: Vec<(PersistedTrial, Attrs)> =
+                Vec::with_capacity(trials.len());
             for trial in trials.iter() {
-                persisted_trials.push(pyobject_to_persisted_trial(&trial, study_id)?);
+                persisted_trials.push(pyobject_to_persisted_trial_with_category_labels(
+                    &trial, study_id,
+                )?);
             }
             Ok(persisted_trials)
         })
@@ -282,8 +316,13 @@ impl ToRustStorage {
         &mut self,
         cache_study_id: u32,
         src_trial: PersistedTrial,
+        category_attrs: Attrs,
         cache_n_trials: Option<u32>,
     ) -> rustuna_core::Result<()> {
+        if !category_attrs.is_empty() {
+            self.cache
+                .set_study_attrs(cache_study_id, category_attrs, false)?;
+        }
         let cache_n_trials = match cache_n_trials {
             Some(n) => n,
             None => self.cache.get_trials(cache_study_id)?.len() as u32,
@@ -350,11 +389,16 @@ impl ToRustStorage {
         let mut src_trials = self
             .obj_get_trials(*src_study_id)
             .map_err(Self::map_pyerr)?;
-        src_trials.sort_by_key(|trial| trial.number);
+        src_trials.sort_by_key(|(trial, _)| trial.number);
 
         let mut cache_n_trials = self.cache.get_trials(cache_study_id)?.len() as u32;
-        for src_trial in src_trials {
-            self.sync_trial(cache_study_id, src_trial, Some(cache_n_trials))?;
+        for (src_trial, category_attrs) in src_trials {
+            self.sync_trial(
+                cache_study_id,
+                src_trial,
+                category_attrs,
+                Some(cache_n_trials),
+            )?;
             cache_n_trials = self.cache.get_trials(cache_study_id)?.len() as u32;
         }
         Ok(())
@@ -439,7 +483,7 @@ impl Storage for ToRustStorage {
                 .ok_or(rustuna_core::Error::new(
                     rustuna_core::ErrorKind::StudyNotFound,
                 ))?;
-        let src_trial = self
+        let (src_trial, category_attrs) = self
             .obj_create_new_trial(*src_study_id)
             .map_err(Self::map_pyerr)?;
         let src_trial_id = src_trial.id;
@@ -448,7 +492,7 @@ impl Storage for ToRustStorage {
             self.sync_trials(study_id)?;
             return self.cache.get_trial(src_trial_id);
         }
-        self.sync_trial(study_id, src_trial, Some(cached_n_trials))?;
+        self.sync_trial(study_id, src_trial, category_attrs, Some(cached_n_trials))?;
         self.cache.get_trial(src_trial_id)
     }
 
@@ -465,7 +509,7 @@ impl Storage for ToRustStorage {
                 .ok_or(rustuna_core::Error::new(
                     rustuna_core::ErrorKind::StudyNotFound,
                 ))?;
-        let src_trial = self
+        let (src_trial, category_attrs) = self
             .obj_create_new_trial_from_template(src_study_id, template)
             .map_err(Self::map_pyerr)?;
         let src_trial_id = src_trial.id;
@@ -474,7 +518,7 @@ impl Storage for ToRustStorage {
             self.sync_trials(study_id)?;
             return self.cache.get_trial(src_trial_id);
         }
-        self.sync_trial(study_id, src_trial, Some(cached_n_trials))?;
+        self.sync_trial(study_id, src_trial, category_attrs, Some(cached_n_trials))?;
         self.cache.get_trial(src_trial_id)
     }
 

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -758,10 +758,10 @@ fn parse_naive_datetime(value: &str) -> PyResult<NaiveDateTime> {
         .map_err(|e| PyValueError::new_err(format!("Failed to parse datetime: {e}")))
 }
 
-pub fn pyobject_to_persisted_trial(
+pub fn pyobject_to_persisted_trial_with_category_labels(
     trial: &Bound<'_, PyAny>,
     study_id: u32,
-) -> PyResult<PersistedTrial> {
+) -> PyResult<(PersistedTrial, Attrs)> {
     let trial_id = match trial.getattr("id") {
         Ok(attr) => attr.extract::<u32>()?,
         Err(_) => trial.getattr("_trial_id")?.extract::<u32>()?,
@@ -821,9 +821,13 @@ pub fn pyobject_to_persisted_trial(
     let src_distributions = src_distributions.cast::<PyDict>()?;
     let mut distributions: HashMap<String, Distribution> =
         HashMap::with_capacity(src_distributions.len());
+    let mut category_attrs = Attrs::new();
     for (key, value) in src_distributions.iter() {
         let key = key.extract::<String>()?;
         let value = value.extract::<PyDistribution>()?;
+        if let Some(labels) = &value.category_labels {
+            category_attrs.extend(category_labels_to_attrs(&key, labels));
+        }
         distributions.insert(key, value.into());
     }
     persisted_trial.distributions = distributions;
@@ -831,5 +835,5 @@ pub fn pyobject_to_persisted_trial(
     let user_attrs = trial.getattr("user_attrs")?;
     let system_attrs = trial.getattr("system_attrs")?;
     persisted_trial.attrs = pyobj_to_attrs(&user_attrs, &system_attrs)?;
-    Ok(persisted_trial)
+    Ok((persisted_trial, category_attrs))
 }

--- a/rustuna_pyo3/tests/storage_tests/test_schema_compatibility.py
+++ b/rustuna_pyo3/tests/storage_tests/test_schema_compatibility.py
@@ -107,7 +107,7 @@ class TestSuiteParam:
     def objective(self, trial: optuna.Trial | rustuna.Trial) -> float:
         x = trial.suggest_float("x", 1.0, 10.0, log=True)
         trial.suggest_int("y", 0, 10, step=2)
-        trial.suggest_categorical("z", [0, 1])
+        trial.suggest_categorical("z", ["red", "green"])
         return x
 
     def assert_trials(
@@ -129,8 +129,20 @@ class TestSuiteParam:
             assert isinstance(y, int)
             assert 1.0 <= x <= 10.0
             assert y in {0, 2, 4, 6, 8, 10}
-            assert trial.params["z"] in {0, 1}
+            assert trial.params["z"] in {"red", "green"}
             assert trial.values == [x]
+            if isinstance(trial, optuna.trial.FrozenTrial):
+                distribution = trial.distributions["z"]
+                assert isinstance(
+                    distribution, optuna.distributions.CategoricalDistribution
+                )
+                assert distribution.choices == ("red", "green")
+            else:
+                distribution = typing.cast(typing.Any, trial.distributions["z"])
+                assert distribution.to_dict()["choices"] == [
+                    "red",
+                    "green",
+                ]
 
 
 class TestSuiteMultiObjective:


### PR DESCRIPTION
## Summary

- Preserve categorical choice labels when converting Python trials into Rustuna trials.
- Store extracted category labels in the Rustuna-side study cache.
- Reconstruct Python categorical distributions with their original choices when writing parameters back to Python storage.
- Add compatibility assertions for non-numeric categorical choices.

## Motivation

Rustuna's core `CategoricalDistribution` stores only the number of choices, while Optuna stores the actual choices in each distribution.

Previously, converting a Python trial to Rustuna discarded the categorical labels. As a result, categorical distributions could be reconstructed as numeric choices such as `[0, 1, ...]`, which caused incorrect parameters when
resuming or bridging studies.

This change keeps the labels separately in study attributes while preserving the compact Rustuna core representation

## Running Optuna Dashboard


```python
import os

import rustuna
from optuna.storages.journal import JournalStorage
from optuna.storages.journal import JournalFileBackend
from optuna_dashboard import run_server


BASE_DIR = os.path.dirname(__file__)


def create_rustuna_studies(storage: rustuna.storages.StorageProtocol) -> None: 
    def objective(trial: rustuna.Trial) -> float:
        x = trial.suggest_float("x", -10, 10)
        _ = trial.suggest_int("y", -10, 10, step=2)
        _ = trial.suggest_categorical("z", ["foo", -10, 5.0, True])
        return (x - 5) ** 2

    study = rustuna.create_study(storage=storage, study_name="check-params")
    study.optimize(objective, n_trials=100)


def main() -> None:
    file_path = os.path.join(BASE_DIR, "optuna_dashboard.journal")
    if not os.path.exists(file_path):
        rustuna_storage = rustuna.storages.JournalFileStorage(file_path)
        create_rustuna_studies(rustuna_storage)

    optuna_storage = JournalStorage(JournalFileBackend(file_path))
    run_server(optuna_storage, host="127.0.0.1", port=8080)


if __name__ == "__main__":
    main()
```

<img width="1521" height="1442" alt="626806950-aaf3e2b1-737b-4792-92c4-7519f3a9ef11" src="https://github.com/user-attachments/assets/ed2ef2c4-a992-48f3-976d-86d2248b0118" />
