### PR TITLE
Avoid Already borrowed errors in storage bindings

### DIFF
--- a/rustuna_pyo3/src/storage/binding.rs
+++ b/rustuna_pyo3/src/storage/binding.rs
@@ -54,7 +54,7 @@ impl StorageBinding {
     }
 
     pub(crate) fn create_new_trial(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         template_trial: Option<&Bound<'_, PyPersistedTrial>>,
@@ -81,7 +81,7 @@ impl StorageBinding {
     }
 
     pub(crate) fn set_trial_param(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         name: String,
@@ -118,7 +118,7 @@ impl StorageBinding {
     }
 
     pub(crate) fn set_category_labels(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         param_name: String,
@@ -135,7 +135,7 @@ impl StorageBinding {
     }
 
     pub(crate) fn get_category_labels(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         param_name: String,
@@ -167,7 +167,7 @@ impl StorageBinding {
     }
 
     pub(crate) fn set_trial_state_values(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         state: PyTrialState,
@@ -197,7 +197,7 @@ impl StorageBinding {
         })
     }
 
-    pub(crate) fn get_studies(&mut self, py: Python<'_>) -> PyResult<Vec<PyPersistedStudy>> {
+    pub(crate) fn get_studies(&self, py: Python<'_>) -> PyResult<Vec<PyPersistedStudy>> {
         py.detach(|| -> PyResult<Vec<PyPersistedStudy>> {
             let mut guard = self.storage.write().map_err(|e| {
                 PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
@@ -209,11 +209,7 @@ impl StorageBinding {
         })
     }
 
-    pub(crate) fn get_study(
-        &mut self,
-        py: Python<'_>,
-        study_id: u32,
-    ) -> PyResult<PyPersistedStudy> {
+    pub(crate) fn get_study(&self, py: Python<'_>, study_id: u32) -> PyResult<PyPersistedStudy> {
         py.detach(|| -> PyResult<PyPersistedStudy> {
             let mut guard = self.storage.write().map_err(|e| {
                 PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
@@ -224,7 +220,7 @@ impl StorageBinding {
     }
 
     pub(crate) fn get_trials(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         states: Option<Vec<PyTrialState>>,
@@ -247,11 +243,7 @@ impl StorageBinding {
         })
     }
 
-    pub(crate) fn get_trial(
-        &mut self,
-        py: Python<'_>,
-        trial_id: u32,
-    ) -> PyResult<PyPersistedTrial> {
+    pub(crate) fn get_trial(&self, py: Python<'_>, trial_id: u32) -> PyResult<PyPersistedTrial> {
         py.detach(|| -> PyResult<PyPersistedTrial> {
             let mut guard = self.storage.write().map_err(|e| {
                 PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
@@ -286,7 +278,7 @@ impl StorageBinding {
     }
 
     pub(crate) fn get_study_user_attr(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         key: String,
@@ -302,7 +294,7 @@ impl StorageBinding {
     }
 
     pub(crate) fn get_study_system_attr(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         key: String,
@@ -318,7 +310,7 @@ impl StorageBinding {
     }
 
     pub(crate) fn get_trial_id_from_study_id_trial_number(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         trial_number: u32,
@@ -335,7 +327,7 @@ impl StorageBinding {
     }
 
     pub(crate) fn set_study_system_attrs(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         attrs: Py<PyAny>,
@@ -354,7 +346,7 @@ impl StorageBinding {
     }
 
     pub(crate) fn set_study_user_attrs(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         attrs: Py<PyAny>,
@@ -373,7 +365,7 @@ impl StorageBinding {
     }
 
     pub(crate) fn set_trial_system_attrs(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         attrs: Py<PyAny>,
@@ -392,7 +384,7 @@ impl StorageBinding {
     }
 
     pub(crate) fn set_trial_user_attrs(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         attrs: Py<PyAny>,
@@ -411,7 +403,7 @@ impl StorageBinding {
     }
 
     pub(crate) fn set_trial_intermediate_value(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         step: u32,
@@ -431,7 +423,7 @@ impl StorageBinding {
         })
     }
 
-    pub(crate) fn discard_trials(&mut self, py: Python<'_>, trial_ids: Vec<u32>) -> PyResult<()> {
+    pub(crate) fn discard_trials(&self, py: Python<'_>, trial_ids: Vec<u32>) -> PyResult<()> {
         py.detach(|| -> PyResult<()> {
             let mut guard = self.storage.write().map_err(|e| {
                 PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
@@ -455,7 +447,7 @@ impl StorageBinding {
 
 impl StorageBinding {
     fn set_category_labels_internal(
-        &mut self,
+        &self,
         study_id: u32,
         param_name: String,
         category_labels: Vec<CategoryLabel>,

--- a/rustuna_pyo3/src/storage/in_memory.rs
+++ b/rustuna_pyo3/src/storage/in_memory.rs
@@ -44,7 +44,7 @@ impl PyInMemoryStorage {
     }
 
     fn create_new_study(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_name: String,
         directions: Vec<PyDirection>,
@@ -52,13 +52,13 @@ impl PyInMemoryStorage {
         self.binding.create_new_study(py, study_name, directions)
     }
 
-    fn delete_study(&mut self, py: Python<'_>, study_id: u32) -> PyResult<()> {
+    fn delete_study(&self, py: Python<'_>, study_id: u32) -> PyResult<()> {
         self.binding.delete_study(py, study_id)
     }
 
     #[pyo3(signature = (study_id, template_trial=None))]
     fn create_new_trial(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         template_trial: Option<&Bound<'_, PyPersistedTrial>>,
@@ -67,7 +67,7 @@ impl PyInMemoryStorage {
     }
 
     fn set_trial_param(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         name: String,
@@ -79,7 +79,7 @@ impl PyInMemoryStorage {
     }
 
     fn set_category_labels(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         param_name: String,
@@ -90,7 +90,7 @@ impl PyInMemoryStorage {
     }
 
     fn get_category_labels(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         param_name: String,
@@ -102,7 +102,7 @@ impl PyInMemoryStorage {
 
     #[pyo3(signature = (trial_id, state, values=None))]
     fn set_trial_state_values(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         state: PyTrialState,
@@ -112,17 +112,17 @@ impl PyInMemoryStorage {
             .set_trial_state_values(py, trial_id, state, values)
     }
 
-    fn get_studies(&mut self, py: Python<'_>) -> PyResult<Vec<PyPersistedStudy>> {
+    fn get_studies(&self, py: Python<'_>) -> PyResult<Vec<PyPersistedStudy>> {
         self.binding.get_studies(py)
     }
 
-    fn get_study(&mut self, py: Python<'_>, study_id: u32) -> PyResult<PyPersistedStudy> {
+    fn get_study(&self, py: Python<'_>, study_id: u32) -> PyResult<PyPersistedStudy> {
         self.binding.get_study(py, study_id)
     }
 
     #[pyo3(signature = (study_id, *, states = None))]
     fn get_trials(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         states: Option<Vec<PyTrialState>>,
@@ -130,7 +130,7 @@ impl PyInMemoryStorage {
         self.binding.get_trials(py, study_id, states)
     }
 
-    fn get_trial(&mut self, py: Python<'_>, trial_id: u32) -> PyResult<PyPersistedTrial> {
+    fn get_trial(&self, py: Python<'_>, trial_id: u32) -> PyResult<PyPersistedTrial> {
         self.binding.get_trial(py, trial_id)
     }
 
@@ -138,17 +138,12 @@ impl PyInMemoryStorage {
         self.binding.get_cached_trial(py, trial_id)
     }
 
-    fn get_study_user_attr(
-        &mut self,
-        py: Python<'_>,
-        study_id: u32,
-        key: String,
-    ) -> PyResult<String> {
+    fn get_study_user_attr(&self, py: Python<'_>, study_id: u32, key: String) -> PyResult<String> {
         self.binding.get_study_user_attr(py, study_id, key)
     }
 
     fn get_study_system_attr(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         key: String,
@@ -157,7 +152,7 @@ impl PyInMemoryStorage {
     }
 
     fn get_trial_id_from_study_id_trial_number(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         trial_number: u32,
@@ -167,7 +162,7 @@ impl PyInMemoryStorage {
     }
 
     fn set_study_system_attrs(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         attrs: Py<PyAny>,
@@ -176,7 +171,7 @@ impl PyInMemoryStorage {
     }
 
     fn set_study_user_attrs(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         attrs: Py<PyAny>,
@@ -185,7 +180,7 @@ impl PyInMemoryStorage {
     }
 
     fn set_trial_system_attrs(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         attrs: Py<PyAny>,
@@ -194,7 +189,7 @@ impl PyInMemoryStorage {
     }
 
     fn set_trial_user_attrs(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         attrs: Py<PyAny>,
@@ -203,7 +198,7 @@ impl PyInMemoryStorage {
     }
 
     fn set_trial_intermediate_value(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         step: u32,
@@ -213,7 +208,7 @@ impl PyInMemoryStorage {
             .set_trial_intermediate_value(py, trial_id, step, intermediate_value)
     }
 
-    fn discard_trials(&mut self, py: Python<'_>, trial_ids: Vec<u32>) -> PyResult<()> {
+    fn discard_trials(&self, py: Python<'_>, trial_ids: Vec<u32>) -> PyResult<()> {
         self.binding.discard_trials(py, trial_ids)
     }
 

--- a/rustuna_pyo3/src/storage/journal.rs
+++ b/rustuna_pyo3/src/storage/journal.rs
@@ -45,7 +45,7 @@ impl PyJournalFileStorage {
     }
 
     fn create_new_study(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_name: String,
         directions: Vec<PyDirection>,
@@ -53,13 +53,13 @@ impl PyJournalFileStorage {
         self.binding.create_new_study(py, study_name, directions)
     }
 
-    fn delete_study(&mut self, py: Python<'_>, study_id: u32) -> PyResult<()> {
+    fn delete_study(&self, py: Python<'_>, study_id: u32) -> PyResult<()> {
         self.binding.delete_study(py, study_id)
     }
 
     #[pyo3(signature = (study_id, template_trial=None))]
     fn create_new_trial(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         template_trial: Option<&Bound<'_, PyPersistedTrial>>,
@@ -68,7 +68,7 @@ impl PyJournalFileStorage {
     }
 
     fn set_trial_param(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         name: String,
@@ -80,7 +80,7 @@ impl PyJournalFileStorage {
     }
 
     fn set_category_labels(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         param_name: String,
@@ -91,7 +91,7 @@ impl PyJournalFileStorage {
     }
 
     fn get_category_labels(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         param_name: String,
@@ -103,7 +103,7 @@ impl PyJournalFileStorage {
 
     #[pyo3(signature = (trial_id, state, values=None))]
     fn set_trial_state_values(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         state: PyTrialState,
@@ -113,17 +113,17 @@ impl PyJournalFileStorage {
             .set_trial_state_values(py, trial_id, state, values)
     }
 
-    fn get_studies(&mut self, py: Python<'_>) -> PyResult<Vec<PyPersistedStudy>> {
+    fn get_studies(&self, py: Python<'_>) -> PyResult<Vec<PyPersistedStudy>> {
         self.binding.get_studies(py)
     }
 
-    fn get_study(&mut self, py: Python<'_>, study_id: u32) -> PyResult<PyPersistedStudy> {
+    fn get_study(&self, py: Python<'_>, study_id: u32) -> PyResult<PyPersistedStudy> {
         self.binding.get_study(py, study_id)
     }
 
     #[pyo3(signature = (study_id, *, states = None))]
     fn get_trials(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         states: Option<Vec<PyTrialState>>,
@@ -131,7 +131,7 @@ impl PyJournalFileStorage {
         self.binding.get_trials(py, study_id, states)
     }
 
-    fn get_trial(&mut self, py: Python<'_>, trial_id: u32) -> PyResult<PyPersistedTrial> {
+    fn get_trial(&self, py: Python<'_>, trial_id: u32) -> PyResult<PyPersistedTrial> {
         self.binding.get_trial(py, trial_id)
     }
 
@@ -139,17 +139,12 @@ impl PyJournalFileStorage {
         self.binding.get_cached_trial(py, trial_id)
     }
 
-    fn get_study_user_attr(
-        &mut self,
-        py: Python<'_>,
-        study_id: u32,
-        key: String,
-    ) -> PyResult<String> {
+    fn get_study_user_attr(&self, py: Python<'_>, study_id: u32, key: String) -> PyResult<String> {
         self.binding.get_study_user_attr(py, study_id, key)
     }
 
     fn get_study_system_attr(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         key: String,
@@ -158,7 +153,7 @@ impl PyJournalFileStorage {
     }
 
     fn get_trial_id_from_study_id_trial_number(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         trial_number: u32,
@@ -168,7 +163,7 @@ impl PyJournalFileStorage {
     }
 
     fn set_study_system_attrs(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         attrs: Py<PyAny>,
@@ -177,7 +172,7 @@ impl PyJournalFileStorage {
     }
 
     fn set_study_user_attrs(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         attrs: Py<PyAny>,
@@ -186,7 +181,7 @@ impl PyJournalFileStorage {
     }
 
     fn set_trial_system_attrs(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         attrs: Py<PyAny>,
@@ -195,7 +190,7 @@ impl PyJournalFileStorage {
     }
 
     fn set_trial_user_attrs(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         attrs: Py<PyAny>,
@@ -204,7 +199,7 @@ impl PyJournalFileStorage {
     }
 
     fn set_trial_intermediate_value(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         step: u32,
@@ -214,7 +209,7 @@ impl PyJournalFileStorage {
             .set_trial_intermediate_value(py, trial_id, step, intermediate_value)
     }
 
-    fn discard_trials(&mut self, py: Python<'_>, trial_ids: Vec<u32>) -> PyResult<()> {
+    fn discard_trials(&self, py: Python<'_>, trial_ids: Vec<u32>) -> PyResult<()> {
         self.binding.discard_trials(py, trial_ids)
     }
 

--- a/rustuna_pyo3/src/storage/sqlite3.rs
+++ b/rustuna_pyo3/src/storage/sqlite3.rs
@@ -44,7 +44,7 @@ impl PySQLite3Storage {
     }
 
     fn create_new_study(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_name: String,
         directions: Vec<PyDirection>,
@@ -52,13 +52,13 @@ impl PySQLite3Storage {
         self.binding.create_new_study(py, study_name, directions)
     }
 
-    fn delete_study(&mut self, py: Python<'_>, study_id: u32) -> PyResult<()> {
+    fn delete_study(&self, py: Python<'_>, study_id: u32) -> PyResult<()> {
         self.binding.delete_study(py, study_id)
     }
 
     #[pyo3(signature = (study_id, template_trial=None))]
     fn create_new_trial(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         template_trial: Option<&Bound<'_, PyPersistedTrial>>,
@@ -67,7 +67,7 @@ impl PySQLite3Storage {
     }
 
     fn set_trial_param(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         name: String,
@@ -79,7 +79,7 @@ impl PySQLite3Storage {
     }
 
     fn set_category_labels(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         param_name: String,
@@ -90,7 +90,7 @@ impl PySQLite3Storage {
     }
 
     fn get_category_labels(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         param_name: String,
@@ -102,7 +102,7 @@ impl PySQLite3Storage {
 
     #[pyo3(signature = (trial_id, state, values=None))]
     fn set_trial_state_values(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         state: PyTrialState,
@@ -112,17 +112,17 @@ impl PySQLite3Storage {
             .set_trial_state_values(py, trial_id, state, values)
     }
 
-    fn get_studies(&mut self, py: Python<'_>) -> PyResult<Vec<PyPersistedStudy>> {
+    fn get_studies(&self, py: Python<'_>) -> PyResult<Vec<PyPersistedStudy>> {
         self.binding.get_studies(py)
     }
 
-    fn get_study(&mut self, py: Python<'_>, study_id: u32) -> PyResult<PyPersistedStudy> {
+    fn get_study(&self, py: Python<'_>, study_id: u32) -> PyResult<PyPersistedStudy> {
         self.binding.get_study(py, study_id)
     }
 
     #[pyo3(signature = (study_id, *, states = None))]
     fn get_trials(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         states: Option<Vec<PyTrialState>>,
@@ -130,7 +130,7 @@ impl PySQLite3Storage {
         self.binding.get_trials(py, study_id, states)
     }
 
-    fn get_trial(&mut self, py: Python<'_>, trial_id: u32) -> PyResult<PyPersistedTrial> {
+    fn get_trial(&self, py: Python<'_>, trial_id: u32) -> PyResult<PyPersistedTrial> {
         self.binding.get_trial(py, trial_id)
     }
 
@@ -138,17 +138,12 @@ impl PySQLite3Storage {
         self.binding.get_cached_trial(py, trial_id)
     }
 
-    fn get_study_user_attr(
-        &mut self,
-        py: Python<'_>,
-        study_id: u32,
-        key: String,
-    ) -> PyResult<String> {
+    fn get_study_user_attr(&self, py: Python<'_>, study_id: u32, key: String) -> PyResult<String> {
         self.binding.get_study_user_attr(py, study_id, key)
     }
 
     fn get_study_system_attr(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         key: String,
@@ -157,7 +152,7 @@ impl PySQLite3Storage {
     }
 
     fn get_trial_id_from_study_id_trial_number(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         trial_number: u32,
@@ -167,7 +162,7 @@ impl PySQLite3Storage {
     }
 
     fn set_study_system_attrs(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         attrs: Py<PyAny>,
@@ -176,7 +171,7 @@ impl PySQLite3Storage {
     }
 
     fn set_study_user_attrs(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         attrs: Py<PyAny>,
@@ -185,7 +180,7 @@ impl PySQLite3Storage {
     }
 
     fn set_trial_system_attrs(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         attrs: Py<PyAny>,
@@ -194,7 +189,7 @@ impl PySQLite3Storage {
     }
 
     fn set_trial_user_attrs(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         attrs: Py<PyAny>,
@@ -203,7 +198,7 @@ impl PySQLite3Storage {
     }
 
     fn set_trial_intermediate_value(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         step: u32,
@@ -213,7 +208,7 @@ impl PySQLite3Storage {
             .set_trial_intermediate_value(py, trial_id, step, intermediate_value)
     }
 
-    fn discard_trials(&mut self, py: Python<'_>, trial_ids: Vec<u32>) -> PyResult<()> {
+    fn discard_trials(&self, py: Python<'_>, trial_ids: Vec<u32>) -> PyResult<()> {
         self.binding.discard_trials(py, trial_ids)
     }
 

--- a/rustuna_pyo3/src/storage/to_python.rs
+++ b/rustuna_pyo3/src/storage/to_python.rs
@@ -37,7 +37,7 @@ impl ToPythonStorage {
     }
 
     fn create_new_study(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_name: String,
         directions: Vec<PyDirection>,
@@ -45,13 +45,13 @@ impl ToPythonStorage {
         self.binding.create_new_study(py, study_name, directions)
     }
 
-    fn delete_study(&mut self, py: Python<'_>, study_id: u32) -> PyResult<()> {
+    fn delete_study(&self, py: Python<'_>, study_id: u32) -> PyResult<()> {
         self.binding.delete_study(py, study_id)
     }
 
     #[pyo3(signature = (study_id, template_trial=None))]
     fn create_new_trial(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         template_trial: Option<&Bound<'_, PyPersistedTrial>>,
@@ -60,7 +60,7 @@ impl ToPythonStorage {
     }
 
     fn set_trial_param(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         name: String,
@@ -72,7 +72,7 @@ impl ToPythonStorage {
     }
 
     fn set_category_labels(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         param_name: String,
@@ -83,7 +83,7 @@ impl ToPythonStorage {
     }
 
     fn get_category_labels(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         param_name: String,
@@ -95,7 +95,7 @@ impl ToPythonStorage {
 
     #[pyo3(signature = (trial_id, state, values=None))]
     fn set_trial_state_values(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         state: PyTrialState,
@@ -105,17 +105,17 @@ impl ToPythonStorage {
             .set_trial_state_values(py, trial_id, state, values)
     }
 
-    fn get_studies(&mut self, py: Python<'_>) -> PyResult<Vec<PyPersistedStudy>> {
+    fn get_studies(&self, py: Python<'_>) -> PyResult<Vec<PyPersistedStudy>> {
         self.binding.get_studies(py)
     }
 
-    fn get_study(&mut self, py: Python<'_>, study_id: u32) -> PyResult<PyPersistedStudy> {
+    fn get_study(&self, py: Python<'_>, study_id: u32) -> PyResult<PyPersistedStudy> {
         self.binding.get_study(py, study_id)
     }
 
     #[pyo3(signature = (study_id, *, states = None))]
     fn get_trials(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         states: Option<Vec<PyTrialState>>,
@@ -123,7 +123,7 @@ impl ToPythonStorage {
         self.binding.get_trials(py, study_id, states)
     }
 
-    fn get_trial(&mut self, py: Python<'_>, trial_id: u32) -> PyResult<PyPersistedTrial> {
+    fn get_trial(&self, py: Python<'_>, trial_id: u32) -> PyResult<PyPersistedTrial> {
         self.binding.get_trial(py, trial_id)
     }
 
@@ -131,17 +131,12 @@ impl ToPythonStorage {
         self.binding.get_cached_trial(py, trial_id)
     }
 
-    fn get_study_user_attr(
-        &mut self,
-        py: Python<'_>,
-        study_id: u32,
-        key: String,
-    ) -> PyResult<String> {
+    fn get_study_user_attr(&self, py: Python<'_>, study_id: u32, key: String) -> PyResult<String> {
         self.binding.get_study_user_attr(py, study_id, key)
     }
 
     fn get_study_system_attr(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         key: String,
@@ -150,7 +145,7 @@ impl ToPythonStorage {
     }
 
     fn get_trial_id_from_study_id_trial_number(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         trial_number: u32,
@@ -160,7 +155,7 @@ impl ToPythonStorage {
     }
 
     fn set_study_system_attrs(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         attrs: Py<PyAny>,
@@ -169,7 +164,7 @@ impl ToPythonStorage {
     }
 
     fn set_study_user_attrs(
-        &mut self,
+        &self,
         py: Python<'_>,
         study_id: u32,
         attrs: Py<PyAny>,
@@ -178,7 +173,7 @@ impl ToPythonStorage {
     }
 
     fn set_trial_system_attrs(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         attrs: Py<PyAny>,
@@ -187,7 +182,7 @@ impl ToPythonStorage {
     }
 
     fn set_trial_user_attrs(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         attrs: Py<PyAny>,
@@ -196,7 +191,7 @@ impl ToPythonStorage {
     }
 
     fn set_trial_intermediate_value(
-        &mut self,
+        &self,
         py: Python<'_>,
         trial_id: u32,
         step: u32,
@@ -206,7 +201,7 @@ impl ToPythonStorage {
             .set_trial_intermediate_value(py, trial_id, step, intermediate_value)
     }
 
-    fn discard_trials(&mut self, py: Python<'_>, trial_ids: Vec<u32>) -> PyResult<()> {
+    fn discard_trials(&self, py: Python<'_>, trial_ids: Vec<u32>) -> PyResult<()> {
         self.binding.discard_trials(py, trial_ids)
     }
 


### PR DESCRIPTION
## Summary

- Change storage binding methods from `&mut self` to `&self`.
- Apply the change to `StorageBinding` and all Python storage wrappers.
- Avoid PyO3 runtime borrow conflicts when storage methods are called concurrently or reentrantly.

## Motivation

The storage wrapper itself does not require exclusive access. The underlying storage is already shared through `Arc<RwLock<dyn Storage>>`, which provides the necessary synchronization.

Using `&mut self` caused PyO3's runtime borrow checking to reject some nested or concurrent calls with:

```text
RuntimeError: Already borrowed
```

Using shared receivers allows multiple storage operations to access the wrapper while preserving synchronization through the existing storage lock.