### PR TITLE
Add link to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Rustuna
 
 :link: [**Website**](https://optuna.org/)
+| :page_with_curl: [**Docs**](https://rustuna.readthedocs.io/)
 | [**Twitter**](https://twitter.com/OptunaAutoML)
 | [**LinkedIn**](https://www.linkedin.com/showcase/optuna/)
 | [**Medium**](https://medium.com/optuna)

--- a/rustuna_pyo3/pyproject.toml
+++ b/rustuna_pyo3/pyproject.toml
@@ -17,6 +17,7 @@ dynamic = ["version"]
 [project.urls]
 homepage = "https://optuna.org/"
 repository = "https://github.com/optuna/rustuna"
+documentation = "https://rustuna.readthedocs.io"
 bugtracker = "https://github.com/optuna/rustuna/issues"
 
 [tool.maturin]


### PR DESCRIPTION
Follow-up #175 

The documentation was successfuly built and published on readthedocs.io. This PR adds link to the documentation on README and pyproject.toml.