### PR TITLE
Add support for `discard_trials` on SQLite3Storage

### DIFF
--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -973,12 +973,14 @@ class SQLite3Storage:
     Args:
         file_path: Path to the SQLite3 database file.
         create_database: If True, initialize the database when it is missing.
+        apply_discard: If True, omit discarded trials from subsequent reads when supported by the database schema.
     """
     def __init__(
         self,
         file_path: str,
         *,
         create_database: bool = True,
+        apply_discard: bool = False,
     ) -> None: ...
     def create_new_study(
         self, study_name: str, directions: list[StudyDirection]

--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -973,7 +973,13 @@ class SQLite3Storage:
     Args:
         file_path: Path to the SQLite3 database file.
         create_database: If True, initialize the database when it is missing.
-        apply_discard: If True, omit discarded trials from subsequent reads when supported by the database schema.
+        apply_discard: If True, omit discarded trials from subsequent reads. ``discard_trials()``
+            marks the trials in the database regardless of this option, so a storage opened with
+            ``apply_discard=False`` still records discards for other readers to apply. Discards
+            need a Rustuna-specific column on the ``trials`` table; it is added by
+            ``create_database``, and enabling this option on a database that lacks it raises an
+            error instead of silently ignoring discards. Discards applied by another process are
+            picked up on the next read, except when that process' clock lags behind.
     """
     def __init__(
         self,

--- a/rustuna_pyo3/src/storage/sqlite3.rs
+++ b/rustuna_pyo3/src/storage/sqlite3.rs
@@ -28,8 +28,8 @@ impl PySQLite3Storage {
 #[pymethods]
 impl PySQLite3Storage {
     #[new]
-    #[pyo3(signature = (file_path, *, create_database = true))]
-    fn py_new(file_path: &str, create_database: bool) -> PyResult<Self> {
+    #[pyo3(signature = (file_path, *, create_database = true, apply_discard = false))]
+    fn py_new(file_path: &str, create_database: bool, apply_discard: bool) -> PyResult<Self> {
         let backend = SQLite3Storage::new(file_path).map_err(|e| {
             PyRuntimeError::new_err(format!("Failed to open the SQLite3 file: {e:?}"))
         })?;
@@ -38,7 +38,10 @@ impl PySQLite3Storage {
                 PyRuntimeError::new_err(format!("Failed to create the database: {e:?}"))
             })?;
         }
-        let arc_storage = Arc::new(RwLock::new(CachedStorage::new(Box::new(backend))));
+        let arc_storage = Arc::new(RwLock::new(CachedStorage::new(
+            Box::new(backend),
+            apply_discard,
+        )));
         let binding = StorageBinding::new(arc_storage);
         Ok(PySQLite3Storage { binding })
     }

--- a/rustuna_pyo3/src/storage/sqlite3.rs
+++ b/rustuna_pyo3/src/storage/sqlite3.rs
@@ -5,7 +5,7 @@ use pyo3::prelude::*;
 
 use rustuna_core::storage::Storage;
 use rustuna_storage::cache::CachedStorage;
-use rustuna_storage::sqlite3::SQLite3Storage;
+use rustuna_storage::sqlite3::{SQLite3Storage, SQLite3StorageOptions};
 
 use crate::distribution::PyDistribution;
 use crate::storage::binding::StorageBinding;
@@ -30,18 +30,22 @@ impl PySQLite3Storage {
     #[new]
     #[pyo3(signature = (file_path, *, create_database = true, apply_discard = false))]
     fn py_new(file_path: &str, create_database: bool, apply_discard: bool) -> PyResult<Self> {
-        let backend = SQLite3Storage::new(file_path).map_err(|e| {
-            PyRuntimeError::new_err(format!("Failed to open the SQLite3 file: {e:?}"))
-        })?;
+        let backend =
+            SQLite3Storage::new_with_option(file_path, SQLite3StorageOptions { apply_discard })
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to open the SQLite3 file: {e:?}"))
+                })?;
         if create_database {
             backend.create_database().map_err(|e| {
                 PyRuntimeError::new_err(format!("Failed to create the database: {e:?}"))
             })?;
         }
-        let arc_storage = Arc::new(RwLock::new(CachedStorage::new(
-            Box::new(backend),
-            apply_discard,
-        )));
+        // After create_database, so that databases initialized by Optuna are migrated rather
+        // than rejected.
+        backend
+            .validate_discard_support()
+            .map_err(|e| PyRuntimeError::new_err(format!("{e:?}")))?;
+        let arc_storage = Arc::new(RwLock::new(CachedStorage::new(Box::new(backend))));
         let binding = StorageBinding::new(arc_storage);
         Ok(PySQLite3Storage { binding })
     }

--- a/rustuna_pyo3/tests/storage_tests/test_sqlite3.py
+++ b/rustuna_pyo3/tests/storage_tests/test_sqlite3.py
@@ -43,6 +43,73 @@ def test_use_optuna_db() -> None:
         assert len(study.trials) == 10
 
 
+def test_optuna_can_use_a_database_created_by_rustuna() -> None:
+    # Rustuna adds a `discarded_at` column to the trials table, so make sure Optuna can still
+    # read and extend a database that Rustuna initialized.
+    with tempfile.TemporaryDirectory() as workdir:
+        file_path = f"{workdir}/test.db"
+        storage = rustuna.storages.SQLite3Storage(file_path, apply_discard=True)
+        study = rustuna.create_study(storage=storage, study_name="example")
+        for _ in range(3):
+            trial = study.ask()
+            study.tell(trial.number, 1.0)
+        trial_ids = [t._trial_id for t in study.trials]
+        storage.discard_trials([trial_ids[0]])
+
+        optuna_study = optuna.load_study(
+            study_name="example", storage=RDBStorage(f"sqlite:///{file_path}")
+        )
+        assert len(optuna_study.trials) == 3
+        optuna_study.optimize(lambda t: t.suggest_float("x", 0, 1), n_trials=2)
+        assert len(optuna_study.trials) == 5
+
+        # The discard survives the writes made through Optuna.
+        storage = rustuna.storages.SQLite3Storage(file_path, apply_discard=True)
+        assert len(storage.get_trials(study._study_id)) == 4
+        with pytest.raises(rustuna.exceptions.TrialDiscarded, match="Trial discarded"):
+            storage.get_trial(trial_ids[0])
+
+
+def test_sqlite3_storage_discards_are_recorded_without_apply_discard() -> None:
+    with tempfile.TemporaryDirectory() as workdir:
+        file_path = f"{workdir}/discarded.db"
+        storage = rustuna.storages.SQLite3Storage(file_path, apply_discard=False)
+        study = rustuna.create_study(storage=storage, study_name="example")
+        for _ in range(2):
+            trial = study.ask()
+            study.tell(trial.number, 1.0)
+        trial_ids = [t._trial_id for t in study.trials]
+
+        # As with JournalStorage, the discard is written even though this storage does not
+        # apply it when reading.
+        storage.discard_trials([trial_ids[0]])
+        assert not storage.may_omit_trials()
+        assert storage.get_trial(trial_ids[0])._trial_id == trial_ids[0]
+
+        storage = rustuna.storages.SQLite3Storage(file_path, apply_discard=True)
+        assert len(storage.get_trials(study._study_id)) == 1
+        with pytest.raises(rustuna.exceptions.TrialDiscarded, match="Trial discarded"):
+            storage.get_trial(trial_ids[0])
+
+
+def test_sqlite3_storage_rejects_apply_discard_without_migration() -> None:
+    with tempfile.TemporaryDirectory() as workdir:
+        file_path = f"{workdir}/optuna.db"
+        # A database created by Optuna has no `discarded_at` column.
+        RDBStorage(f"sqlite:///{file_path}")
+
+        with pytest.raises(RuntimeError, match="discarded_at"):
+            rustuna.storages.SQLite3Storage(
+                file_path, create_database=False, apply_discard=True
+            )
+
+        # create_database migrates the column in, so the same file is usable afterwards.
+        storage = rustuna.storages.SQLite3Storage(
+            file_path, create_database=True, apply_discard=True
+        )
+        assert storage.may_omit_trials()
+
+
 def test_sqlite3_storage_can_apply_discard() -> None:
     with tempfile.TemporaryDirectory() as workdir:
         file_path = f"{workdir}/discarded.db"

--- a/rustuna_pyo3/tests/storage_tests/test_sqlite3.py
+++ b/rustuna_pyo3/tests/storage_tests/test_sqlite3.py
@@ -1,6 +1,7 @@
 import tempfile
 
 import optuna
+import pytest
 from optuna.storages import RDBStorage
 
 import rustuna
@@ -40,3 +41,27 @@ def test_use_optuna_db() -> None:
 
         study.optimize(objective, 10)
         assert len(study.trials) == 10
+
+
+def test_sqlite3_storage_can_apply_discard() -> None:
+    with tempfile.TemporaryDirectory() as workdir:
+        file_path = f"{workdir}/discarded.db"
+        storage = rustuna.storages.SQLite3Storage(file_path, apply_discard=True)
+        study = rustuna.create_study(storage=storage, study_name="example")
+
+        for _ in range(2):
+            trial = study.ask()
+            study.tell(trial.number, 1.0)
+
+        trial_0_id = study.trials[0]._trial_id
+        trial_1_id = study.trials[1]._trial_id
+        storage.discard_trials([trial_0_id])
+        with pytest.raises(rustuna.exceptions.TrialDiscarded, match="Trial discarded"):
+            storage.get_trial(trial_0_id)
+
+        # Resume
+        storage = rustuna.storages.SQLite3Storage(file_path, apply_discard=True)
+        assert len(storage.get_trials(study._study_id)) == 1
+        with pytest.raises(rustuna.exceptions.TrialDiscarded, match="Trial discarded"):
+            storage.get_trial(trial_0_id)
+        assert storage.get_trial(trial_1_id)._trial_id == trial_1_id

--- a/rustuna_storage/src/cache.rs
+++ b/rustuna_storage/src/cache.rs
@@ -9,6 +9,18 @@ use rustuna_core::study_cache::StudyCache;
 use rustuna_core::trial::{PersistedTrial, TrialStateValues};
 use rustuna_core::{Error, ErrorKind, Result};
 
+/// Trials discarded since a previous synchronization point.
+///
+/// See [`CachedStorageBackend::get_discarded_trials_diff`].
+#[derive(Clone, Debug, Default)]
+pub struct DiscardedTrialsDiff {
+    /// Numbers of the trials the backend reports as discarded.
+    pub numbers: Vec<u32>,
+    /// Opaque token to pass as the cursor of the next call. `None` when the backend has no
+    /// discarded trials to report.
+    pub cursor: Option<String>,
+}
+
 /// Backend interface for [`CachedStorage`].
 ///
 /// Unlike `rustuna_core::storage::Storage`, this trait returns owned values instead of references.
@@ -65,9 +77,34 @@ pub trait CachedStorageBackend: Send + Sync {
         attrs: Attrs,
         error_on_overwrite: bool,
     ) -> Result<()>;
+    /// Whether reads from this backend omit discarded trials.
+    ///
+    /// This mirrors `InMemoryStorageOptions::apply_discard` and
+    /// `JournalStorageOptions::apply_discard`: [`Self::discard_trials`] persists the discard
+    /// regardless of this flag, which only decides whether reads apply it.
+    fn apply_discard(&self) -> bool {
+        false
+    }
+    fn discard_trials(&mut self, trial_ids: &[u32]) -> Result<()>;
+
+    /// Returns the trials discarded at or after `cursor`, along with the cursor to pass next
+    /// time. Passing `None` asks for every discarded trial of the study.
+    ///
+    /// [`Self::get_trials_diff`] only revisits unfinished and newly created trials, so a discard
+    /// applied by another process to a trial the cache already holds as finished would otherwise
+    /// stay invisible forever. Backends without discard support return an empty diff.
+    ///
+    /// The cursor is an opaque token produced by the backend. Implementations may return trials
+    /// that were already reported for the previous cursor; applying a discard twice is a no-op.
+    fn get_discarded_trials_diff(
+        &mut self,
+        study_id: u32,
+        cursor: Option<&str>,
+    ) -> Result<DiscardedTrialsDiff>;
 
     // Return trials that need refreshing: unfinished trials in `included_numbers`
     // and trials with trial_number greater than `trial_number_greater_than`.
+    // Discarded trials are excluded when the backend applies discards.
     fn get_trials_diff(
         &mut self,
         study_id: u32,
@@ -88,15 +125,22 @@ pub struct CachedStorage {
     study_caches: HashMap<u32, StudyCache>,
     unfinished_trials: HashMap<u32, Vec<u32>>,
     last_finished_trial_number: HashMap<u32, i32>,
+    // Cursor handed back to CachedStorageBackend::get_discarded_trials_diff, so that picking up
+    // discards made by other processes stays proportional to the number of new discards.
+    discard_cursor: HashMap<u32, String>,
     // Cache for category labels: (study_id, param_name) -> labels
     // Since category labels cannot be overwritten once set, this cache never needs invalidation.
     category_labels_cache: HashMap<(u32, String), Vec<CategoryLabel>>,
 
+    apply_discard: bool,
     backend: Box<dyn CachedStorageBackend>,
 }
 
 impl CachedStorage {
     /// Creates a caching wrapper around the given backend.
+    ///
+    /// Whether discarded trials are omitted from reads is decided by the backend, through
+    /// [`CachedStorageBackend::apply_discard`].
     pub fn new(backend: Box<dyn CachedStorageBackend>) -> CachedStorage {
         CachedStorage {
             studies: Vec::new(),
@@ -105,7 +149,9 @@ impl CachedStorage {
             study_caches: HashMap::new(),
             unfinished_trials: HashMap::new(),
             last_finished_trial_number: HashMap::new(),
+            discard_cursor: HashMap::new(),
             category_labels_cache: HashMap::new(),
+            apply_discard: backend.apply_discard(),
             backend,
         }
     }
@@ -125,37 +171,87 @@ impl CachedStorage {
             .backend
             .get_trials_diff(study_id, &unfinished, last_finished)?;
 
-        if loaded.is_empty() {
+        // `get_trials_diff` never revisits a trial that was already finished when the cursor
+        // passed it, so discards applied by other processes are synchronized separately.
+        let discarded = if self.apply_discard {
+            let cursor = self.discard_cursor.get(&study_id).cloned();
+            let diff = self
+                .backend
+                .get_discarded_trials_diff(study_id, cursor.as_deref())?;
+            if let Some(cursor) = diff.cursor {
+                self.discard_cursor.insert(study_id, cursor);
+            }
+            diff.numbers
+        } else {
+            Vec::new()
+        };
+
+        if loaded.is_empty() && discarded.is_empty() {
             return Ok(());
         }
 
         let trials = self.trials.entry(study_id).or_default();
+        let max_number = loaded
+            .iter()
+            .map(|trial| trial.number)
+            .chain(discarded.iter().copied())
+            .max();
+        if let Some(max_number) = max_number {
+            if trials.len() <= max_number as usize {
+                trials.resize(max_number as usize + 1, None);
+            }
+        }
         for trial in loaded {
             self.trial_id_to_study_number
                 .insert(trial.id, (study_id, trial.number));
             let trial_number = trial.number as usize;
-            if trials.len() <= trial_number {
-                trials.resize(trial_number + 1, None);
-            }
             trials[trial_number] = Some(trial);
         }
+        // Clearing a slot the backend re-reports is a no-op, so this stays idempotent.
+        for number in discarded {
+            if let Some(slot) = trials.get_mut(number as usize) {
+                *slot = None;
+            }
+        }
 
+        // Note that the joint search space is not recomputed here. StudyCache::update can only
+        // narrow it, so it keeps reflecting the discarded trials.
         let study_cache = self.study_caches.entry(study_id).or_default();
         study_cache.update(trials);
 
+        self.recompute_trial_bookkeeping(study_id);
+        Ok(())
+    }
+
+    /// Recomputes which trials still need refreshing and how far the refresh cursor may advance.
+    fn recompute_trial_bookkeeping(&mut self, study_id: u32) {
+        let apply_discard = self.apply_discard;
+        let Some(trials) = self.trials.get(&study_id) else {
+            return;
+        };
         let mut unfinished_next = vec![];
-        let mut last_finished_next = last_finished;
-        for trial in trials.iter().flatten() {
-            if trial.is_finished() {
-                last_finished_next = last_finished_next.max(trial.number as i32);
-            } else {
-                unfinished_next.push(trial.number);
+        let mut last_finished_next = self
+            .last_finished_trial_number
+            .get(&study_id)
+            .copied()
+            .unwrap_or(-1);
+        for (number, slot) in trials.iter().enumerate() {
+            match slot {
+                // A discarded trial never comes back, so it is as terminal as a finished one.
+                // Letting it advance the cursor is what keeps refreshes incremental after a
+                // whole prefix of the study has been discarded; otherwise the cursor would stay
+                // behind the discarded range and every refresh would rescan it.
+                None if apply_discard => last_finished_next = last_finished_next.max(number as i32),
+                None => {}
+                Some(trial) if trial.is_finished() => {
+                    last_finished_next = last_finished_next.max(trial.number as i32)
+                }
+                Some(trial) => unfinished_next.push(trial.number),
             }
         }
         self.unfinished_trials.insert(study_id, unfinished_next);
         self.last_finished_trial_number
             .insert(study_id, last_finished_next);
-        Ok(())
     }
 
     fn resolve_trial_location(&mut self, trial_id: u32) -> Result<(u32, u32)> {
@@ -163,17 +259,15 @@ impl CachedStorage {
             return Ok((*study_id, *trial_number));
         }
 
+        // Ask the backend where the trial lives, but let refresh_trials fill the cache. Writing
+        // this single trial in would leave every lower number as an unloaded `None`, which
+        // recompute_trial_bookkeeping cannot tell apart from a discarded trial.
         let trial = self.backend.get_trial(trial_id)?;
         let study_id = trial.study_id;
         let trial_number = trial.number;
-        let trials = self.trials.entry(study_id).or_default();
-        let trial_index = trial_number as usize;
-        if trials.len() <= trial_index {
-            trials.resize(trial_index + 1, None);
-        }
-        trials[trial_index] = Some(trial);
         self.trial_id_to_study_number
             .insert(trial_id, (study_id, trial_number));
+        self.refresh_trials(study_id)?;
         Ok((study_id, trial_number))
     }
 
@@ -183,6 +277,18 @@ impl CachedStorage {
             .and_then(|trials| trials.get(trial_number as usize))
             .and_then(|trial| trial.as_ref())
             .is_some_and(|trial| trial.is_finished())
+    }
+
+    /// Returns whether the cache knows the trial to be discarded.
+    ///
+    /// A slot past the end of the vector means "not loaded", not "discarded".
+    fn is_trial_discarded_in_cache(&self, study_id: u32, trial_number: u32) -> bool {
+        self.apply_discard
+            && self
+                .trials
+                .get(&study_id)
+                .and_then(|trials| trials.get(trial_number as usize))
+                .is_some_and(Option::is_none)
     }
 }
 
@@ -310,6 +416,9 @@ impl rustuna_core::storage::Storage for CachedStorage {
             return Err(Error::new(ErrorKind::TrialAlreadyFinished));
         }
         self.refresh_trials(study_id)?;
+        if self.is_trial_discarded_in_cache(study_id, trial_number) {
+            return Err(Error::new(ErrorKind::TrialDiscarded));
+        }
         if let Some(trials) = self.trials.get(&study_id) {
             if let Some(trial) = trials
                 .get(trial_number as usize)
@@ -365,9 +474,14 @@ impl rustuna_core::storage::Storage for CachedStorage {
         trial_id: u32,
         state_values: TrialStateValues,
     ) -> Result<()> {
+        // Resolve and check before writing: rejecting the call after the backend already
+        // recorded the new state would leave the storage holding a value we reported as failed.
+        let (study_id, trial_number) = self.resolve_trial_location(trial_id)?;
+        if self.is_trial_discarded_in_cache(study_id, trial_number) {
+            return Err(Error::new(ErrorKind::TrialDiscarded));
+        }
         self.backend
             .set_trial_state_values(trial_id, state_values.clone())?;
-        let (study_id, trial_number) = self.resolve_trial_location(trial_id)?;
 
         self.unfinished_trials
             .entry(study_id)
@@ -406,6 +520,9 @@ impl rustuna_core::storage::Storage for CachedStorage {
         }
         if self.is_trial_finished_in_cache(study_id, trial_number) {
             return Err(Error::new(ErrorKind::TrialAlreadyFinished));
+        }
+        if self.is_trial_discarded_in_cache(study_id, trial_number) {
+            return Err(Error::new(ErrorKind::TrialDiscarded));
         }
 
         self.backend
@@ -599,12 +716,50 @@ impl rustuna_core::storage::Storage for CachedStorage {
         Ok(cache.get_joint_search_space())
     }
 
-    fn discard_trials(&mut self, _trial_ids: &[u32]) -> Result<()> {
+    fn discard_trials(&mut self, trial_ids: &[u32]) -> Result<()> {
+        // Resolve the locations before writing. Doing it afterwards would ask the backend for
+        // trials it has just been told to hide, and would leave the discard persisted even when
+        // this call reports an error.
+        // TODO(c-bata): Add self.study_number_to_trial_id to simplify this code.
+        let mut locations: Vec<(u32, u32)> = Vec::with_capacity(trial_ids.len());
+        for trial_id in trial_ids {
+            let location = self.resolve_trial_location(*trial_id)?;
+            if !locations.contains(&location) {
+                locations.push(location);
+            }
+        }
+
+        // Like JournalStorage, the discard is always persisted; `apply_discard` only decides
+        // whether reads apply it.
+        self.backend.discard_trials(trial_ids)?;
+        if !self.apply_discard {
+            return Ok(());
+        }
+
+        let mut discarded_studies: Vec<u32> = Vec::new();
+        for (study_id, trial_number) in locations {
+            if let Some(trials) = self.trials.get_mut(&study_id) {
+                if let Some(slot) = trials.get_mut(trial_number as usize) {
+                    *slot = None;
+                }
+            }
+            if let Some(unfinished) = self.unfinished_trials.get_mut(&study_id) {
+                unfinished.retain(|number| *number != trial_number);
+            }
+            if !discarded_studies.contains(&study_id) {
+                discarded_studies.push(study_id);
+            }
+        }
+        for study_id in discarded_studies {
+            // Advance the refresh cursor past the trials we just removed, so that a later
+            // refresh does not keep asking the backend for the whole discarded range.
+            self.recompute_trial_bookkeeping(study_id);
+        }
         Ok(())
     }
 
     fn may_omit_trials(&self) -> bool {
-        false
+        self.apply_discard
     }
 }
 
@@ -617,13 +772,31 @@ mod tests {
 
     struct DummyBackend {
         inner: rustuna_core::storage::InMemoryStorage,
+        apply_discard: bool,
+        // (trial_id, discard sequence), standing in for the `discarded_at` timestamp
+        // SQLite3Storage stamps on each discarded trial.
+        discarded_trial_ids: Vec<(u32, u32)>,
+        next_discard_seq: u32,
     }
 
     impl DummyBackend {
         fn new() -> Self {
+            DummyBackend::new_with_option(false)
+        }
+
+        fn new_with_option(apply_discard: bool) -> Self {
             DummyBackend {
                 inner: rustuna_core::storage::InMemoryStorage::new(),
+                apply_discard,
+                discarded_trial_ids: Vec::new(),
+                next_discard_seq: 1,
             }
+        }
+
+        fn is_discarded(&self, trial_id: u32) -> bool {
+            self.discarded_trial_ids
+                .iter()
+                .any(|(id, _)| *id == trial_id)
         }
     }
 
@@ -704,6 +877,9 @@ mod tests {
             let all = self.inner.get_trials(study_id)?.clone();
             let mut trials = Vec::new();
             for t in all.into_iter().flatten() {
+                if self.apply_discard && self.is_discarded(t.id) {
+                    continue;
+                }
                 if included_numbers.contains(&t.number)
                     || (t.number as i32) > trial_number_greater_than
                 {
@@ -739,6 +915,45 @@ mod tests {
         ) -> Result<()> {
             self.inner
                 .set_trial_attrs(trial_id, attrs, error_on_overwrite)
+        }
+
+        fn apply_discard(&self) -> bool {
+            self.apply_discard
+        }
+
+        fn discard_trials(&mut self, trial_ids: &[u32]) -> Result<()> {
+            let seq = self.next_discard_seq;
+            self.next_discard_seq += 1;
+            for trial_id in trial_ids {
+                if !self.is_discarded(*trial_id) {
+                    self.discarded_trial_ids.push((*trial_id, seq));
+                }
+            }
+            Ok(())
+        }
+
+        fn get_discarded_trials_diff(
+            &mut self,
+            study_id: u32,
+            cursor: Option<&str>,
+        ) -> Result<DiscardedTrialsDiff> {
+            let cursor: u32 = cursor.and_then(|c| c.parse().ok()).unwrap_or(0);
+            let mut diff = DiscardedTrialsDiff::default();
+            let mut max_seq = None;
+            for (trial_id, seq) in self.discarded_trial_ids.clone() {
+                // `>=`, mirroring SQLite3Storage: several trials can share a sequence number.
+                if seq < cursor {
+                    continue;
+                }
+                let trial = self.inner.get_trial(trial_id)?;
+                if trial.study_id != study_id {
+                    continue;
+                }
+                diff.numbers.push(trial.number);
+                max_seq = Some(max_seq.unwrap_or(seq).max(seq));
+            }
+            diff.cursor = max_seq.map(|seq| seq.to_string());
+            Ok(diff)
         }
     }
     #[test]
@@ -1042,6 +1257,79 @@ mod tests {
             .set_trial_param(trial1_id, "x", &int_dist, 1.0)
             .expect_err("Expected IncompatibleDistribution error");
         assert!(matches!(err.kind, ErrorKind::IncompatibleDistribution));
+        Ok(())
+    }
+
+    #[test]
+    fn discard_trials_invalidates_cache_and_backend() -> Result<()> {
+        let mut storage = CachedStorage::new(Box::new(DummyBackend::new_with_option(true)));
+        let study_id = storage
+            .create_new_study("study", vec![Direction::Minimize])?
+            .id;
+        let trial0_id = storage.create_new_trial(study_id)?.id;
+        let trial1_id = storage.create_new_trial(study_id)?.id;
+        storage.get_trials(study_id)?;
+
+        storage.discard_trials(&[trial0_id])?;
+
+        let trials = storage.get_trials(study_id)?;
+        assert!(trials[0].is_none());
+        assert_eq!(trials[1].as_ref().unwrap().id, trial1_id);
+        assert!(storage.may_omit_trials());
+        assert!(matches!(
+            storage.get_trial(trial0_id).unwrap_err().kind,
+            ErrorKind::TrialDiscarded
+        ));
+        let backend_trials = storage.backend.get_trials_diff(study_id, &[], -1)?;
+        assert_eq!(backend_trials.len(), 1);
+        assert_eq!(backend_trials[0].id, trial1_id);
+        Ok(())
+    }
+
+    #[test]
+    fn discarded_trials_advance_the_refresh_cursor() -> Result<()> {
+        // Populate the backend first, so that the cache below starts cold the way a freshly
+        // opened storage does.
+        let mut backend = DummyBackend::new_with_option(true);
+        let study_id = backend
+            .create_new_study("study", vec![Direction::Minimize])?
+            .id;
+        let mut trial_ids = vec![];
+        for _ in 0..5 {
+            let trial_id = backend.create_new_trial(study_id)?.id;
+            backend.set_trial_state_values(trial_id, TrialStateValues::Complete(vec![1.0]))?;
+            trial_ids.push(trial_id);
+        }
+        backend.discard_trials(&trial_ids)?;
+        // A running trial at the tail: no trial is finished any more, so without treating the
+        // discarded ones as terminal the cursor stays at -1 and every refresh rescans the whole
+        // discarded prefix.
+        backend.create_new_trial(study_id)?;
+
+        let mut storage = CachedStorage::new(Box::new(backend));
+        let trials = storage.get_trials(study_id)?;
+        assert_eq!(trials.len(), 6);
+        assert!(trials[..5].iter().all(Option::is_none));
+
+        assert_eq!(storage.last_finished_trial_number.get(&study_id), Some(&4));
+        assert_eq!(storage.unfinished_trials.get(&study_id), Some(&vec![5]));
+        Ok(())
+    }
+
+    #[test]
+    fn discard_trials_keeps_cache_when_apply_discard_is_false() -> Result<()> {
+        let mut storage = CachedStorage::new(Box::new(DummyBackend::new()));
+        let study_id = storage
+            .create_new_study("study", vec![Direction::Minimize])?
+            .id;
+        let trial_id = storage.create_new_trial(study_id)?.id;
+        storage.get_trials(study_id)?;
+
+        storage.discard_trials(&[trial_id])?;
+
+        let trials = storage.get_trials(study_id)?;
+        assert_eq!(trials[0].as_ref().unwrap().id, trial_id);
+        assert!(!storage.may_omit_trials());
         Ok(())
     }
 }

--- a/rustuna_storage/src/sqlite3.rs
+++ b/rustuna_storage/src/sqlite3.rs
@@ -1,4 +1,4 @@
-use crate::cache::CachedStorageBackend;
+use crate::cache::{CachedStorageBackend, DiscardedTrialsDiff};
 use rusqlite::{params, Connection, Error as RusqliteError, OptionalExtension};
 use rustuna_core::attr::{AttrKey, Attrs, CategoryLabel};
 use rustuna_core::distribution::Distribution;
@@ -10,6 +10,16 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 
+/// Options for [`SQLite3Storage`].
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct SQLite3StorageOptions {
+    /// If `true`, discarded trials are omitted from subsequent reads.
+    ///
+    /// As in `JournalStorageOptions`, this only gates reads: `discard_trials` marks the trials
+    /// in the database regardless of this option.
+    pub apply_discard: bool,
+}
+
 /// SQLite-backed storage backend.
 ///
 /// This backend persists studies and trials in a local SQLite database and is typically wrapped
@@ -17,28 +27,62 @@ use std::sync::Mutex;
 /// `rustuna_core`.
 pub struct SQLite3Storage {
     conn: Mutex<Connection>,
-    has_is_discarded_column: AtomicBool,
+    options: SQLite3StorageOptions,
+    has_discarded_at_column: AtomicBool,
 }
 
 const SCHEMA_SQL: &str = include_str!("sqlite3_schema.sql");
 const TRIALS_STUDY_ID_NUMBER_INDEX_SQL: &str =
     "CREATE INDEX IF NOT EXISTS trials_study_id_number_key ON trials (study_id, number)";
+const TRIALS_DISCARDED_AT_COLUMN_SQL: &str = "ALTER TABLE trials ADD COLUMN discarded_at DATETIME";
+const TRIALS_DISCARDED_AT_INDEX_SQL: &str =
+    "CREATE INDEX IF NOT EXISTS trials_study_id_discarded_at_key ON trials (study_id, discarded_at)";
+// Naive UTC, so that the value is comparable as a string across processes and usable as a
+// synchronization cursor.
+const DISCARDED_AT_NOW_SQL: &str = "strftime('%Y-%m-%d %H:%M:%f', 'now')";
 type TrialRow = (u32, u32, String, Option<String>, Option<String>);
 
 impl SQLite3Storage {
     /// Opens a SQLite database file.
     pub fn new(file_path: &str) -> Result<SQLite3Storage> {
+        Self::new_with_option(file_path, SQLite3StorageOptions::default())
+    }
+
+    /// Opens a SQLite database file with the given options.
+    ///
+    /// When `apply_discard` is enabled, call [`Self::validate_discard_support`] after
+    /// [`Self::create_database`] to reject databases whose schema predates the discard column.
+    pub fn new_with_option(
+        file_path: &str,
+        options: SQLite3StorageOptions,
+    ) -> Result<SQLite3Storage> {
         let conn = Connection::open(file_path).map_err(|e| {
             Error::with_reason(
                 ErrorKind::StorageError,
                 format!("Failed to open {file_path}: {e}"),
             )
         })?;
-        let has_is_discarded_column = Self::has_is_discarded_column(&conn)?;
+        let has_discarded_at_column = Self::has_discarded_at_column(&conn)?;
         Ok(SQLite3Storage {
             conn: Mutex::new(conn),
-            has_is_discarded_column: AtomicBool::new(has_is_discarded_column),
+            options,
+            has_discarded_at_column: AtomicBool::new(has_discarded_at_column),
         })
+    }
+
+    /// Returns an error when discards were requested but the database cannot record them.
+    ///
+    /// [`Self::create_database`] migrates the column in, so this only fails for databases opened
+    /// without initialization.
+    pub fn validate_discard_support(&self) -> Result<()> {
+        if self.options.apply_discard && !self.has_discarded_at_column.load(Ordering::Acquire) {
+            return Err(Error::with_reason(
+                ErrorKind::StorageError,
+                "apply_discard requires the Rustuna-specific `discarded_at` column on the \
+                 trials table. Open the database with create_database enabled to add it.",
+            ));
+        }
+        Ok(())
     }
 
     /// Creates the Rustuna schema if the database has not been initialized yet.
@@ -74,6 +118,27 @@ impl SQLite3Storage {
                         format!("Failed to create trial lookup index: {e}"),
                     )
                 })?;
+
+            // Same reasoning for the discard column: a database created by Optuna or by an
+            // older Rustuna has a `trials` table without it, and `SCHEMA_SQL` above is skipped
+            // for such databases. Adding it here keeps `apply_discard` from silently degrading
+            // into a no-op that only looks correct until the storage is reopened.
+            if !Self::has_discarded_at_column(&conn)? {
+                conn.execute_batch(TRIALS_DISCARDED_AT_COLUMN_SQL)
+                    .map_err(|e| {
+                        Error::with_reason(
+                            ErrorKind::StorageError,
+                            format!("Failed to add the discarded_at column: {e}"),
+                        )
+                    })?;
+            }
+            conn.execute_batch(TRIALS_DISCARDED_AT_INDEX_SQL)
+                .map_err(|e| {
+                    Error::with_reason(
+                        ErrorKind::StorageError,
+                        format!("Failed to create discard lookup index: {e}"),
+                    )
+                })?;
             Ok(())
         })();
 
@@ -90,9 +155,9 @@ impl SQLite3Storage {
             }
         }
 
-        let has_is_discarded_column = Self::has_is_discarded_column(&conn)?;
-        self.has_is_discarded_column
-            .store(has_is_discarded_column, Ordering::Release);
+        let has_discarded_at_column = Self::has_discarded_at_column(&conn)?;
+        self.has_discarded_at_column
+            .store(has_discarded_at_column, Ordering::Release);
 
         Ok(())
     }
@@ -114,7 +179,7 @@ impl SQLite3Storage {
         Ok(exists.is_some())
     }
 
-    fn has_is_discarded_column(conn: &Connection) -> Result<bool> {
+    fn has_discarded_at_column(conn: &Connection) -> Result<bool> {
         let mut stmt = conn.prepare("PRAGMA table_info(trials)").map_err(|e| {
             Error::with_reason(
                 ErrorKind::StorageError,
@@ -135,7 +200,7 @@ impl SQLite3Storage {
                     ErrorKind::StorageError,
                     format!("Failed to inspect trials schema: {e}"),
                 )
-            })? == "is_discarded"
+            })? == "discarded_at"
             {
                 return Ok(true);
             }
@@ -170,8 +235,21 @@ impl SQLite3Storage {
 }
 
 impl CachedStorageBackend for SQLite3Storage {
+    fn apply_discard(&self) -> bool {
+        self.options.apply_discard
+    }
+
     fn discard_trials(&mut self, trial_ids: &[u32]) -> Result<()> {
-        if !self.has_is_discarded_column.load(Ordering::Acquire) {
+        if !self.has_discarded_at_column.load(Ordering::Acquire) {
+            // Failing loudly rather than silently: a no-op here would let the caller believe the
+            // trials were discarded until the database is reopened and they all reappear.
+            return Err(Error::with_reason(
+                ErrorKind::StorageError,
+                "Cannot discard trials: the trials table has no `discarded_at` column. Open the \
+                 database with create_database enabled to add it.",
+            ));
+        }
+        if trial_ids.is_empty() {
             return Ok(());
         }
 
@@ -186,32 +264,42 @@ impl CachedStorageBackend for SQLite3Storage {
             )
         })?;
         for trial_id in trial_ids {
-            let exists: Option<u32> = tx
-                .query_row(
-                    "SELECT trial_id FROM trials WHERE trial_id = ?",
+            // `discarded_at IS NULL` keeps the first timestamp when the same trial is discarded
+            // twice. Restamping it would move the trial ahead of readers that already passed it,
+            // making them replay a discard they have applied.
+            let updated = tx
+                .execute(
+                    &format!(
+                        "UPDATE trials SET discarded_at = {DISCARDED_AT_NOW_SQL} \
+                         WHERE trial_id = ? AND discarded_at IS NULL"
+                    ),
                     params![trial_id],
-                    |row| row.get(0),
                 )
-                .optional()
                 .map_err(|e| {
                     Error::with_reason(
                         ErrorKind::StorageError,
                         format!("Database query failed: {e}"),
                     )
                 })?;
-            if exists.is_none() {
-                return Err(Error::new(ErrorKind::TrialNotFound));
+            if updated == 0 {
+                // Either the trial does not exist, or it was already discarded.
+                let exists: Option<u32> = tx
+                    .query_row(
+                        "SELECT trial_id FROM trials WHERE trial_id = ?",
+                        params![trial_id],
+                        |row| row.get(0),
+                    )
+                    .optional()
+                    .map_err(|e| {
+                        Error::with_reason(
+                            ErrorKind::StorageError,
+                            format!("Database query failed: {e}"),
+                        )
+                    })?;
+                if exists.is_none() {
+                    return Err(Error::new(ErrorKind::TrialNotFound));
+                }
             }
-            tx.execute(
-                "UPDATE trials SET is_discarded = 1 WHERE trial_id = ?",
-                params![trial_id],
-            )
-            .map_err(|e| {
-                Error::with_reason(
-                    ErrorKind::StorageError,
-                    format!("Database query failed: {e}"),
-                )
-            })?;
         }
         tx.commit().map_err(|e| {
             Error::with_reason(
@@ -219,6 +307,65 @@ impl CachedStorageBackend for SQLite3Storage {
                 format!("Database query failed: {e}"),
             )
         })
+    }
+
+    fn get_discarded_trials_diff(
+        &mut self,
+        study_id: u32,
+        cursor: Option<&str>,
+    ) -> Result<DiscardedTrialsDiff> {
+        if !self.has_discarded_at_column.load(Ordering::Acquire) {
+            return Ok(DiscardedTrialsDiff::default());
+        }
+        let guard = self
+            .conn
+            .lock()
+            .map_err(|_| Error::new(ErrorKind::StorageError))?;
+
+        // `>=` instead of `>`: several trials can share a timestamp, and the cursor only carries
+        // the timestamp itself. Re-reading the boundary batch costs at most one discard call and
+        // applying a discard twice is a no-op, whereas `>` would drop the trials tied with it.
+        //
+        // Trials discarded by another process whose clock lags behind the cursor are missed. That
+        // only costs memory (the trial stays cached), never correctness, so it is not worth
+        // ordering discards across machines.
+        let mut stmt = guard
+            .prepare(
+                "SELECT number, discarded_at FROM trials \
+                 WHERE study_id = ? AND discarded_at IS NOT NULL AND discarded_at >= ?",
+            )
+            .map_err(|e| {
+                Error::with_reason(
+                    ErrorKind::StorageError,
+                    format!("Database query failed: {e}"),
+                )
+            })?;
+        // Every non-NULL timestamp compares greater than or equal to the empty string.
+        let rows = stmt
+            .query_map(params![study_id, cursor.unwrap_or("")], |row| {
+                Ok((row.get::<_, u32>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(|e| {
+                Error::with_reason(
+                    ErrorKind::StorageError,
+                    format!("Database query failed: {e}"),
+                )
+            })?;
+
+        let mut diff = DiscardedTrialsDiff::default();
+        for row in rows {
+            let (number, discarded_at) = row.map_err(|e| {
+                Error::with_reason(
+                    ErrorKind::StorageError,
+                    format!("Database query failed: {e}"),
+                )
+            })?;
+            diff.numbers.push(number);
+            if diff.cursor.as_ref().is_none_or(|max| *max < discarded_at) {
+                diff.cursor = Some(discarded_at);
+            }
+        }
+        Ok(diff)
     }
 
     fn create_new_study(
@@ -1217,7 +1364,6 @@ impl CachedStorageBackend for SQLite3Storage {
         study_id: u32,
         included_numbers: &[u32],
         trial_number_greater_than: i32,
-        filter_discarded: bool,
     ) -> rustuna_core::Result<Vec<rustuna_core::trial::PersistedTrial>> {
         let guard = self
             .conn
@@ -1227,8 +1373,8 @@ impl CachedStorageBackend for SQLite3Storage {
         let select_columns =
             "SELECT trial_id, number, state, datetime_start, datetime_complete FROM trials";
         let discard_condition =
-            if filter_discarded && self.has_is_discarded_column.load(Ordering::Acquire) {
-                " AND is_discarded = 0"
+            if self.options.apply_discard && self.has_discarded_at_column.load(Ordering::Acquire) {
+                " AND discarded_at IS NULL"
             } else {
                 ""
             };
@@ -1836,8 +1982,13 @@ mod tests {
     use tempfile::tempdir;
 
     fn init_storage() -> Result<SQLite3Storage> {
-        let storage = SQLite3Storage::new(":memory:")?;
+        init_storage_with_option(SQLite3StorageOptions::default())
+    }
+
+    fn init_storage_with_option(options: SQLite3StorageOptions) -> Result<SQLite3Storage> {
+        let storage = SQLite3Storage::new_with_option(":memory:", options)?;
         storage.create_database()?;
+        storage.validate_discard_support()?;
         Ok(storage)
     }
 
@@ -1909,8 +2060,10 @@ mod tests {
 
     #[test]
     fn discard_trials_are_omitted_by_cached_storage() -> Result<()> {
-        let backend = init_storage()?;
-        let mut storage = CachedStorage::new(Box::new(backend), true);
+        let backend = init_storage_with_option(SQLite3StorageOptions {
+            apply_discard: true,
+        })?;
+        let mut storage = CachedStorage::new(Box::new(backend));
         assert!(storage.may_omit_trials());
 
         let study_id = storage
@@ -1927,6 +2080,153 @@ mod tests {
             storage.get_trial(trial0_id).unwrap_err().kind,
             ErrorKind::TrialDiscarded
         ));
+        Ok(())
+    }
+
+    fn open_file_storage(path: &str, apply_discard: bool) -> Result<CachedStorage> {
+        let backend =
+            SQLite3Storage::new_with_option(path, SQLite3StorageOptions { apply_discard })?;
+        backend.create_database()?;
+        backend.validate_discard_support()?;
+        Ok(CachedStorage::new(Box::new(backend)))
+    }
+
+    #[test]
+    fn discarded_trials_stay_discarded_after_reopening() -> Result<()> {
+        let dir = tempdir().map_err(|_| Error::new(ErrorKind::Unexpected))?;
+        let path = dir.path().join("storage.sqlite3");
+        let path = path.to_string_lossy().to_string();
+
+        let (study_id, trial0_id, trial1_id) = {
+            let mut storage = open_file_storage(&path, true)?;
+            let study_id = storage
+                .create_new_study("example", vec![Direction::Minimize])?
+                .id;
+            let trial0_id = storage.create_new_trial(study_id)?.id;
+            storage.set_trial_state_values(trial0_id, TrialStateValues::Complete(vec![1.0]))?;
+            let trial1_id = storage.create_new_trial(study_id)?.id;
+            storage.set_trial_state_values(trial1_id, TrialStateValues::Complete(vec![2.0]))?;
+            storage.discard_trials(&[trial0_id])?;
+            (study_id, trial0_id, trial1_id)
+        };
+
+        // A fresh cache has no trial_id -> location mapping, so resolving the discarded trial
+        // goes through the backend. It must not resurrect it into the cache.
+        let mut storage = open_file_storage(&path, true)?;
+        assert!(matches!(
+            storage.get_trial(trial0_id).unwrap_err().kind,
+            ErrorKind::TrialDiscarded
+        ));
+        assert_eq!(storage.get_trial(trial1_id)?.id, trial1_id);
+        let trials = storage.get_trials(study_id)?;
+        assert!(trials[0].is_none());
+        assert_eq!(trials[1].as_ref().unwrap().id, trial1_id);
+
+        // The same, but asking for the discarded trial before anything else is cached.
+        let mut storage = open_file_storage(&path, true)?;
+        assert!(matches!(
+            storage.get_trial(trial0_id).unwrap_err().kind,
+            ErrorKind::TrialDiscarded
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn discards_are_persisted_when_apply_discard_is_disabled() -> Result<()> {
+        let dir = tempdir().map_err(|_| Error::new(ErrorKind::Unexpected))?;
+        let path = dir.path().join("storage.sqlite3");
+        let path = path.to_string_lossy().to_string();
+
+        let (study_id, trial_id) = {
+            // As in JournalStorage, the discard is written even though this storage does not
+            // apply it when reading.
+            let mut storage = open_file_storage(&path, false)?;
+            let study_id = storage
+                .create_new_study("example", vec![Direction::Minimize])?
+                .id;
+            let trial_id = storage.create_new_trial(study_id)?.id;
+            storage.create_new_trial(study_id)?;
+            storage.discard_trials(&[trial_id])?;
+            assert_eq!(storage.get_trial(trial_id)?.id, trial_id);
+            assert!(!storage.may_omit_trials());
+            (study_id, trial_id)
+        };
+
+        let mut storage = open_file_storage(&path, true)?;
+        let trials = storage.get_trials(study_id)?;
+        assert!(trials[0].is_none());
+        assert!(matches!(
+            storage.get_trial(trial_id).unwrap_err().kind,
+            ErrorKind::TrialDiscarded
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn discards_by_another_process_are_synchronized() -> Result<()> {
+        let dir = tempdir().map_err(|_| Error::new(ErrorKind::Unexpected))?;
+        let path = dir.path().join("storage.sqlite3");
+        let path = path.to_string_lossy().to_string();
+
+        let mut reader = open_file_storage(&path, true)?;
+        let study_id = reader
+            .create_new_study("example", vec![Direction::Minimize])?
+            .id;
+        let trial0_id = reader.create_new_trial(study_id)?.id;
+        reader.set_trial_state_values(trial0_id, TrialStateValues::Complete(vec![1.0]))?;
+        let trial1_id = reader.create_new_trial(study_id)?.id;
+        reader.set_trial_state_values(trial1_id, TrialStateValues::Complete(vec![2.0]))?;
+        assert_eq!(reader.get_trials(study_id)?.iter().flatten().count(), 2);
+
+        // trial0 is already finished, so get_trials_diff will never revisit it. Only the
+        // dedicated discard synchronization can notice this.
+        let mut writer = open_file_storage(&path, true)?;
+        writer.discard_trials(&[trial0_id])?;
+
+        let trials = reader.get_trials(study_id)?;
+        assert!(trials[0].is_none());
+        assert_eq!(trials[1].as_ref().unwrap().id, trial1_id);
+        Ok(())
+    }
+
+    #[test]
+    fn rejected_writes_on_discarded_trials_do_not_reach_the_database() -> Result<()> {
+        let dir = tempdir().map_err(|_| Error::new(ErrorKind::Unexpected))?;
+        let path = dir.path().join("storage.sqlite3");
+        let path = path.to_string_lossy().to_string();
+
+        let (study_id, trial_id) = {
+            let mut storage = open_file_storage(&path, true)?;
+            let study_id = storage
+                .create_new_study("example", vec![Direction::Minimize])?
+                .id;
+            let trial_id = storage.create_new_trial(study_id)?.id;
+            storage.discard_trials(&[trial_id])?;
+
+            assert!(matches!(
+                storage
+                    .set_trial_state_values(trial_id, TrialStateValues::Complete(vec![42.0]))
+                    .unwrap_err()
+                    .kind,
+                ErrorKind::TrialDiscarded
+            ));
+            assert!(matches!(
+                storage
+                    .set_trial_intermediate_values(trial_id, HashMap::from([(0, 42.0)]))
+                    .unwrap_err()
+                    .kind,
+                ErrorKind::TrialDiscarded
+            ));
+            (study_id, trial_id)
+        };
+
+        // Reopen without applying discards to see what actually landed in the database.
+        let mut storage = open_file_storage(&path, false)?;
+        let trials = storage.get_trials(study_id)?;
+        let trial = trials[0].as_ref().expect("trial should still be readable");
+        assert_eq!(trial.id, trial_id);
+        assert!(matches!(trial.state_values, TrialStateValues::Running));
+        assert!(trial.intermediate_values.is_empty());
         Ok(())
     }
 
@@ -1954,7 +2254,7 @@ mod tests {
         let trial = storage.get_trial(trial_id)?;
         assert!(matches!(trial.state_values, TrialStateValues::Waiting));
 
-        let trials = storage.get_trials_diff(study_id, &[trial.number], -1, false)?;
+        let trials = storage.get_trials_diff(study_id, &[trial.number], -1)?;
         assert_eq!(trials.len(), 1);
         assert!(matches!(trials[0].state_values, TrialStateValues::Waiting));
 
@@ -2244,17 +2544,17 @@ mod tests {
         }
 
         // Get all trials with number > 2
-        let trials = storage.get_trials_diff(study_id, &[], 2, false)?;
+        let trials = storage.get_trials_diff(study_id, &[], 2)?;
         assert_eq!(trials.len(), 2);
         assert_eq!(trials[0].number, 3);
         assert_eq!(trials[1].number, 4);
 
         // Get specific trials by number
-        let trials = storage.get_trials_diff(study_id, &[0, 2], -1, false)?;
+        let trials = storage.get_trials_diff(study_id, &[0, 2], -1)?;
         assert_eq!(trials.len(), 5); // All trials + included ones
 
         // Get trials with number > 3 OR in [0, 1]
-        let trials = storage.get_trials_diff(study_id, &[0, 1], 3, false)?;
+        let trials = storage.get_trials_diff(study_id, &[0, 1], 3)?;
         assert_eq!(trials.len(), 3); // trials 0, 1, 4
         Ok(())
     }
@@ -2269,7 +2569,7 @@ mod tests {
         storage.create_new_trial(study_id)?;
 
         // trial_number_greater_than is much larger than existing trial numbers
-        let trials = storage.get_trials_diff(study_id, &[], 500000, false)?;
+        let trials = storage.get_trials_diff(study_id, &[], 500000)?;
         assert_eq!(trials.len(), 0);
 
         Ok(())
@@ -2288,7 +2588,7 @@ mod tests {
     //     // A large inclusion list used to raise errors in some implementations.
     //     // Check that it is not an issue. See https://github.com/optuna/optuna/issues/1457.
     //     let large_numbers: Vec<u32> = (0..500000).collect();
-    //     let trials = storage.get_trials_diff(study_id, &large_numbers, 500000, false)?;
+    //     let trials = storage.get_trials_diff(study_id, &large_numbers, 500000)?;
     //     assert_eq!(trials.len(), 1);
 
     //     Ok(())
@@ -2304,11 +2604,11 @@ mod tests {
         storage.create_new_trial(study_id)?;
 
         // trial_number_greater_than = -1 should return all trials
-        let trials = storage.get_trials_diff(study_id, &[], -1, false)?;
+        let trials = storage.get_trials_diff(study_id, &[], -1)?;
         assert_eq!(trials.len(), 1);
 
         // trial_number_greater_than much larger than existing trials
-        let trials = storage.get_trials_diff(study_id, &[], 500001, false)?;
+        let trials = storage.get_trials_diff(study_id, &[], 500001)?;
         assert_eq!(trials.len(), 0);
 
         Ok(())
@@ -2318,7 +2618,7 @@ mod tests {
     fn run_optimization() -> Result<()> {
         let storage = SQLite3Storage::new(":memory:")?;
         storage.create_database()?;
-        let storage = CachedStorage::new(Box::new(storage), false);
+        let storage = CachedStorage::new(Box::new(storage));
 
         let study = create_study(
             "simple-quadratic",

--- a/rustuna_storage/src/sqlite3.rs
+++ b/rustuna_storage/src/sqlite3.rs
@@ -7,6 +7,7 @@ use rustuna_core::trial::{PersistedTrial, TrialStateValues};
 use rustuna_core::{Error, ErrorKind, Result};
 use serde_json::{json, Number, Value};
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 
 /// SQLite-backed storage backend.
@@ -16,6 +17,7 @@ use std::sync::Mutex;
 /// `rustuna_core`.
 pub struct SQLite3Storage {
     conn: Mutex<Connection>,
+    has_is_discarded_column: AtomicBool,
 }
 
 const SCHEMA_SQL: &str = include_str!("sqlite3_schema.sql");
@@ -32,8 +34,10 @@ impl SQLite3Storage {
                 format!("Failed to open {file_path}: {e}"),
             )
         })?;
+        let has_is_discarded_column = Self::has_is_discarded_column(&conn)?;
         Ok(SQLite3Storage {
             conn: Mutex::new(conn),
+            has_is_discarded_column: AtomicBool::new(has_is_discarded_column),
         })
     }
 
@@ -86,6 +90,10 @@ impl SQLite3Storage {
             }
         }
 
+        let has_is_discarded_column = Self::has_is_discarded_column(&conn)?;
+        self.has_is_discarded_column
+            .store(has_is_discarded_column, Ordering::Release);
+
         Ok(())
     }
 
@@ -104,6 +112,35 @@ impl SQLite3Storage {
                 )
             })?;
         Ok(exists.is_some())
+    }
+
+    fn has_is_discarded_column(conn: &Connection) -> Result<bool> {
+        let mut stmt = conn.prepare("PRAGMA table_info(trials)").map_err(|e| {
+            Error::with_reason(
+                ErrorKind::StorageError,
+                format!("Failed to inspect trials schema: {e}"),
+            )
+        })?;
+        let columns = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .map_err(|e| {
+                Error::with_reason(
+                    ErrorKind::StorageError,
+                    format!("Failed to inspect trials schema: {e}"),
+                )
+            })?;
+        for column in columns {
+            if column.map_err(|e| {
+                Error::with_reason(
+                    ErrorKind::StorageError,
+                    format!("Failed to inspect trials schema: {e}"),
+                )
+            })? == "is_discarded"
+            {
+                return Ok(true);
+            }
+        }
+        Ok(false)
     }
 
     fn validate_study_id(&self, study_id: u32) -> Result<()> {
@@ -133,6 +170,57 @@ impl SQLite3Storage {
 }
 
 impl CachedStorageBackend for SQLite3Storage {
+    fn discard_trials(&mut self, trial_ids: &[u32]) -> Result<()> {
+        if !self.has_is_discarded_column.load(Ordering::Acquire) {
+            return Ok(());
+        }
+
+        let mut guard = self
+            .conn
+            .lock()
+            .map_err(|_| Error::new(ErrorKind::StorageError))?;
+        let tx = guard.transaction().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::StorageError,
+                format!("Database query failed: {e}"),
+            )
+        })?;
+        for trial_id in trial_ids {
+            let exists: Option<u32> = tx
+                .query_row(
+                    "SELECT trial_id FROM trials WHERE trial_id = ?",
+                    params![trial_id],
+                    |row| row.get(0),
+                )
+                .optional()
+                .map_err(|e| {
+                    Error::with_reason(
+                        ErrorKind::StorageError,
+                        format!("Database query failed: {e}"),
+                    )
+                })?;
+            if exists.is_none() {
+                return Err(Error::new(ErrorKind::TrialNotFound));
+            }
+            tx.execute(
+                "UPDATE trials SET is_discarded = 1 WHERE trial_id = ?",
+                params![trial_id],
+            )
+            .map_err(|e| {
+                Error::with_reason(
+                    ErrorKind::StorageError,
+                    format!("Database query failed: {e}"),
+                )
+            })?;
+        }
+        tx.commit().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::StorageError,
+                format!("Database query failed: {e}"),
+            )
+        })
+    }
+
     fn create_new_study(
         &mut self,
         study_name: &str,
@@ -640,7 +728,7 @@ impl CachedStorageBackend for SQLite3Storage {
             .lock()
             .map_err(|_| Error::new(ErrorKind::StorageError))?;
 
-        // Query to trials table .
+        // Query to trials table.
         let trial_row: Option<TrialRow> = guard
             .query_row(
                 "SELECT study_id, number, state, datetime_start, datetime_complete FROM trials WHERE trial_id = ?",
@@ -1129,6 +1217,7 @@ impl CachedStorageBackend for SQLite3Storage {
         study_id: u32,
         included_numbers: &[u32],
         trial_number_greater_than: i32,
+        filter_discarded: bool,
     ) -> rustuna_core::Result<Vec<rustuna_core::trial::PersistedTrial>> {
         let guard = self
             .conn
@@ -1137,6 +1226,12 @@ impl CachedStorageBackend for SQLite3Storage {
 
         let select_columns =
             "SELECT trial_id, number, state, datetime_start, datetime_complete FROM trials";
+        let discard_condition =
+            if filter_discarded && self.has_is_discarded_column.load(Ordering::Acquire) {
+                " AND is_discarded = 0"
+            } else {
+                ""
+            };
         // Numbers above the threshold are already returned by the range query. Filtering them
         // out here avoids an unnecessary second scan in the usual case where the current trial
         // is the only unfinished trial.
@@ -1152,7 +1247,9 @@ impl CachedStorageBackend for SQLite3Storage {
         let (sql, params): (String, Vec<Box<dyn rusqlite::ToSql>>) = if included_numbers.is_empty()
         {
             (
-                format!("{select_columns} WHERE study_id = ? AND number > ? ORDER BY trial_id"),
+                format!(
+                    "{select_columns} WHERE study_id = ? AND number > ?{discard_condition} ORDER BY trial_id"
+                ),
                 vec![Box::new(study_id), Box::new(trial_number_greater_than)],
             )
         } else {
@@ -1173,9 +1270,9 @@ impl CachedStorageBackend for SQLite3Storage {
             );
             (
                 format!(
-                    "{select_columns} WHERE study_id = ? AND number > ? \
+                    "{select_columns} WHERE study_id = ? AND number > ?{discard_condition} \
                          UNION ALL \
-                         {select_columns} WHERE study_id = ? AND number IN ({placeholders}) \
+                         {select_columns} WHERE study_id = ? AND number IN ({placeholders}){discard_condition} \
                          ORDER BY trial_id"
                 ),
                 params,
@@ -1734,6 +1831,7 @@ mod tests {
     use super::*;
     use crate::cache::CachedStorage;
     use rustuna_core::sampler::RandomSampler;
+    use rustuna_core::storage::Storage;
     use rustuna_core::study::{create_study, Direction};
     use tempfile::tempdir;
 
@@ -1810,6 +1908,29 @@ mod tests {
     }
 
     #[test]
+    fn discard_trials_are_omitted_by_cached_storage() -> Result<()> {
+        let backend = init_storage()?;
+        let mut storage = CachedStorage::new(Box::new(backend), true);
+        assert!(storage.may_omit_trials());
+
+        let study_id = storage
+            .create_new_study("example", vec![Direction::Minimize])?
+            .id;
+        let trial0_id = storage.create_new_trial(study_id)?.id;
+        let trial1_id = storage.create_new_trial(study_id)?.id;
+        storage.discard_trials(&[trial0_id])?;
+
+        let trials = storage.get_trials(study_id)?;
+        assert!(trials[0].is_none());
+        assert_eq!(trials[1].as_ref().unwrap().id, trial1_id);
+        assert!(matches!(
+            storage.get_trial(trial0_id).unwrap_err().kind,
+            ErrorKind::TrialDiscarded
+        ));
+        Ok(())
+    }
+
+    #[test]
     fn create_new_study_rejects_duplicate_name() -> Result<()> {
         let mut storage = init_storage()?;
         storage.create_new_study("dup", vec![Direction::Minimize])?;
@@ -1833,7 +1954,7 @@ mod tests {
         let trial = storage.get_trial(trial_id)?;
         assert!(matches!(trial.state_values, TrialStateValues::Waiting));
 
-        let trials = storage.get_trials_diff(study_id, &[trial.number], -1)?;
+        let trials = storage.get_trials_diff(study_id, &[trial.number], -1, false)?;
         assert_eq!(trials.len(), 1);
         assert!(matches!(trials[0].state_values, TrialStateValues::Waiting));
 
@@ -2123,17 +2244,17 @@ mod tests {
         }
 
         // Get all trials with number > 2
-        let trials = storage.get_trials_diff(study_id, &[], 2)?;
+        let trials = storage.get_trials_diff(study_id, &[], 2, false)?;
         assert_eq!(trials.len(), 2);
         assert_eq!(trials[0].number, 3);
         assert_eq!(trials[1].number, 4);
 
         // Get specific trials by number
-        let trials = storage.get_trials_diff(study_id, &[0, 2], -1)?;
+        let trials = storage.get_trials_diff(study_id, &[0, 2], -1, false)?;
         assert_eq!(trials.len(), 5); // All trials + included ones
 
         // Get trials with number > 3 OR in [0, 1]
-        let trials = storage.get_trials_diff(study_id, &[0, 1], 3)?;
+        let trials = storage.get_trials_diff(study_id, &[0, 1], 3, false)?;
         assert_eq!(trials.len(), 3); // trials 0, 1, 4
         Ok(())
     }
@@ -2148,7 +2269,7 @@ mod tests {
         storage.create_new_trial(study_id)?;
 
         // trial_number_greater_than is much larger than existing trial numbers
-        let trials = storage.get_trials_diff(study_id, &[], 500000)?;
+        let trials = storage.get_trials_diff(study_id, &[], 500000, false)?;
         assert_eq!(trials.len(), 0);
 
         Ok(())
@@ -2167,7 +2288,7 @@ mod tests {
     //     // A large inclusion list used to raise errors in some implementations.
     //     // Check that it is not an issue. See https://github.com/optuna/optuna/issues/1457.
     //     let large_numbers: Vec<u32> = (0..500000).collect();
-    //     let trials = storage.get_trials_diff(study_id, &large_numbers, 500000)?;
+    //     let trials = storage.get_trials_diff(study_id, &large_numbers, 500000, false)?;
     //     assert_eq!(trials.len(), 1);
 
     //     Ok(())
@@ -2183,11 +2304,11 @@ mod tests {
         storage.create_new_trial(study_id)?;
 
         // trial_number_greater_than = -1 should return all trials
-        let trials = storage.get_trials_diff(study_id, &[], -1)?;
+        let trials = storage.get_trials_diff(study_id, &[], -1, false)?;
         assert_eq!(trials.len(), 1);
 
         // trial_number_greater_than much larger than existing trials
-        let trials = storage.get_trials_diff(study_id, &[], 500001)?;
+        let trials = storage.get_trials_diff(study_id, &[], 500001, false)?;
         assert_eq!(trials.len(), 0);
 
         Ok(())
@@ -2197,7 +2318,7 @@ mod tests {
     fn run_optimization() -> Result<()> {
         let storage = SQLite3Storage::new(":memory:")?;
         storage.create_database()?;
-        let storage = CachedStorage::new(Box::new(storage));
+        let storage = CachedStorage::new(Box::new(storage), false);
 
         let study = create_study(
             "simple-quadratic",

--- a/rustuna_storage/src/sqlite3_schema.sql
+++ b/rustuna_storage/src/sqlite3_schema.sql
@@ -27,6 +27,8 @@ CREATE TABLE IF NOT EXISTS trials (
 	state VARCHAR(8) NOT NULL,
 	datetime_start DATETIME,
 	datetime_complete DATETIME,
+	-- Rustuna-specific column; it is not part of Optuna's SQLite schema.
+	is_discarded BOOLEAN NOT NULL DEFAULT 0,
 	PRIMARY KEY (trial_id),
 	FOREIGN KEY(study_id) REFERENCES studies (study_id)
 );

--- a/rustuna_storage/src/sqlite3_schema.sql
+++ b/rustuna_storage/src/sqlite3_schema.sql
@@ -28,7 +28,10 @@ CREATE TABLE IF NOT EXISTS trials (
 	datetime_start DATETIME,
 	datetime_complete DATETIME,
 	-- Rustuna-specific column; it is not part of Optuna's SQLite schema.
-	is_discarded BOOLEAN NOT NULL DEFAULT 0,
+	-- NULL means the trial is live. It hides the trial from reads and doubles as the
+	-- synchronization cursor other processes use to pick up newly discarded trials.
+	-- Stored as naive UTC, unlike datetime_start and datetime_complete above.
+	discarded_at DATETIME,
 	PRIMARY KEY (trial_id),
 	FOREIGN KEY(study_id) REFERENCES studies (study_id)
 );
@@ -114,4 +117,8 @@ CREATE INDEX IF NOT EXISTS trials_study_id_key ON trials (study_id);
 -- This composite index is not included in Optuna's SQLite schema. Rustuna adds it
 -- to efficiently refresh trials by study and trial number.
 CREATE INDEX IF NOT EXISTS trials_study_id_number_key ON trials (study_id, number);
+-- This index is not included in Optuna's SQLite schema either. Rustuna adds it so that
+-- picking up trials discarded by other processes costs one range scan over the new entries
+-- instead of a scan over every discarded trial.
+CREATE INDEX IF NOT EXISTS trials_study_id_discarded_at_key ON trials (study_id, discarded_at);
 INSERT OR IGNORE INTO version_info (version_info_id, schema_version, library_version) VALUES (1, 12, '4.6.0.dev')

--- a/rustuna_storage/tests/sqlite3.rs
+++ b/rustuna_storage/tests/sqlite3.rs
@@ -90,7 +90,7 @@ study.optimize(objective, n_trials=10)
     let studies = storage.get_studies()?;
     assert_eq!(studies.len(), 1);
 
-    let trials = storage.get_trials_diff(studies[0].id, &[], -1)?;
+    let trials = storage.get_trials_diff(studies[0].id, &[], -1, false)?;
     let trial0 = trials
         .into_iter()
         .find(|trial| trial.number == 0)
@@ -139,9 +139,10 @@ study.optimize(objective, n_trials=10)
 "#;
     // Evaluate 10 trials
     run_optuna_script(&python, &db_path, script)?;
-    let mut storage = CachedStorage::new(Box::new(SQLite3Storage::new(
-        db_path.to_string_lossy().as_ref(),
-    )?));
+    let mut storage = CachedStorage::new(
+        Box::new(SQLite3Storage::new(db_path.to_string_lossy().as_ref())?),
+        false,
+    );
     let study_id = {
         let studies = storage.get_studies()?;
         assert_eq!(studies.len(), 1);

--- a/rustuna_storage/tests/sqlite3.rs
+++ b/rustuna_storage/tests/sqlite3.rs
@@ -90,7 +90,7 @@ study.optimize(objective, n_trials=10)
     let studies = storage.get_studies()?;
     assert_eq!(studies.len(), 1);
 
-    let trials = storage.get_trials_diff(studies[0].id, &[], -1, false)?;
+    let trials = storage.get_trials_diff(studies[0].id, &[], -1)?;
     let trial0 = trials
         .into_iter()
         .find(|trial| trial.number == 0)
@@ -139,10 +139,9 @@ study.optimize(objective, n_trials=10)
 "#;
     // Evaluate 10 trials
     run_optuna_script(&python, &db_path, script)?;
-    let mut storage = CachedStorage::new(
-        Box::new(SQLite3Storage::new(db_path.to_string_lossy().as_ref())?),
-        false,
-    );
+    let mut storage = CachedStorage::new(Box::new(SQLite3Storage::new(
+        db_path.to_string_lossy().as_ref(),
+    )?));
     let study_id = {
         let studies = storage.get_studies()?;
         assert_eq!(studies.len(), 1);


### PR DESCRIPTION
## Summary

* This PR adds support for `storage.discard_trials(trial_ids: list[int]) -> None` api for `SQLite3Storage` and `CachedStorage`.
* Add `apply_discard` argument on `rustuna.samplers.SQLite3Storage`.