### PR TITLE
Add API documentation for `rustuna.converter`

### DIFF
--- a/docs/docs/api/converter.md
+++ b/docs/docs/api/converter.md
@@ -1,0 +1,47 @@
+# rustuna.converter
+
+The `converter` module provides adapters and conversion functions for using
+Rustuna objects through Optuna's Python interfaces and for using Optuna
+objects from Rustuna.
+
+## From Rustuna to Optuna
+
+::: rustuna.converter.ToOptunaStudy
+
+::: rustuna.converter.ToOptunaSampler
+
+::: rustuna.converter.ToOptunaStorage
+
+::: rustuna.converter.to_optuna_direction
+
+::: rustuna.converter.to_optuna_directions
+
+::: rustuna.converter.to_optuna_distribution
+
+::: rustuna.converter.to_optuna_distributions
+
+::: rustuna.converter.to_frozen_study
+
+::: rustuna.converter.FrozenTrialLike
+
+::: rustuna.converter.to_frozen_trial
+
+::: rustuna.converter.to_optuna_state
+
+## From Optuna to Rustuna
+
+::: rustuna.converter.ToRustunaStorage
+
+::: rustuna.converter.to_rustuna_direction
+
+::: rustuna.converter.to_rustuna_directions
+
+::: rustuna.converter.to_rustuna_distribution
+
+::: rustuna.converter.to_rustuna_distributions
+
+::: rustuna.converter.to_persisted_study
+
+::: rustuna.converter.to_persisted_trial
+
+::: rustuna.converter.to_rustuna_state

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
       - rustuna.trial_queue: api/trial_queue.md
       - rustuna.distributions: api/distributions.md
       - rustuna.importance: api/importance.md
+      - rustuna.converter: api/converter.md
 
 markdown_extensions:
   - attr_list

--- a/rustuna_pyo3/rustuna/converter/_direction.py
+++ b/rustuna_pyo3/rustuna/converter/_direction.py
@@ -10,18 +10,25 @@ import rustuna
 def to_rustuna_directions(
     items: Sequence[optuna.study.StudyDirection],
 ) -> list[rustuna.study.StudyDirection]:
+    """Convert a sequence of Optuna directions to Rustuna directions."""
     return [to_rustuna_direction(item) for item in items]
 
 
 def to_optuna_directions(
     items: Sequence[rustuna.study.StudyDirection],
 ) -> list[optuna.study.StudyDirection]:
+    """Convert a sequence of Rustuna directions to Optuna directions."""
     return [to_optuna_direction(item) for item in items]
 
 
 def to_rustuna_direction(
     item: optuna.study.StudyDirection,
 ) -> rustuna.study.StudyDirection:
+    """Convert one Optuna direction to a Rustuna direction.
+
+    Raises:
+        ValueError: If ``item`` is ``StudyDirection.UNSET``.
+    """
     if item == optuna.study.StudyDirection.MAXIMIZE:
         return rustuna.study.StudyDirection.MAXIMIZE
     elif item == optuna.study.StudyDirection.MINIMIZE:
