### PR TITLE
Match Optuna's multivariate default for multi-objective TPESampler

### DIFF
--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -1122,14 +1122,17 @@ class TPESampler:
         seed: Seed for random number generator. If `None`, a random seed is used.
         n_startup_trials: The random sampling is used instead of the TPE algorithm until
             the given number of trials finish in the same study. Defaults to `10`.
-        multivariate: If `True`, the multivariate TPE is used when suggesting parameters.
-            The multivariate TPE samples all parameters jointly, which is reported to
-            outperform the independent TPE. Defaults to `True`.
+        multivariate: If `True`, the multivariate TPE samples all parameters jointly, which is
+            reported to outperform the independent TPE. If `False`, parameters are sampled
+            independently. If `None` (the default), the mode is selected automatically to match
+            Optuna: multivariate for single-objective studies and independent for multi-objective
+            studies.
 
     Note:
-        Multivariate mode is enabled by default (`multivariate=True`).
-        In multivariate mode, TPE samples all non-conditional parameters jointly, which is reported to
-        outperform independent sampling. See
+        By default (`multivariate=None`) multivariate TPE is used for single-objective
+        optimization and independent TPE is used for multi-objective optimization, matching
+        Optuna's `TPESampler`. In multivariate mode, TPE samples all non-conditional parameters
+        jointly, which is reported to outperform independent sampling. See
         [BOHB: Robust and Efficient Hyperparameter Optimization at Scale](http://proceedings.mlr.press/v80/falkner18a.html)
         for more details.
     """
@@ -1138,7 +1141,7 @@ class TPESampler:
         *,
         seed: int | None = None,
         n_startup_trials: int = 10,
-        multivariate: bool = True,
+        multivariate: bool | None = None,
     ) -> None: ...
     @property
     def support_joint_sampling(self) -> bool: ...

--- a/rustuna_pyo3/src/sampler/tpe.rs
+++ b/rustuna_pyo3/src/sampler/tpe.rs
@@ -22,8 +22,12 @@ pub struct PyTpeSampler {
 #[pymethods]
 impl PyTpeSampler {
     #[new]
-    #[pyo3(signature = (*, seed = None, n_startup_trials = 10, multivariate = true))]
-    fn py_new(seed: Option<u64>, n_startup_trials: usize, multivariate: bool) -> PyResult<Self> {
+    #[pyo3(signature = (*, seed = None, n_startup_trials = 10, multivariate = None))]
+    fn py_new(
+        seed: Option<u64>,
+        n_startup_trials: usize,
+        multivariate: Option<bool>,
+    ) -> PyResult<Self> {
         let rs_sampler = TpeSampler::from_config(TpeConfig {
             seed,
             n_startup_trials,

--- a/rustuna_sampler/src/tpe/sampler.rs
+++ b/rustuna_sampler/src/tpe/sampler.rs
@@ -21,8 +21,10 @@ const EPS: f64 = 1e-12;
 pub struct TpeConfig {
     /// Whether to use multivariate TPE for joint suggestions over the inferred search space.
     ///
-    /// When this is `false`, parameters are sampled independently.
-    pub multivariate: bool,
+    /// `Some(true)` forces multivariate (joint) sampling and `Some(false)` forces independent
+    /// (univariate) sampling. `None` selects automatically, matching Optuna: multivariate for
+    /// single-objective studies and independent for multi-objective studies.
+    pub multivariate: Option<bool>,
     /// Number of completed trials to collect before switching from random sampling to TPE.
     pub n_startup_trials: usize,
     /// Optional RNG seed.
@@ -31,7 +33,7 @@ pub struct TpeConfig {
 impl Default for TpeConfig {
     fn default() -> Self {
         Self {
-            multivariate: true,
+            multivariate: None,
             n_startup_trials: 10,
             seed: None,
         }
@@ -94,7 +96,7 @@ type SplitValue = (Vec<u32>, Vec<u32>);
 /// ```
 pub struct TpeSampler {
     rng: StdRng,
-    multivariate: bool,
+    multivariate: Option<bool>,
     n_startup_trials: usize,
     random_sampler: RandomSampler,
     // TODO(y0z): Change to LruCache<(Vec<&PersistedTrial>, usize), (Vec<&PersistedTrial>, Vec<&PersistedTrial>)>
@@ -124,8 +126,9 @@ impl TpeSampler {
 
     /// Creates a sampler with the default configuration.
     ///
-    /// The default configuration enables multivariate TPE and uses random sampling for the first
-    /// 10 completed trials.
+    /// The default configuration selects multivariate TPE automatically (multivariate for
+    /// single-objective, independent for multi-objective, matching Optuna) and uses random
+    /// sampling for the first 10 completed trials.
     pub fn new() -> TpeSampler {
         Self::from_config(TpeConfig::default())
     }
@@ -136,7 +139,7 @@ impl TpeSampler {
     /// generator from the provided seed.
     pub fn seed_from_u64(seed: u64) -> TpeSampler {
         Self::from_config(TpeConfig {
-            multivariate: true,
+            multivariate: None,
             seed: Some(seed),
             n_startup_trials: 10,
         })
@@ -584,7 +587,11 @@ impl Sampler for TpeSampler {
     }
 
     fn support_joint_sampling(&self) -> bool {
-        self.multivariate
+        // `Some(false)` disables joint sampling outright. `Some(true)` and `None` both allow it;
+        // the `None` (auto) case is resolved per objective-count inside `sample_joint`, which
+        // returns an empty map for multi-objective studies so every parameter falls back to
+        // independent sampling (matching Optuna's `multivariate=False` default for MO).
+        self.multivariate != Some(false)
     }
 
     fn sample_joint(
@@ -593,6 +600,14 @@ impl Sampler for TpeSampler {
         storage: Arc<RwLock<dyn Storage>>,
         search_space: &HashMap<String, Distribution>,
     ) -> Result<HashMap<String, f64>> {
+        // Resolve the effective multivariate flag. Default (`None`) follows Optuna: multivariate
+        // for single-objective, independent for multi-objective. Returning an empty map routes
+        // all parameters through independent sampling.
+        let multivariate = self.multivariate.unwrap_or(ctx.directions.len() == 1);
+        if !multivariate {
+            return Ok(HashMap::new());
+        }
+
         let mut guard = storage.write().map_err(|e| {
             Error::with_reason(
                 ErrorKind::Unexpected,


### PR DESCRIPTION
`TPESampler`'s `multivariate` now defaults to `None` (auto) instead of `True`:
- single-objective → multivariate (unchanged)
- multi-objective → independent

This matches Optuna, whose `TPESampler` uses `multivariate=False` for multi-objective studies by default.