### PR TITLE
Support `StudyDirection` in `create_study` direction arguments

### DIFF
--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -330,8 +330,9 @@ def create_study(
     study_name: str | None = None,
     storage: StorageProtocol | None = None,
     sampler: SamplerProtocol | None = None,
-    direction: Literal["minimize"] | Literal["maximize"] | None = None,
-    directions: list[Literal["minimize"] | Literal["maximize"]] | None = None,
+    direction: Literal["minimize"] | Literal["maximize"] | StudyDirection | None = None,
+    directions: Sequence[Literal["minimize"] | Literal["maximize"] | StudyDirection]
+    | None = None,
     load_if_exists: bool = False,
     trial_queue: TrialQueueProtocol | None = None,
 ) -> Study:
@@ -341,9 +342,12 @@ def create_study(
         study_name: Study's name. If omitted, a unique name is generated automatically.
         storage: Storage object to persist study data. If None, InMemoryStorage is used.
         sampler: Sampler object for parameter suggestion. If None, TPESampler is used.
-        direction: Direction of optimization. Either 'minimize' or 'maximize'.
+        direction: Direction of optimization. Either 'minimize', 'maximize', or a
+            ``StudyDirection``.
             Cannot be specified together with ``directions``.
         directions: Directions of optimization for multi-objective optimization.
+            Each direction can be specified as 'minimize', 'maximize', or a
+            ``StudyDirection``.
             Cannot be specified together with ``direction``.
         load_if_exists: If True, return an existing study when ``study_name`` already exists.
         trial_queue: Trial queue object for managing trial execution order. If None,

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -233,8 +233,8 @@ pub fn py_create_study(
     study_name: Option<String>,
     storage: Option<Py<PyAny>>,
     sampler: Option<Py<PyAny>>,
-    direction: Option<String>,
-    directions: Option<Vec<String>>,
+    direction: Option<Py<PyAny>>,
+    directions: Option<Vec<Py<PyAny>>>,
     load_if_exists: bool,
     trial_queue: Option<Py<PyAny>>,
 ) -> PyResult<PyStudy> {
@@ -243,7 +243,7 @@ pub fn py_create_study(
         None => "default".to_string(), // TODO(c-bata): Generate random name with uuid.
     };
     let (storage_arc, storage_pyobj) = Python::attach(|py| into_storage_pyobj(py, storage))?;
-    let directions = convert_directions(direction, directions)?;
+    let directions = Python::attach(|py| convert_directions(py, direction, directions))?;
     let is_multi_objective = directions.len() > 1;
     let (sampler_arc, sampler_pyobj) =
         Python::attach(|py| into_sampler_pyobj(py, sampler, is_multi_objective))?;
@@ -764,38 +764,47 @@ impl From<PyDirection> for Direction {
 }
 
 fn convert_directions(
-    direction: Option<String>,
-    directions: Option<Vec<String>>,
+    py: Python<'_>,
+    direction: Option<Py<PyAny>>,
+    directions: Option<Vec<Py<PyAny>>>,
 ) -> PyResult<Vec<Direction>> {
     if direction.is_some() && directions.is_some() {
         Err(PyValueError::new_err(
             "Cannot specify both `direction` and `directions`",
         ))?;
     };
-    let direction = match direction {
-        Some(d) => match d.as_str() {
-            "minimize" => Direction::Minimize,
-            "maximize" => Direction::Maximize,
-            _ => Err(PyValueError::new_err(
-                "Invalid direction. Please specify either `minimize` or `maximize`",
-            ))?,
-        },
-        None => Direction::Minimize,
-    };
+    let direction = direction
+        .as_ref()
+        .map(|d| convert_direction(d.bind(py)))
+        .transpose()?
+        .unwrap_or(Direction::Minimize);
     let directions = match directions {
         Some(ds) => ds
             .into_iter()
-            .map(|d| match d.as_str() {
-                "minimize" => Ok(Direction::Minimize),
-                "maximize" => Ok(Direction::Maximize),
-                _ => Err(PyValueError::new_err(
-                    "Invalid direction. Please specify either `minimize` or `maximize`",
-                )),
-            })
+            .map(|d| convert_direction(d.bind(py)))
             .collect(),
         None => Ok(vec![direction]),
     }?;
     Ok(directions)
+}
+
+fn convert_direction(direction: &Bound<'_, PyAny>) -> PyResult<Direction> {
+    if let Ok(direction) = direction.extract::<PyDirection>() {
+        return Ok(direction.into());
+    }
+
+    match direction.extract::<String>() {
+        Ok(direction) => match direction.as_str() {
+            "minimize" => Ok(Direction::Minimize),
+            "maximize" => Ok(Direction::Maximize),
+            _ => Err(PyValueError::new_err(
+                "Invalid direction. Please specify either `minimize` or `maximize`",
+            )),
+        },
+        Err(_) => Err(PyValueError::new_err(
+            "Invalid direction. Please specify either `minimize` or `maximize`",
+        )),
+    }
 }
 
 #[pyfunction]

--- a/rustuna_pyo3/tests/test_rustuna.py
+++ b/rustuna_pyo3/tests/test_rustuna.py
@@ -173,6 +173,22 @@ def test_optimize_multi_objective():
     assert len(trial.values) == 2
 
 
+def test_create_study_with_study_direction():
+    study = rustuna.create_study(direction=rustuna.study.StudyDirection.MAXIMIZE)
+    assert study.directions == [rustuna.study.StudyDirection.MAXIMIZE]
+
+    study = rustuna.create_study(
+        directions=[
+            rustuna.study.StudyDirection.MINIMIZE,
+            rustuna.study.StudyDirection.MAXIMIZE,
+        ]
+    )
+    assert study.directions == [
+        rustuna.study.StudyDirection.MINIMIZE,
+        rustuna.study.StudyDirection.MAXIMIZE,
+    ]
+
+
 def test_study():
     study = rustuna.create_study(study_name="example")
 


### PR DESCRIPTION
## Summary

- Allow `rustuna.study.StudyDirection` values for the `direction` argument.
- Allow `rustuna.study.StudyDirection` values in the `directions` argument.
- Preserve support for `"minimize"` and `"maximize"` strings.
- Update type stubs and add tests.