@@ -33,6 +40,7 @@ def to_rustuna_direction(
 def to_optuna_direction(
     item: rustuna.study.StudyDirection,
 ) -> optuna.study.StudyDirection:
+    """Convert one Rustuna direction to an Optuna direction."""
     if item == rustuna.study.StudyDirection.MAXIMIZE:
         return optuna.study.StudyDirection.MAXIMIZE
     else:

--- a/rustuna_pyo3/rustuna/converter/_distribution.py
+++ b/rustuna_pyo3/rustuna/converter/_distribution.py
@@ -9,18 +9,25 @@ from rustuna._rustuna import Distribution
 def to_optuna_distributions(
     src: dict[str, Distribution],
 ) -> dict[str, optuna.distributions.BaseDistribution]:
+    """Convert a mapping of Rustuna distributions to Optuna distributions."""
     return {k: to_optuna_distribution(v) for k, v in src.items()}
 
 
 def to_rustuna_distributions(
     src: dict[str, optuna.distributions.BaseDistribution],
 ) -> dict[str, Distribution]:
+    """Convert a mapping of Optuna distributions to Rustuna distributions."""
     return {k: to_rustuna_distribution(v) for k, v in src.items()}
 
 
 def to_optuna_distribution(
     src: Distribution,
 ) -> optuna.distributions.BaseDistribution:
+    """Convert a Rustuna distribution to its Optuna counterpart.
+
+    Raises:
+        ValueError: If the distribution type is not supported.
+    """
     d = src.to_dict()
     if d["type"] == "FloatDistribution":
         return optuna.distributions.FloatDistribution(
@@ -39,6 +46,11 @@ def to_optuna_distribution(
 def to_rustuna_distribution(
     src: optuna.distributions.BaseDistribution,
 ) -> Distribution:
+    """Convert an Optuna distribution to its Rustuna counterpart.
+
+    Raises:
+        ValueError: If the distribution type is not supported.
+    """
     if isinstance(src, optuna.distributions.FloatDistribution):
         return rustuna.distributions.FloatDistribution(
             low=src.low,

--- a/rustuna_pyo3/rustuna/converter/_frozen_study.py
+++ b/rustuna_pyo3/rustuna/converter/_frozen_study.py
@@ -9,6 +9,7 @@ from ._direction import to_optuna_directions, to_rustuna_directions
 
 
 def to_frozen_study(study: rustuna.study.PersistedStudy) -> FrozenStudy:
+    """Convert a Rustuna persisted study to an Optuna frozen study."""
     return FrozenStudy(
         study_name=study.name,
         study_id=study.id,
@@ -20,6 +21,7 @@ def to_frozen_study(study: rustuna.study.PersistedStudy) -> FrozenStudy:
 
 
 def to_persisted_study(study: FrozenStudy) -> rustuna.study.PersistedStudy:
+    """Convert an Optuna frozen study to a Rustuna persisted study."""
     return rustuna.study.PersistedStudy(
         id=study._study_id,
         name=study.study_name,

--- a/rustuna_pyo3/rustuna/converter/_sampler.py
+++ b/rustuna_pyo3/rustuna/converter/_sampler.py
@@ -26,6 +26,29 @@ if TYPE_CHECKING:
 
 
 class ToOptunaSampler(BaseSampler):
+    """Adapt a Rustuna sampler to Optuna's ``BaseSampler`` interface.
+
+    Args:
+        sampler: The Rustuna sampler to adapt.
+
+    Example:
+        Use a Rustuna sampler in an Optuna study.
+
+        ```python
+        import optuna
+        import rustuna
+        from rustuna.converter import ToOptunaSampler
+
+        def objective(trial: optuna.Trial) -> float:
+            # Define your objective function.
+            return trial.suggest_float("x", -1, 1) ** 2
+
+        sampler = ToOptunaSampler(rustuna.samplers.TPESampler())
+        study = optuna.create_study(sampler=sampler)
+        study.optimize(objective, n_trials=10)
+        ```
+    """
+
     def __init__(self, sampler: SamplerProtocol) -> None:
         self._sampler = sampler
         self._inter_section_search_space = IntersectionSearchSpace()
@@ -42,6 +65,7 @@ class ToOptunaSampler(BaseSampler):
         trial: FrozenTrial,
         search_space: dict[str, BaseDistribution],
     ) -> dict[str, Any]:
+        """Sample jointly distributed parameters using the Rustuna sampler."""
         if search_space == {}:
             return {}
 
@@ -77,6 +101,7 @@ class ToOptunaSampler(BaseSampler):
         param_name: str,
         param_distribution: BaseDistribution,
     ) -> Any:
+        """Sample one parameter using the Rustuna sampler."""
         ctx = rustuna.samplers.SamplerContext(
             study_id=study._study_id,
             trial_number=trial.number,
@@ -95,6 +120,7 @@ class ToOptunaSampler(BaseSampler):
         study: Study,
         trial: FrozenTrial,
     ) -> dict[str, BaseDistribution]:
+        """Infer the relative search space supported by the Rustuna sampler."""
         if not self._sampler.support_joint_sampling:
             return {}
 
@@ -117,6 +143,7 @@ class ToOptunaSampler(BaseSampler):
         state: TrialState,
         values: Sequence[float] | None,
     ) -> None:
+        """Notify the Rustuna sampler that a trial has finished."""
         after_trial = getattr(self._sampler, "after_trial", None)
         if after_trial is None:
             return

--- a/rustuna_pyo3/rustuna/converter/_storage.py
+++ b/rustuna_pyo3/rustuna/converter/_storage.py
@@ -41,6 +41,30 @@ logger = optuna.logging.get_logger(__name__)
 
 
 class ToRustunaStorage:
+    """Adapt an Optuna storage to Rustuna's storage protocol.
+
+    Args:
+        storage: The Optuna storage to adapt.
+
+    Example:
+        Use an Optuna SQLite-backed storage with a Rustuna study.
+
+        ```python
+        import optuna
+        import rustuna
+        from rustuna.converter import ToRustunaStorage
+
+        def objective(trial: rustuna.Trial) -> float:
+            # Define your objective function.
+            return trial.suggest_float("x", -1, 1) ** 2
+
+        optuna_storage = optuna.storages.RDBStorage("sqlite:///study.db")
+        storage = ToRustunaStorage(optuna_storage)
+        study = rustuna.create_study(storage=storage)
+        study.optimize(objective, n_trials=10)
+        ```
+    """
+
     def __init__(self, storage: BaseStorage) -> None:
         self._storage = storage
         self._trial_id_to_study_id: dict[int, int] = {}
@@ -207,6 +231,30 @@ class ToRustunaStorage:
 
 
 class ToOptunaStorage(BaseStorage):
+    """Adapt a Rustuna storage to Optuna's ``BaseStorage`` interface.
+
+    Args:
+        storage: The Rustuna storage to adapt.
+
+    Example:
+        Use a Rustuna journal storage with an Optuna study.
+
+        ```python
+        import optuna
+        import rustuna
+        from rustuna.converter import ToOptunaStorage
+
+        def objective(trial: optuna.Trial) -> float:
+            # Define your objective function.
+            return trial.suggest_float("x", -1, 1) ** 2
+
+        rustuna_storage = rustuna.storages.JournalFileStorage("study.log")
+        storage = ToOptunaStorage(rustuna_storage)
+        study = optuna.create_study(storage=storage)
+        study.optimize(objective, n_trials=10)
+        ```
+    """
+
     def __init__(self, storage: rustuna.storages.StorageProtocol) -> None:
         self._storage = storage
         self._trial_cache: dict[int, FrozenTrialLike] = {}

--- a/rustuna_pyo3/rustuna/converter/_study.py
+++ b/rustuna_pyo3/rustuna/converter/_study.py
@@ -22,20 +22,31 @@ class ToOptunaStudy(_OptunaStudy):
     This adapter allows Optuna APIs that consume a study, such as visualization
     functions, to operate on a study created by Rustuna. Trial data is converted
     to Optuna's ``FrozenTrial`` representation, while study operations are
-    forwarded to the underlying Rustuna storage through :class:`ToOptunaStorage`.
+    forwarded to the underlying Rustuna storage through `ToOptunaStorage`.
 
     Args:
         study: The Rustuna study to expose through the Optuna API.
 
-    Note:
-        Rustuna stores user attributes as strings. Attributes written directly
-        through the Rustuna study are exposed with their stored string values,
-        while attributes written through this adapter use Optuna's JSON-compatible
-        representation.
+    Example:
+        Use a Rustuna study with an Optuna visualization function.
+
+        ```python
+        import rustuna
+        from optuna.visualization import plot_optimization_history
+        from rustuna.converter import ToOptunaStudy
+
+        def objective(trial: rustuna.Trial) -> float:
+            # Define your objective function.
+            return trial.suggest_float("x", -1, 1) ** 2
+
+        rustuna_study = rustuna.create_study()
+        rustuna_study.optimize(objective, n_trials=10)
+        optuna_study = ToOptunaStudy(rustuna_study)
+        fig = plot_optimization_history(optuna_study)
+        ```
     """
 
     def __init__(self, study: rustuna.Study):
-        """Create an Optuna-compatible view of ``study``."""
         self._rustuna_study = study
         super().__init__(
             study.study_name,

--- a/rustuna_pyo3/rustuna/converter/_trial.py
+++ b/rustuna_pyo3/rustuna/converter/_trial.py
@@ -39,6 +39,7 @@ to_optuna_state_map = {v: k for k, v in to_rustuna_state_map.items()}
 
 
 def to_optuna_state(state: rustuna.trial.TrialState) -> optuna.trial.TrialState:
+    """Convert a Rustuna trial state to an Optuna trial state."""
     if state == rustuna.trial.TrialState.RUNNING:
         return optuna.trial.TrialState.RUNNING
     elif state == rustuna.trial.TrialState.COMPLETE:
@@ -54,6 +55,7 @@ def to_optuna_state(state: rustuna.trial.TrialState) -> optuna.trial.TrialState:
 
 
 def to_rustuna_state(state: optuna.trial.TrialState) -> rustuna.trial.TrialState:
+    """Convert an Optuna trial state to a Rustuna trial state."""
     return to_rustuna_state_map[state]
 
 
@@ -61,6 +63,7 @@ def to_persisted_trial(
     trial: optuna.trial.FrozenTrial,
     study_id: int,
 ) -> rustuna.trial.PersistedTrial:
+    """Convert an Optuna frozen trial to a Rustuna persisted trial."""
     rustuna_system_attrs = to_rustuna_attrs(trial.system_attrs)
 
     distributions: dict[str, Distribution] = {}
@@ -85,6 +88,12 @@ def to_persisted_trial(
 
 
 class FrozenTrialLike(FrozenTrial):
+    """Lazily convert a Rustuna trial into an Optuna ``FrozenTrial``.
+
+    Args:
+        persisted_trial: The Rustuna trial to expose through the Optuna API.
+    """
+
     def __init__(self, persisted_trial: rustuna.trial.PersistedTrial) -> None:
         self._persisted_trial = persisted_trial
 
@@ -265,12 +274,6 @@ class FrozenTrialLike(FrozenTrial):
 
     @property
     def last_step(self) -> int | None:
-        """Return the maximum step of `intermediate_values` in the trial.
-
-        Returns:
-            The maximum step of intermediates.
-        """
-
         if len(self.intermediate_values) == 0:
             return None
         else:
@@ -278,19 +281,12 @@ class FrozenTrialLike(FrozenTrial):
 
     @property
     def duration(self) -> datetime.timedelta | None:
-        """Return the elapsed time taken to complete the trial.
-
-        Returns:
-            The duration.
-        """
-
         if self.datetime_start and self.datetime_complete:
             return self.datetime_complete - self.datetime_start
         else:
             return None
 
     def __reduce__(self) -> str | tuple[Any, ...]:
-        """Convert to a real FrozenTrial for pickling."""
         frozen_trial = FrozenTrial(
             number=self.number,
             state=self.state,
@@ -376,6 +372,13 @@ def to_frozen_trial(
     *,
     use_frozen_trial_like: bool = True,
 ) -> FrozenTrial:
+    """Convert a Rustuna persisted trial to an Optuna frozen trial.
+
+    Args:
+        persisted_trial: The Rustuna trial to convert.
+        use_frozen_trial_like: If ``True``, return a lazy ``FrozenTrialLike``
+            instance. Otherwise, return a materialized ``FrozenTrial``.
+    """
     ft_like = FrozenTrialLike(persisted_trial)
     if use_frozen_trial_like:
         return ft_like


### PR DESCRIPTION
## Summary

- Add API reference documentation for `rustuna.converter`
- Add all public converter classes and functions to the documentation
- Add docstrings for converter adapters and conversion helpers
- Add concise usage examples for:
  - `ToOptunaStudy`
  - `ToOptunaSampler`
  - `ToOptunaStorage`
  - `ToRustunaStorage`
- Add `rustuna.converter` to the documentation navigation

<img width="1328" height="1288" alt="Screenshot 2026-07-27 19 07 49" src="https://github.com/user-attachments/assets/51f6e64e-1b2a-4bfb-a0e5-77a33d545af3" />
