### PR TITLE
Add `readthedocs.yml`

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,24 @@
+version: 2
+
+build:
+  os: ubuntu-lts-latest
+  tools:
+    python: "latest"
+    rust: "latest"
+  jobs:
+    pre_build:
+      - cd rustuna_pyo3 && maturin develop
+
+mkdocs:
+  configuration: docs/mkdocs.yml
+  fail_on_warning: false
+
+formats: all
+
+python:
+  install:
+    - method: uv
+      command: sync
+      path: docs
+      groups:
+        - docs


### PR DESCRIPTION
## Summary

* Add `.readthedocs.yml` to publish the Rustuna document.
* Please refer to https://www.maturin.rs/sphinx.html for how to build PyO3 project on readthedocs.