### PR TITLE
Add `ToOptunaStudy` converter

### DIFF
--- a/rustuna_pyo3/pyproject.toml
+++ b/rustuna_pyo3/pyproject.toml
@@ -33,4 +33,8 @@ dev = [
     "maturin",
     "mypy",
     "freezegun",
+    # test dependencies
+    "matplotlib",
+    "plotly",
+    "scipy",
 ]

--- a/rustuna_pyo3/rustuna/converter/__init__.py
+++ b/rustuna_pyo3/rustuna/converter/__init__.py
@@ -10,6 +10,10 @@ from ._distribution import (
     to_rustuna_distribution,
     to_rustuna_distributions,
 )
+from ._frozen_study import (
+    to_frozen_study,
+    to_persisted_study,
+)
 from ._sampler import (
     ToOptunaSampler,
 )
@@ -18,8 +22,7 @@ from ._storage import (
     ToRustunaStorage,
 )
 from ._study import (
-    to_frozen_study,
-    to_persisted_study,
+    ToOptunaStudy,
 )
 from ._trial import (
     FrozenTrialLike,
@@ -48,4 +51,5 @@ __all__ = [
     "to_optuna_state",
     "to_persisted_trial",
     "to_rustuna_state",
+    "ToOptunaStudy",
 ]

--- a/rustuna_pyo3/rustuna/converter/_attrs.py
+++ b/rustuna_pyo3/rustuna/converter/_attrs.py
@@ -45,6 +45,11 @@ class OptunaAttrsView(dict[str, Any]):
     def _raw_key(self, key: str) -> str:
         return _OPTUNA_ATTR_PREFIX + key
 
+    def __setitem__(self, key: str, value: Any) -> None:
+        if key not in self._keys:
+            self._keys += (key,)
+        self._cache[key] = value
+
     def __contains__(self, key: object) -> bool:
         return isinstance(key, str) and key in self._keys
 

--- a/rustuna_pyo3/rustuna/converter/_frozen_study.py
+++ b/rustuna_pyo3/rustuna/converter/_frozen_study.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from optuna.study._frozen import FrozenStudy
+
+import rustuna
+
+from ._attrs import to_optuna_attrs, to_rustuna_attrs
+from ._direction import to_optuna_directions, to_rustuna_directions
+
+
+def to_frozen_study(study: rustuna.study.PersistedStudy) -> FrozenStudy:
+    return FrozenStudy(
+        study_name=study.name,
+        study_id=study.id,
+        direction=None,
+        directions=to_optuna_directions(study.directions),
+        user_attrs=to_optuna_attrs(study.user_attrs),
+        system_attrs=to_optuna_attrs(study.system_attrs),
+    )
+
+
+def to_persisted_study(study: FrozenStudy) -> rustuna.study.PersistedStudy:
+    return rustuna.study.PersistedStudy(
+        id=study._study_id,
+        name=study.study_name,
+        directions=to_rustuna_directions(study.directions),
+        user_attrs=to_rustuna_attrs(study.user_attrs),
+        system_attrs=to_rustuna_attrs(study.system_attrs),
+    )

--- a/rustuna_pyo3/rustuna/converter/_storage.py
+++ b/rustuna_pyo3/rustuna/converter/_storage.py
@@ -17,8 +17,9 @@ from optuna.trial import FrozenTrial, TrialState
 import rustuna
 
 from ._attrs import to_optuna_attrs, to_rustuna_attrs
+from ._direction import to_optuna_directions
 from ._distribution import to_optuna_distribution, to_rustuna_distribution
-from ._study import to_frozen_study, to_optuna_directions, to_persisted_study
+from ._frozen_study import to_frozen_study, to_persisted_study
 from ._trial import (
     FrozenTrialLike,
     to_frozen_trial,

--- a/rustuna_pyo3/rustuna/converter/_storage.py
+++ b/rustuna_pyo3/rustuna/converter/_storage.py
@@ -317,8 +317,9 @@ class ToOptunaStorage(BaseStorage):
             self._storage.set_trial_state_values(trial_id, rustuna_state, values)
         except rustuna.exceptions.UpdateFinishedTrialError as e:
             raise optuna.exceptions.UpdateFinishedTrialError(str(e)) from e
-        # TODO(c-bata): Add support for pop waiting trial
-        return False
+        # TODO(c-bata): Consider adding an atomic state-claim API to prevent
+        # multiple workers from claiming the same WAITING trial.
+        return True
 
     def set_trial_intermediate_value(
         self, trial_id: int, step: int, intermediate_value: float

--- a/rustuna_pyo3/rustuna/converter/_study.py
+++ b/rustuna_pyo3/rustuna/converter/_study.py
@@ -8,6 +8,7 @@ from optuna import Study as _OptunaStudy
 
 import rustuna
 
+from ._attrs import to_optuna_attrs
 from ._storage import ToOptunaStorage
 from ._trial import (
     to_frozen_trial,
@@ -16,7 +17,25 @@ from ._trial import (
 
 
 class ToOptunaStudy(_OptunaStudy):
+    """Expose a Rustuna study through Optuna's ``Study`` interface.
+
+    This adapter allows Optuna APIs that consume a study, such as visualization
+    functions, to operate on a study created by Rustuna. Trial data is converted
+    to Optuna's ``FrozenTrial`` representation, while study operations are
+    forwarded to the underlying Rustuna storage through :class:`ToOptunaStorage`.
+
+    Args:
+        study: The Rustuna study to expose through the Optuna API.
+
+    Note:
+        Rustuna stores user attributes as strings. Attributes written directly
+        through the Rustuna study are exposed with their stored string values,
+        while attributes written through this adapter use Optuna's JSON-compatible
+        representation.
+    """
+
     def __init__(self, study: rustuna.Study):
+        """Create an Optuna-compatible view of ``study``."""
         self._rustuna_study = study
         super().__init__(
             study.study_name,
@@ -36,8 +55,15 @@ class ToOptunaStudy(_OptunaStudy):
                     continue
                 rustuna_states.append(rustuna_state)
         trials = self._rustuna_study.get_trials(states=rustuna_states)
-        return [to_frozen_trial(t, use_frozen_trial_like=True) for t in trials]
+        return [to_frozen_trial(t, use_frozen_trial_like=not deepcopy) for t in trials]
 
     @property
     def user_attrs(self) -> dict[str, Any]:
-        return self._rustuna_study.user_attrs
+        attrs = self._rustuna_study.user_attrs
+        raw_attrs = {
+            key: value
+            for key, value in attrs.items()
+            if not key.startswith("optuna_attr:")
+        }
+        raw_attrs.update(to_optuna_attrs(attrs))
+        return raw_attrs

--- a/rustuna_pyo3/rustuna/converter/_study.py
+++ b/rustuna_pyo3/rustuna/converter/_study.py
@@ -1,29 +1,43 @@
 from __future__ import annotations
 
-from optuna.study._frozen import FrozenStudy
+from collections.abc import Container
+from typing import Any
+
+import optuna
+from optuna import Study as _OptunaStudy
 
 import rustuna
 
-from ._attrs import to_optuna_attrs, to_rustuna_attrs
-from ._direction import to_optuna_directions, to_rustuna_directions
+from ._storage import ToOptunaStorage
+from ._trial import (
+    to_frozen_trial,
+    to_rustuna_state_map,
+)
 
 
-def to_frozen_study(study: rustuna.study.PersistedStudy) -> FrozenStudy:
-    return FrozenStudy(
-        study_name=study.name,
-        study_id=study.id,
-        direction=None,
-        directions=to_optuna_directions(study.directions),
-        user_attrs=to_optuna_attrs(study.user_attrs),
-        system_attrs=to_optuna_attrs(study.system_attrs),
-    )
+class ToOptunaStudy(_OptunaStudy):
+    def __init__(self, study: rustuna.Study):
+        self._rustuna_study = study
+        super().__init__(
+            study.study_name,
+            ToOptunaStorage(study._storage),
+        )
 
+    def get_trials(
+        self,
+        deepcopy: bool = True,
+        states: Container[optuna.trial.TrialState] | None = None,
+    ) -> list[optuna.trial.FrozenTrial]:
+        rustuna_states: list[rustuna.trial.TrialState] | None = None
+        if states is not None:
+            rustuna_states = []
+            for optuna_state, rustuna_state in to_rustuna_state_map.items():
+                if optuna_state not in states:
+                    continue
+                rustuna_states.append(rustuna_state)
+        trials = self._rustuna_study.get_trials(states=rustuna_states)
+        return [to_frozen_trial(t, use_frozen_trial_like=True) for t in trials]
 
-def to_persisted_study(study: FrozenStudy) -> rustuna.study.PersistedStudy:
-    return rustuna.study.PersistedStudy(
-        id=study._study_id,
-        name=study.study_name,
-        directions=to_rustuna_directions(study.directions),
-        user_attrs=to_rustuna_attrs(study.user_attrs),
-        system_attrs=to_rustuna_attrs(study.system_attrs),
-    )
+    @property
+    def user_attrs(self) -> dict[str, Any]:
+        return self._rustuna_study.user_attrs

--- a/rustuna_pyo3/rustuna/converter/_trial.py
+++ b/rustuna_pyo3/rustuna/converter/_trial.py
@@ -35,8 +35,7 @@ to_rustuna_state_map = {
     optuna.trial.TrialState.PRUNED: rustuna.trial.TrialState.PRUNED,
     optuna.trial.TrialState.WAITING: rustuna.trial.TrialState.WAITING,
 }
-# TODO(c-bata): Make rustuna.trial.TrialState hashable.
-# to_optuna_state_map = {v: k for k, v in to_optuna_state_map.items()}
+to_optuna_state_map = {v: k for k, v in to_rustuna_state_map.items()}
 
 
 def to_optuna_state(state: rustuna.trial.TrialState) -> optuna.trial.TrialState:

--- a/rustuna_pyo3/rustuna/converter/_trial.py
+++ b/rustuna_pyo3/rustuna/converter/_trial.py
@@ -148,7 +148,7 @@ class FrozenTrialLike(FrozenTrial):
 
     @property
     def value(self) -> float | None:
-        values = self.__values or self._persisted_trial.values
+        values = self.values
         if values is None:
             return None
         if len(values) > 1:
@@ -173,7 +173,9 @@ class FrozenTrialLike(FrozenTrial):
     # These `_get_values`, `_set_values`, and `values = property(_get_values, _set_values)` are
     # defined to pass the mypy.
     def _get_values(self) -> list[float] | None:
-        return self.__values or self._persisted_trial.values
+        if self.__values is None:
+            self.__values = self._persisted_trial.values
+        return self.__values
 
     def _set_values(self, v: Sequence[float] | None) -> None:
         if v is not None:
@@ -205,7 +207,9 @@ class FrozenTrialLike(FrozenTrial):
 
     @property
     def params(self) -> dict[str, Any]:
-        return self.__params or self._persisted_trial.params
+        if self.__params is None:
+            self.__params = self._persisted_trial.params
+        return self.__params
 
     @params.setter
     def params(self, params: dict[str, Any]) -> None:
@@ -213,9 +217,11 @@ class FrozenTrialLike(FrozenTrial):
 
     @property
     def distributions(self) -> dict[str, BaseDistribution]:
-        return self.__distributions or to_optuna_distributions(
-            self._persisted_trial.distributions
-        )
+        if self.__distributions is None:
+            self.__distributions = to_optuna_distributions(
+                self._persisted_trial.distributions
+            )
+        return self.__distributions
 
     @distributions.setter
     def distributions(self, value: dict[str, BaseDistribution]) -> None:
@@ -249,9 +255,9 @@ class FrozenTrialLike(FrozenTrial):
 
     @property
     def intermediate_values(self) -> dict[int, float]:
-        if self.__intermediate_values is not None:
-            return self.__intermediate_values
-        return self._persisted_trial.intermediate_values
+        if self.__intermediate_values is None:
+            self.__intermediate_values = self._persisted_trial.intermediate_values
+        return self.__intermediate_values
 
     @intermediate_values.setter
     def intermediate_values(self, values: dict[int, float]) -> None:

--- a/rustuna_pyo3/tests/converter_tests/test_converters.py
+++ b/rustuna_pyo3/tests/converter_tests/test_converters.py
@@ -1,7 +1,6 @@
 import optuna
 import pytest
 
-import rustuna
 from rustuna import converter
 
 

--- a/rustuna_pyo3/tests/converter_tests/test_to_optuna_study.py
+++ b/rustuna_pyo3/tests/converter_tests/test_to_optuna_study.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import optuna
+import pytest
+from optuna.distributions import CategoricalDistribution, FloatDistribution
+from optuna.trial import FrozenTrial, TrialState
+
+import rustuna
+from rustuna.converter import ToOptunaStudy
+
+
+@pytest.fixture
+def rustuna_study() -> rustuna.study.Study:
+    return rustuna.create_study(
+        storage=rustuna.storages.InMemoryStorage(),
+        directions=["minimize"],
+    )
+
+
+@pytest.fixture
+def study(rustuna_study: rustuna.study.Study) -> ToOptunaStudy:
+    return ToOptunaStudy(rustuna_study)
+
+
+def test_study_properties_and_user_attrs(
+    study: ToOptunaStudy, rustuna_study: rustuna.study.Study
+) -> None:
+    rustuna_study.set_user_attr("raw", "value")
+
+    assert study.study_name == rustuna_study.study_name
+    assert study.directions == [optuna.study.StudyDirection.MINIMIZE]
+    assert study.direction == optuna.study.StudyDirection.MINIMIZE
+    assert study.user_attrs == {"raw": "value"}
+
+    study.set_user_attr("json", {"answer": 42})
+    assert study.user_attrs == {"raw": "value", "json": {"answer": 42}}
+
+
+def test_get_trials_filters_states_and_respects_deepcopy(
+    study: ToOptunaStudy,
+) -> None:
+    completed_trial = study.ask()
+    study.tell(completed_trial, 1.0)
+    running_trial = study.ask()
+
+    assert [trial.number for trial in study.get_trials()] == [0, 1]
+    assert [
+        trial.number for trial in study.get_trials(states=(TrialState.COMPLETE,))
+    ] == [0]
+    assert [
+        trial.number for trial in study.get_trials(states=(TrialState.RUNNING,))
+    ] == [1]
+    assert study.get_trials(states=[]) == []
+
+    deep_copied = study.get_trials(deepcopy=True)
+    assert all(isinstance(trial, FrozenTrial) for trial in deep_copied)
+    deep_copied[0].params["new"] = 1
+    assert "new" not in study.trials[0].params
+
+    shallow = study.get_trials(deepcopy=False)
+    assert shallow[0].number == completed_trial.number
+    assert running_trial.number == 1
+
+
+def test_optimize_updates_trial_data_and_invokes_callbacks(
+    study: ToOptunaStudy,
+) -> None:
+    callback_trials: list[FrozenTrial] = []
+
+    def objective(trial: optuna.Trial) -> float:
+        x = trial.suggest_float("x", -1, 1)
+        assert trial.params == {"x": x}
+        assert trial.distributions == {"x": FloatDistribution(-1, 1)}
+        trial.report(x**2, step=0)
+        trial.set_user_attr("note", "from objective")
+        assert trial.user_attrs == {"note": "from objective"}
+        return x**2
+
+    def callback(_: optuna.Study, trial: FrozenTrial) -> None:
+        callback_trials.append(trial)
+
+    study.optimize(objective, n_trials=3, callbacks=[callback])
+
+    assert len(study.trials) == 3
+    assert len(callback_trials) == 3
+    assert all(trial.state == TrialState.COMPLETE for trial in study.trials)
+    assert all(trial.user_attrs == {"note": "from objective"} for trial in study.trials)
+    assert all(trial.intermediate_values == {0: trial.value} for trial in study.trials)
+
+
+@pytest.mark.parametrize("catch", [(), (ValueError,)])
+def test_optimize_failure_and_catch(
+    study: ToOptunaStudy,
+    catch: tuple[type[Exception], ...],
+) -> None:
+    def objective(_: optuna.Trial) -> float:
+        raise ValueError("expected failure")
+
+    if catch:
+        study.optimize(objective, n_trials=2, catch=catch)
+    else:
+        with pytest.raises(ValueError, match="expected failure"):
+            study.optimize(objective, n_trials=1)
+
+    assert all(trial.state == TrialState.FAIL for trial in study.trials)
+
+
+def test_optimize_pruned(study: ToOptunaStudy) -> None:
+    def objective(trial: optuna.Trial) -> float:
+        trial.report(1.0, step=0)
+        raise optuna.TrialPruned
+
+    study.optimize(objective, n_trials=2)
+
+    assert len(study.trials) == 2
+    assert all(trial.state == TrialState.PRUNED for trial in study.trials)
+    assert all(trial.intermediate_values == {0: 1.0} for trial in study.trials)
+
+
+def test_best_trial_properties(study: ToOptunaStudy) -> None:
+    for value in [3.0, 1.0, 2.0]:
+        study.tell(study.ask(), value)
+
+    assert study.best_trial.number == 1
+    assert study.best_value == 1.0
+    assert study.best_params == {}
+    assert study.best_trial == study.trials[1]
+
+
+def test_multi_objective_properties() -> None:
+    rustuna_study = rustuna.create_study(
+        storage=rustuna.storages.InMemoryStorage(),
+        directions=["minimize", "maximize"],
+    )
+    study = ToOptunaStudy(rustuna_study)
+
+    assert study.directions == [
+        optuna.study.StudyDirection.MINIMIZE,
+        optuna.study.StudyDirection.MAXIMIZE,
+    ]
+    with pytest.raises(RuntimeError, match="single direction"):
+        _ = study.direction
+
+    for values in [[2.0, 2.0], [1.0, 1.0], [3.0, 1.0]]:
+        study.tell(study.ask(), values)
+
+    assert {tuple(trial.values or []) for trial in study.best_trials} == {
+        (2.0, 2.0),
+        (1.0, 1.0),
+    }
+    with pytest.raises(RuntimeError, match="single best trial"):
+        _ = study.best_trial
+
+
+def test_ask_and_tell_with_fixed_distributions(study: ToOptunaStudy) -> None:
+    distributions = {
+        "x": FloatDistribution(0, 1),
+        "choice": CategoricalDistribution(["a", "b"]),
+    }
+    trial = study.ask(fixed_distributions=distributions)
+
+    assert set(trial.params) == {"x", "choice"}
+    assert 0 <= trial.params["x"] <= 1
+    assert trial.params["choice"] in {"a", "b"}
+    assert trial.distributions == distributions
+
+    study.tell(trial, 1.0)
+    assert study.trials[-1].params == trial.params
+    assert study.trials[-1].distributions == distributions
+
+
+def test_enqueue_trial(study: ToOptunaStudy) -> None:
+    study.enqueue_trial({"x": 0.25}, user_attrs={"memo": "queued"})
+
+    def objective(trial: optuna.Trial) -> float:
+        assert trial.suggest_float("x", 0, 1) == 0.25
+        assert trial.user_attrs == {"memo": "queued"}
+        return 0.0
+
+    study.optimize(objective, n_trials=1)
+
+    assert study.trials[0].params == {"x": 0.25}
+    assert study.trials[0].user_attrs == {"memo": "queued"}
+
+
+def test_add_trial_and_add_trials(study: ToOptunaStudy) -> None:
+    distribution = CategoricalDistribution(["a", "b"])
+    trial = optuna.create_trial(
+        params={"choice": "a"},
+        distributions={"choice": distribution},
+        value=1.0,
+        user_attrs={"source": "single"},
+    )
+    study.add_trial(trial)
+    study.add_trials(
+        [
+            optuna.create_trial(
+                params={"choice": "b"},
+                distributions={"choice": distribution},
+                value=2.0,
+                user_attrs={"source": "multiple"},
+            )
+        ]
+    )
+
+    assert len(study.trials) == 2
+    assert study.trials[0].params == {"choice": "a"}
+    assert study.trials[1].params == {"choice": "b"}
+    assert [trial.user_attrs["source"] for trial in study.trials] == [
+        "single",
+        "multiple",
+    ]
+
+
+def test_stop(study: ToOptunaStudy) -> None:
+    def objective(trial: optuna.Trial) -> float:
+        if trial.number == 1:
+            trial.study.stop()
+        return float(trial.number)
+
+    study.optimize(objective, n_trials=10)
+
+    assert len(study.trials) == 2

--- a/rustuna_pyo3/tests/converter_tests/test_visualization.py
+++ b/rustuna_pyo3/tests/converter_tests/test_visualization.py
@@ -4,10 +4,19 @@
 import warnings
 from typing import Callable
 
-import matplotlib.pyplot as plt
 import optuna
-import plotly.graph_objects as go
 import pytest
+
+try:
+    import matplotlib.pyplot as plt
+    import plotly.graph_objects as go  # type: ignore[import-untyped]
+    import scipy  # type: ignore[import-untyped]
+except ModuleNotFoundError:
+    pytest.skip(
+        "Visualization tests require matplotlib, plotly, and scipy.",
+        allow_module_level=True,
+    )
+
 from matplotlib.axes._axes import Axes
 from optuna.visualization import (
     plot_contour,

--- a/rustuna_pyo3/tests/converter_tests/test_visualization.py
+++ b/rustuna_pyo3/tests/converter_tests/test_visualization.py
@@ -1,0 +1,88 @@
+# These tests are ported from the following file:
+# https://github.com/optuna/optuna/blob/v4.9.0/tests/visualization_tests/test_visualizations.py
+
+import warnings
+from typing import Callable
+
+import matplotlib.pyplot as plt
+import optuna
+import plotly.graph_objects as go
+import pytest
+from matplotlib.axes._axes import Axes
+from optuna.visualization import (
+    plot_contour,
+    plot_edf,
+    plot_optimization_history,
+    plot_parallel_coordinate,
+    plot_param_importances,
+    plot_rank,
+    plot_slice,
+    plot_timeline,
+)
+from optuna.visualization.matplotlib import plot_contour as matplotlib_plot_contour
+from optuna.visualization.matplotlib import plot_edf as matplotlib_plot_edf
+from optuna.visualization.matplotlib import (
+    plot_optimization_history as matplotlib_plot_optimization_history,
+)
+from optuna.visualization.matplotlib import (
+    plot_parallel_coordinate as matplotlib_plot_parallel_coordinate,
+)
+from optuna.visualization.matplotlib import (
+    plot_param_importances as matplotlib_plot_param_importances,
+)
+from optuna.visualization.matplotlib import plot_rank as matplotlib_plot_rank
+from optuna.visualization.matplotlib import plot_slice as matplotlib_plot_slice
+from optuna.visualization.matplotlib import plot_timeline as matplotlib_plot_timeline
+
+import rustuna
+from rustuna.converter import ToOptunaStudy
+
+# https://github.com/optuna/optuna/blob/master/tests/visualization_tests/test_visualizations.py
+parametrize_visualization_functions_for_single_objective = pytest.mark.parametrize(
+    "plot_func",
+    [
+        plot_optimization_history,
+        plot_edf,
+        plot_contour,
+        plot_parallel_coordinate,
+        plot_rank,
+        plot_slice,
+        plot_timeline,
+        plot_param_importances,
+        matplotlib_plot_optimization_history,
+        matplotlib_plot_edf,
+        matplotlib_plot_contour,
+        matplotlib_plot_parallel_coordinate,
+        matplotlib_plot_rank,
+        matplotlib_plot_slice,
+        matplotlib_plot_timeline,
+        matplotlib_plot_param_importances,
+    ],
+)
+
+
+@parametrize_visualization_functions_for_single_objective
+def test_visualization_for_single_objective(
+    plot_func: Callable[[optuna.study.Study], go.Figure | Axes],
+) -> None:
+    def objective(trial: rustuna.Trial) -> float:
+        category = trial.suggest_categorical("category", ["foo", "bar"])
+        if category == "foo":
+            return (trial.suggest_float("x1", 0, 10) - 2) ** 2
+        else:
+            return -((trial.suggest_float("x2", -10, 0) + 5) ** 2)
+
+    rustuna_study = rustuna.create_study(sampler=rustuna.samplers.RandomSampler())
+    rustuna_study.optimize(objective, n_trials=20)
+
+    optuna_study = ToOptunaStudy(rustuna_study)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", optuna.exceptions.ExperimentalWarning)
+        warnings.filterwarnings(
+            "ignore",
+            message=r"Contour plot will not be displayed because .* cannot co-exist in `trial.params`\.",
+            category=UserWarning,
+        )
+        fig = plot_func(optuna_study)  # Must not raise exception here.
+    if isinstance(fig, Axes):
+        plt.close()


### PR DESCRIPTION
## Usage

```python
import rustuna
from rustuna.converter import ToOptunaStudy
from optuna.visualization.matplotlib import plot_optimization_history
import matplotlib.pylab as plt


def run_rustuna_study() -> rustuna.Study:
    def objective(trial: rustuna.Trial) -> float:
        x = trial.suggest_float("x", -10, 10)
        _ = trial.suggest_int("y", -10, 10, step=2)
        _ = trial.suggest_categorical("z", ["foo", -10, 5.0, True])

        trial.set_user_attrs({"foo": "bar"})
        return (x - 5) ** 2

    study = rustuna.create_study(study_name="visualization-test")
    study.optimize(objective, n_trials=100)
    return study


def main() -> None:
    study = ToOptunaStudy(run_rustuna_study())
    plot_optimization_history(study)
    plt.savefig("./optuna_optimization_history.png")


if __name__ == "__main__":
    main()
```

<img width="640" height="480" alt="626779457-570d4467-70a3-46f0-b356-6cf52102fdfa" src="https://github.com/user-attachments/assets/e98d9d49-2f75-4958-9e0d-ab840839d3b6" />
