### PR TITLE
Make `SQLite3Storage` faster

### DIFF
--- a/rustuna_storage/src/sqlite3.rs
+++ b/rustuna_storage/src/sqlite3.rs
@@ -19,6 +19,8 @@ pub struct SQLite3Storage {
 }
 
 const SCHEMA_SQL: &str = include_str!("sqlite3_schema.sql");
+const TRIALS_STUDY_ID_NUMBER_INDEX_SQL: &str =
+    "CREATE INDEX IF NOT EXISTS trials_study_id_number_key ON trials (study_id, number)";
 type TrialRow = (u32, u32, String, Option<String>, Option<String>);
 
 impl SQLite3Storage {
@@ -49,16 +51,25 @@ impl SQLite3Storage {
         })?;
 
         let result = (|| -> Result<()> {
-            if Self::is_initialized(&conn)? {
-                return Ok(());
+            if !Self::is_initialized(&conn)? {
+                conn.execute_batch(SCHEMA_SQL).map_err(|e| {
+                    Error::with_reason(
+                        ErrorKind::StorageError,
+                        format!("Failed to create database: {e}"),
+                    )
+                })?;
             }
 
-            conn.execute_batch(SCHEMA_SQL).map_err(|e| {
-                Error::with_reason(
-                    ErrorKind::StorageError,
-                    format!("Failed to create database: {e}"),
-                )
-            })?;
+            // Optuna's SQLite schema does not include this composite index. Keep it available
+            // when opening a database initialized by an older Rustuna version or by Optuna,
+            // because `SCHEMA_SQL` is skipped for initialized databases.
+            conn.execute_batch(TRIALS_STUDY_ID_NUMBER_INDEX_SQL)
+                .map_err(|e| {
+                    Error::with_reason(
+                        ErrorKind::StorageError,
+                        format!("Failed to create trial lookup index: {e}"),
+                    )
+                })?;
             Ok(())
         })();
 
@@ -1124,32 +1135,52 @@ impl CachedStorageBackend for SQLite3Storage {
             .lock()
             .map_err(|_| Error::new(ErrorKind::StorageError))?;
 
-        // Build SQL query with filters
-        let mut sql = String::from(
-            "SELECT trial_id, number, state, datetime_start, datetime_complete FROM trials WHERE study_id = ?",
-        );
-        let mut params: Vec<Box<dyn rusqlite::ToSql>> = vec![Box::new(study_id)];
-
-        let mut trial_filters = vec!["number > ?".to_string()];
-        params.push(Box::new(trial_number_greater_than));
-
-        // Filter by included_numbers if provided
-        if !included_numbers.is_empty() {
+        let select_columns =
+            "SELECT trial_id, number, state, datetime_start, datetime_complete FROM trials";
+        // Numbers above the threshold are already returned by the range query. Filtering them
+        // out here avoids an unnecessary second scan in the usual case where the current trial
+        // is the only unfinished trial.
+        let included_numbers: Vec<u32> = if trial_number_greater_than < 0 {
+            Vec::new()
+        } else {
+            included_numbers
+                .iter()
+                .copied()
+                .filter(|number| *number <= trial_number_greater_than as u32)
+                .collect()
+        };
+        let (sql, params): (String, Vec<Box<dyn rusqlite::ToSql>>) = if included_numbers.is_empty()
+        {
+            (
+                format!("{select_columns} WHERE study_id = ? AND number > ? ORDER BY trial_id"),
+                vec![Box::new(study_id), Box::new(trial_number_greater_than)],
+            )
+        } else {
             let placeholders = included_numbers
                 .iter()
                 .map(|_| "?")
                 .collect::<Vec<_>>()
                 .join(", ");
-            trial_filters.push(format!("number IN ({placeholders})"));
-            for &num in included_numbers {
-                params.push(Box::new(num));
-            }
-        }
-
-        sql.push_str(" AND (");
-        sql.push_str(&trial_filters.join(" OR "));
-        sql.push(')');
-        sql.push_str(" ORDER BY trial_id");
+            let mut params: Vec<Box<dyn rusqlite::ToSql>> = vec![
+                Box::new(study_id),
+                Box::new(trial_number_greater_than),
+                Box::new(study_id),
+            ];
+            params.extend(
+                included_numbers
+                    .iter()
+                    .map(|number| Box::new(*number) as Box<dyn rusqlite::ToSql>),
+            );
+            (
+                format!(
+                    "{select_columns} WHERE study_id = ? AND number > ? \
+                         UNION ALL \
+                         {select_columns} WHERE study_id = ? AND number IN ({placeholders}) \
+                         ORDER BY trial_id"
+                ),
+                params,
+            )
+        };
 
         let mut stmt = guard.prepare(&sql).map_err(|e| {
             Error::with_reason(
@@ -1741,6 +1772,40 @@ mod tests {
         let study = storage.create_new_study("example", vec![Direction::Minimize])?;
         assert_eq!(study.name, "example");
         assert_eq!(storage.get_studies()?.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn create_database_restores_trial_lookup_index() -> Result<()> {
+        let storage = SQLite3Storage::new(":memory:")?;
+        storage.create_database()?;
+
+        {
+            let conn = storage
+                .conn
+                .lock()
+                .map_err(|_| Error::new(ErrorKind::StorageError))?;
+            conn.execute_batch("DROP INDEX trials_study_id_number_key")
+                .map_err(|e| Error::with_reason(ErrorKind::StorageError, e.to_string()))?;
+        }
+
+        // Existing databases skip SCHEMA_SQL, but the performance-critical index must still be
+        // created when the storage is opened again.
+        storage.create_database()?;
+
+        let conn = storage
+            .conn
+            .lock()
+            .map_err(|_| Error::new(ErrorKind::StorageError))?;
+        let index_name: Option<String> = conn
+            .query_row(
+                "SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?",
+                params!["trials_study_id_number_key"],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|e| Error::with_reason(ErrorKind::StorageError, e.to_string()))?;
+        assert_eq!(index_name.as_deref(), Some("trials_study_id_number_key"));
         Ok(())
     }
 

--- a/rustuna_storage/src/sqlite3_schema.sql
+++ b/rustuna_storage/src/sqlite3_schema.sql
@@ -109,4 +109,7 @@ CREATE TABLE IF NOT EXISTS "trial_values" (
 	UNIQUE (trial_id, objective)
 );
 CREATE INDEX IF NOT EXISTS trials_study_id_key ON trials (study_id);
+-- This composite index is not included in Optuna's SQLite schema. Rustuna adds it
+-- to efficiently refresh trials by study and trial number.
+CREATE INDEX IF NOT EXISTS trials_study_id_number_key ON trials (study_id, number);
 INSERT OR IGNORE INTO version_info (version_info_id, schema_version, library_version) VALUES (1, 12, '4.6.0.dev')


### PR DESCRIPTION
## Summary

SQLite3Storage refreshed trials through `get_trials_diff` while updating parameters and user attributes. The query filtered trials by study_id and number, but the SQLite schema only had an index on study_id. As the number of trials increased, SQLite had to scan an increasing number of rows repeatedly.

This PR adds a composite index on (study_id, number) and separates range-based lookups from explicitly included unfinished trials. The composite index is not included in Optuna's SQLite schema. Therefore, SQLite3Storage.create_database()` also creates the index when opening an existing database initialized by Optuna or an older Rustuna version.


## Benchmark

```python
import tempfile
import time
import rustuna
import optuna

optuna.logging.set_verbosity(optuna.logging.WARNING)

n_params = 10
n_user_attrs = 5
n_trials = 10000


def objective(trial: rustuna.Trial | optuna.Trial) -> float:
    sum = 0.0
    for i in range(n_params):
        xi = trial.suggest_float(f"x{i}", -10, 10)
        sum += (xi - i) ** 2
    for i in range(n_user_attrs):
        trial.set_user_attr(f"key{i}", "value")
    if trial.number % (n_trials / 10) == 0:
        print(f"{trial.number=}: {sum=}")
    return sum


def rustuna_bench() -> float:
    with tempfile.NamedTemporaryFile(suffix=".sqlite3") as f:
        sampler = rustuna.samplers.RandomSampler(seed=1)
        storage = rustuna.storages.SQLite3Storage(file_path=f.name)
        study = rustuna.create_study(sampler=sampler, storage=storage)

        start = time.time()
        study.optimize(objective, n_trials=n_trials)
        elapsed = time.time() - start

        assert len(study.get_trials(states=[rustuna.trial.TrialState.COMPLETE])) == n_trials
    return elapsed


def optuna_bench() -> float:
    with tempfile.NamedTemporaryFile(suffix=".sqlite3") as f:
        sampler = optuna.samplers.RandomSampler(seed=1)
        storage = optuna.storages.RDBStorage(f"sqlite:///{f.name}")
        study = optuna.create_study(sampler=sampler, storage=storage)

        start = time.time()
        study.optimize(objective, n_trials=n_trials)
        elapsed = time.time() - start

        assert len(study.get_trials(states=[optuna.trial.TrialState.COMPLETE])) == n_trials
    return elapsed


if __name__ == "__main__":
    rustuna_elapsed = rustuna_bench()
    print(f"{rustuna_elapsed=}")
    optuna_elapsed = optuna_bench()
    print(f"{optuna_elapsed=}")
```

The benchmark was run with the same objective and varying n_trials. Times are wall-clock seconds measured in the same environment.

| n_trials | Rustuna  | Optuna |
| --- | --- | --- |
| 1,000   |  9.81s | 22.27s |
| 10,000 | 103.79s | 222.43s |