### PR TITLE
Normalize datetime to timezone-naive UTC and Remove `chrono` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,37 +36,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 
 [[package]]
-name = "cc"
-version = "1.2.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
-dependencies = [
- "find-msvc-tools",
- "shlex",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "chrono"
-version = "0.4.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
-dependencies = [
- "iana-time-zone",
- "num-traits",
- "windows-link",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "errno"
@@ -104,12 +68,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "find-msvc-tools"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "foldhash"
@@ -167,30 +125,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,12 +176,6 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
-
-[[package]]
-name = "log"
-version = "0.4.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "matrixmultiply"
@@ -388,7 +316,6 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
 dependencies = [
- "chrono",
  "indoc",
  "libc",
  "memoffset",
@@ -536,6 +463,7 @@ dependencies = [
 name = "rustuna_core"
 version = "0.1.0"
 dependencies = [
+ "js-sys",
  "rand",
  "rand_distr",
  "statrs",
@@ -564,7 +492,6 @@ dependencies = [
 name = "rustuna_pyo3"
 version = "0.1.0"
 dependencies = [
- "chrono",
  "pyo3",
  "rustuna_core",
  "rustuna_importance",
@@ -584,7 +511,6 @@ dependencies = [
 name = "rustuna_storage"
 version = "0.1.0"
 dependencies = [
- "chrono",
  "libc",
  "rusqlite",
  "rustuna_core",
@@ -667,12 +593,6 @@ dependencies = [
  "serde",
  "serde_core",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simba"
@@ -832,63 +752,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,4 @@ rustuna_core = { path = "./rustuna_core" }
 rustuna_sampler = { path = "./rustuna_sampler" }
 rustuna_importance = { path = "./rustuna_importance" }
 rustuna_storage = { path = "./rustuna_storage" }
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
 rand = "0.8.5"

--- a/rustuna_core/Cargo.toml
+++ b/rustuna_core/Cargo.toml
@@ -13,5 +13,11 @@ readme = "README.md"
 rand = { workspace = true }
 rand_distr = "0.4.3"
 
+# wasm32-unknown-unknown has no clock of its own, so the host's is read through `Date.now()`.
+# Being target-gated, no other target gains a dependency: the Python extension and native Rust
+# builds still resolve rustuna_core with `rand` alone.
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+js-sys = "0.3.66"
+
 [dev-dependencies]
 statrs = "0.18.0"

--- a/rustuna_core/src/datetime.rs
+++ b/rustuna_core/src/datetime.rs
@@ -1,0 +1,239 @@
+//! Timestamps for trials.
+//!
+//! [`crate::trial::PersistedTrial`] carries timezone-naive **UTC** datetimes. UTC needs a clock but
+//! no timezone database, so this module is built on `std::time` alone and every storage backend can
+//! stamp a trial without taking on a dependency.
+//!
+//! Converting to the local time that users see is deliberately left to the outermost layer: the
+//! Python bindings do it with Python's own `datetime` module, so Rustuna and Optuna always agree on
+//! the timezone database, and Rust callers can pick whichever crate they already use.
+
+/// Seconds in a day.
+const SECS_PER_DAY: i64 = 86_400;
+
+/// A point in time broken down into UTC calendar fields.
+struct UtcParts {
+    year: i64,
+    month: u32,
+    day: u32,
+    hour: u32,
+    minute: u32,
+    second: u32,
+    microsecond: u32,
+}
+
+/// Reads the wall clock as whole seconds since the Unix epoch plus microseconds within that second.
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+fn unix_now() -> (i64, u32) {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    // A clock reading before the Unix epoch would mean the machine is misconfigured by more than
+    // fifty years; clamping to the epoch avoids threading an error through every storage write for
+    // a case that cannot happen in practice.
+    let since_epoch = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    (since_epoch.as_secs() as i64, since_epoch.subsec_micros())
+}
+
+/// Reads the wall clock as whole seconds since the Unix epoch plus microseconds within that second.
+///
+/// `std::time::SystemTime::now` panics on `wasm32-unknown-unknown`, which has no clock of its own.
+/// The host always has one, so it is read through `Date.now()`; the resolution is milliseconds, so
+/// the microseconds are always a multiple of 1000.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+fn unix_now() -> (i64, u32) {
+    unix_from_millis(js_sys::Date::now())
+}
+
+/// Splits milliseconds since the Unix epoch into whole seconds and microseconds within the second.
+///
+/// Compiled outside wasm as well so that the conversion above is covered by the ordinary test run.
+#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
+fn unix_from_millis(millis_since_epoch: f64) -> (i64, u32) {
+    // `floor` rather than a cast, so that a clock set before 1970 keeps the microseconds positive
+    // and the seconds land on the earlier whole second.
+    let secs = (millis_since_epoch / 1000.0).floor();
+    let micros = ((millis_since_epoch - secs * 1000.0) * 1000.0) as u32;
+    (secs as i64, micros.min(999_999))
+}
+
+impl UtcParts {
+    fn now() -> UtcParts {
+        let (secs, microsecond) = unix_now();
+        UtcParts::from_unix(secs, microsecond)
+    }
+
+    fn from_unix(secs: i64, microsecond: u32) -> UtcParts {
+        // Euclidean division so that instants before the epoch floor towards the earlier day
+        // instead of truncating towards zero.
+        let days = secs.div_euclid(SECS_PER_DAY);
+        let secs_of_day = secs.rem_euclid(SECS_PER_DAY);
+        let (year, month, day) = civil_from_days(days);
+        UtcParts {
+            year,
+            month,
+            day,
+            hour: (secs_of_day / 3600) as u32,
+            minute: (secs_of_day % 3600 / 60) as u32,
+            second: (secs_of_day % 60) as u32,
+            microsecond,
+        }
+    }
+}
+
+impl std::fmt::Display for UtcParts {
+    /// Formats as `%Y-%m-%d %H:%M:%S.ffffff`.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let UtcParts {
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            microsecond,
+        } = *self;
+        write!(
+            f,
+            "{year:04}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02}.{microsecond:06}"
+        )
+    }
+}
+
+/// Converts a count of days since 1970-01-01 into a UTC calendar date.
+///
+/// This is Howard Hinnant's `civil_from_days`.
+fn civil_from_days(days: i64) -> (i64, u32, u32) {
+    // Shift the era so that the cycle starts on 0000-03-01, which puts the leap day at the end of
+    // the year and makes the month arithmetic below branch-free.
+    let shifted = days + 719_468;
+    let era = if shifted >= 0 {
+        shifted
+    } else {
+        shifted - 146_096
+    } / 146_097;
+    let day_of_era = (shifted - era * 146_097) as u64; // [0, 146096]
+    let year_of_era =
+        (day_of_era - day_of_era / 1460 + day_of_era / 36_524 - day_of_era / 146_096) / 365; // [0, 399]
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100); // [0, 365]
+    let month_prime = (5 * day_of_year + 2) / 153; // [0, 11], where 0 is March
+    let day = (day_of_year - (153 * month_prime + 2) / 5 + 1) as u32; // [1, 31]
+    let month = if month_prime < 10 {
+        month_prime + 3
+    } else {
+        month_prime - 9
+    } as u32; // [1, 12]
+    let year = year_of_era as i64 + era * 400 + i64::from(month <= 2);
+    (year, month, day)
+}
+
+/// Returns the current time as a timezone-naive UTC timestamp.
+///
+/// The format is `%Y-%m-%d %H:%M:%S.ffffff`, which matches `str(datetime)` in Python and is what
+/// [`crate::trial::PersistedTrial`] holds. Microseconds are always written in full so that
+/// `datetime.fromisoformat` accepts the value on every supported Python version, and so that the
+/// fixed width leaves the timestamps orderable as plain strings.
+pub fn now_naive_utc() -> String {
+    UtcParts::now().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn days_in_month(year: i64, month: u32) -> u32 {
+        match month {
+            1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+            4 | 6 | 9 | 11 => 30,
+            2 if (year % 4 == 0 && year % 100 != 0) || year % 400 == 0 => 29,
+            2 => 28,
+            _ => unreachable!("month out of range: {month}"),
+        }
+    }
+
+    fn format_unix(secs: i64, micros: u32) -> String {
+        UtcParts::from_unix(secs, micros).to_string()
+    }
+
+    #[test]
+    fn formats_the_unix_epoch() {
+        assert_eq!(format_unix(0, 0), "1970-01-01 00:00:00.000000");
+    }
+
+    #[test]
+    fn formats_known_instants() {
+        // Cross-checked against `date -u -r <secs>`.
+        assert_eq!(format_unix(1, 2), "1970-01-01 00:00:01.000002");
+        assert_eq!(format_unix(86_399, 999_999), "1970-01-01 23:59:59.999999");
+        assert_eq!(format_unix(86_400, 0), "1970-01-02 00:00:00.000000");
+        assert_eq!(format_unix(951_782_400, 0), "2000-02-29 00:00:00.000000");
+        assert_eq!(format_unix(1_709_164_800, 0), "2024-02-29 00:00:00.000000");
+        assert_eq!(format_unix(4_107_542_400, 0), "2100-03-01 00:00:00.000000");
+        assert_eq!(format_unix(1_735_689_599, 0), "2024-12-31 23:59:59.000000");
+        assert_eq!(format_unix(1_735_689_600, 0), "2025-01-01 00:00:00.000000");
+        // Before the epoch, where truncating division would land on the wrong day.
+        assert_eq!(format_unix(-1, 0), "1969-12-31 23:59:59.000000");
+        assert_eq!(format_unix(-86_400, 0), "1969-12-31 00:00:00.000000");
+    }
+
+    #[test]
+    fn matches_a_calendar_walked_independently_over_four_centuries() {
+        // 1970-01-01 through 2369, covering every leap-year rule including the 400-year exception.
+        // Walking the calendar day by day is an independent implementation of the same arithmetic:
+        // it shares nothing with civil_from_days beyond the leap-year rule itself.
+        let mut days = 0i64;
+        for year in 1970..2370i64 {
+            for month in 1..=12u32 {
+                for day in 1..=days_in_month(year, month) {
+                    assert_eq!(civil_from_days(days), (year, month, day), "day {days}");
+                    days += 1;
+                }
+            }
+        }
+        assert_eq!(days, 146_097, "four centuries are 146097 days");
+    }
+
+    #[test]
+    fn matches_a_calendar_walked_backwards_from_the_epoch() {
+        let mut days = 0i64;
+        for year in (1600..1970i64).rev() {
+            for month in (1..=12u32).rev() {
+                for day in (1..=days_in_month(year, month)).rev() {
+                    days -= 1;
+                    assert_eq!(civil_from_days(days), (year, month, day), "day {days}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn milliseconds_from_a_host_clock_are_split_correctly() {
+        // The wasm path reads `Date.now()`, which yields milliseconds as an f64.
+        assert_eq!(unix_from_millis(0.0), (0, 0));
+        assert_eq!(unix_from_millis(1.0), (0, 1_000));
+        assert_eq!(unix_from_millis(999.0), (0, 999_000));
+        assert_eq!(unix_from_millis(1_000.0), (1, 0));
+        assert_eq!(
+            unix_from_millis(1_709_164_800_123.0),
+            (1_709_164_800, 123_000)
+        );
+        // Before the epoch, where a plain cast would truncate towards zero and lose a second.
+        assert_eq!(unix_from_millis(-1.0), (-1, 999_000));
+        assert_eq!(unix_from_millis(-1_000.0), (-1, 0));
+
+        let (secs, micros) = unix_from_millis(1_709_164_800_123.0);
+        assert_eq!(format_unix(secs, micros), "2024-02-29 00:00:00.123000");
+        let (secs, micros) = unix_from_millis(-1.0);
+        assert_eq!(format_unix(secs, micros), "1969-12-31 23:59:59.999000");
+    }
+
+    #[test]
+    fn now_is_a_full_width_naive_utc_timestamp() {
+        let naive = now_naive_utc();
+        assert_eq!(naive.len(), "1970-01-01 00:00:00.000000".len(), "{naive}");
+        assert_eq!(naive.as_bytes()[10], b' ', "{naive}");
+        // A timestamp taken later never sorts earlier, which is what the fixed width buys.
+        assert!(naive <= now_naive_utc());
+    }
+}

--- a/rustuna_core/src/lib.rs
+++ b/rustuna_core/src/lib.rs
@@ -7,6 +7,7 @@
 pub use error::{Error, ErrorKind};
 
 pub mod attr;
+pub mod datetime;
 pub mod distribution;
 pub mod parzen_estimator;
 pub mod sampler;

--- a/rustuna_core/src/storage.rs
+++ b/rustuna_core/src/storage.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use crate::attr::{category_labels_to_attrs, get_category_labels, AttrKey, Attrs, CategoryLabel};
+use crate::datetime::now_naive_utc;
 use crate::distribution::Distribution;
 use crate::study::{Direction, PersistedStudy};
 use crate::study_cache::StudyCache;
@@ -334,7 +335,8 @@ impl Storage for InMemoryStorage {
         let trial_id = self.next_trial_id;
         self.next_trial_id += 1;
         let number = trials.len() as u32;
-        let trial = PersistedTrial::new(trial_id, study_id, number);
+        let mut trial = PersistedTrial::new(trial_id, study_id, number);
+        trial.datetime_start = Some(now_naive_utc());
         trials.push(Some(trial));
         self.trial_id_to_study_number
             .insert(trial_id, (study_id, number));
@@ -408,6 +410,14 @@ impl Storage for InMemoryStorage {
                 .and_then(Option::as_mut),
         )?;
         check_trial_is_updatable(trial)?;
+        trial.datetime_complete = if matches!(
+            state_values,
+            TrialStateValues::Complete(_) | TrialStateValues::Pruned | TrialStateValues::Fail
+        ) {
+            Some(now_naive_utc())
+        } else {
+            None
+        };
         trial.state_values = state_values;
         Ok(())
     }
@@ -642,6 +652,39 @@ mod tests {
         assert_eq!(trial.id, 10);
         let trial = storage.create_new_trial(study_id)?;
         assert_eq!(trial.id, 11);
+        Ok(())
+    }
+
+    #[test]
+    fn trials_are_stamped_with_naive_utc_datetimes() -> Result<()> {
+        let before = now_naive_utc();
+        let mut storage = InMemoryStorage::new();
+        let study_id = storage.create_new_study("s", vec![Direction::Minimize])?.id;
+        let trial_id = storage.create_new_trial(study_id)?.id;
+
+        let trial = storage.get_trial(trial_id)?;
+        let started = trial
+            .datetime_start
+            .clone()
+            .expect("a new trial records when it started");
+        assert!(trial.datetime_complete.is_none());
+
+        storage.set_trial_state_values(trial_id, TrialStateValues::Complete(vec![1.0]))?;
+        let trial = storage.get_trial(trial_id)?;
+        let completed = trial
+            .datetime_complete
+            .clone()
+            .expect("a finished trial records when it finished");
+        assert_eq!(trial.datetime_start.as_deref(), Some(started.as_str()));
+
+        // Naive UTC of a fixed width is lexicographically ordered, so the strings can be bracketed
+        // by readings taken around the calls without any date arithmetic.
+        let after = now_naive_utc();
+        assert_eq!(started.len(), after.len());
+        assert!(
+            before <= started && started <= completed && completed <= after,
+            "expected {before} <= {started} <= {completed} <= {after}"
+        );
         Ok(())
     }
 

--- a/rustuna_core/src/trial.rs
+++ b/rustuna_core/src/trial.rs
@@ -289,12 +289,12 @@ pub struct PersistedTrial {
     /// trial data and may be used by future pruning APIs.
     pub intermediate_values: HashMap<u32, f64>,
     pub attrs: Attrs,
-    /// When the trial started, as timezone-naive **local** time (`%Y-%m-%d %H:%M:%S%.f`).
+    /// When the trial started, as timezone-naive **UTC** (`%Y-%m-%d %H:%M:%S%.f`).
     ///
-    /// As in Optuna, the user-facing value is local time while the storage backends persist UTC:
-    /// SQLite stores timezone-naive UTC and journal logs store timezone-aware UTC. Backends
-    /// convert at their own persistence boundary, so every value held here is local time no
-    /// matter which storage produced it.
+    /// UTC needs a clock but no timezone database, which is why it is the representation shared by
+    /// every backend: see [`crate::datetime`]. Storage backends encode it slightly differently on
+    /// disk (SQLite keeps naive UTC, journal logs carry an explicit `+00:00`), and the conversion
+    /// to the local time that `FrozenTrial` exposes happens in the Python bindings.
     pub datetime_start: Option<String>,
     /// When the trial finished, in the same representation as [`Self::datetime_start`].
     pub datetime_complete: Option<String>,

--- a/rustuna_core/src/trial.rs
+++ b/rustuna_core/src/trial.rs
@@ -289,7 +289,14 @@ pub struct PersistedTrial {
     /// trial data and may be used by future pruning APIs.
     pub intermediate_values: HashMap<u32, f64>,
     pub attrs: Attrs,
+    /// When the trial started, as timezone-naive **local** time (`%Y-%m-%d %H:%M:%S%.f`).
+    ///
+    /// As in Optuna, the user-facing value is local time while the storage backends persist UTC:
+    /// SQLite stores timezone-naive UTC and journal logs store timezone-aware UTC. Backends
+    /// convert at their own persistence boundary, so every value held here is local time no
+    /// matter which storage produced it.
     pub datetime_start: Option<String>,
+    /// When the trial finished, in the same representation as [`Self::datetime_start`].
     pub datetime_complete: Option<String>,
 }
 impl PersistedTrial {

--- a/rustuna_pyo3/Cargo.toml
+++ b/rustuna_pyo3/Cargo.toml
@@ -13,8 +13,7 @@ name = "rustuna"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.27", features = ["extension-module", "chrono"] }
-chrono = { workspace = true }
+pyo3 = { version = "0.27", features = ["extension-module"] }
 rustuna_core = { workspace = true }
 rustuna_sampler = { workspace = true }
 rustuna_storage = { workspace = true }

--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -212,8 +212,8 @@ class PersistedTrial:
         user_attrs: Dictionary that contains the attributes of the Trial set with set_user_attr.
         system_attrs: Dictionary that contains the attributes of the Trial set with set_system_attr.
         internal_params: Dictionary that contains internal representations of the parameters.
-        datetime_start: Datetime where the Trial started.
-        datetime_complete: Datetime where the Trial finished.
+        datetime_start: Datetime where the Trial started, as timezone-naive local time.
+        datetime_complete: Datetime where the Trial finished, as timezone-naive local time.
     """
 
     def __init__(

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-use chrono::{Local, NaiveDateTime};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};
@@ -161,9 +160,7 @@ pub fn py_create_trial(
         system_attrs.unwrap_or_default(),
     );
 
-    // Local time, matching optuna.trial.create_trial and PersistedTrial's representation. The
-    // storage backends convert to UTC when they persist the trial.
-    let now = Local::now().naive_local().to_string();
+    let now = rustuna_core::datetime::now_naive_utc();
     if matches!(state, PyTrialState::WAITING) {
         trial.datetime_start = None;
         trial.datetime_complete = None;
@@ -503,8 +500,8 @@ impl PyPersistedTrial {
         user_attrs: Option<HashMap<String, String>>,
         system_attrs: Option<HashMap<String, String>>,
         intermediate_values: Option<HashMap<u32, f64>>,
-        datetime_start: Option<NaiveDateTime>,
-        datetime_complete: Option<NaiveDateTime>,
+        datetime_start: Option<Bound<'_, PyAny>>,
+        datetime_complete: Option<Bound<'_, PyAny>>,
     ) -> PyResult<Self> {
         let mut trial = PersistedTrial::new(trial_id, study_id, number);
         trial.state_values = state_values_from_py(&state, value, values)?;
@@ -521,8 +518,14 @@ impl PyPersistedTrial {
             user_attrs.unwrap_or_default(),
             system_attrs.unwrap_or_default(),
         );
-        trial.datetime_start = datetime_start.map(|dt| dt.to_string());
-        trial.datetime_complete = datetime_complete.map(|dt| dt.to_string());
+        trial.datetime_start = datetime_start
+            .as_ref()
+            .map(py_datetime_to_naive_utc)
+            .transpose()?;
+        trial.datetime_complete = datetime_complete
+            .as_ref()
+            .map(py_datetime_to_naive_utc)
+            .transpose()?;
 
         trial.validate().map_err(err_to_exceptions)?;
         Ok(PyPersistedTrial::new(trial, study_attrs))
@@ -599,19 +602,23 @@ impl PyPersistedTrial {
     }
 
     #[getter]
-    fn datetime_start(&self) -> PyResult<Option<NaiveDateTime>> {
-        self.with_trial(|trial| match trial.datetime_start.as_ref() {
-            Some(raw) => Ok(Some(parse_naive_datetime(raw)?)),
-            None => Ok(None),
-        })
+    fn datetime_start<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        // Read the stored value out first: the conversion below calls back into Python and must
+        // not run while the storage guard is held.
+        let stored = self.with_trial(|trial| Ok(trial.datetime_start.clone()))?;
+        stored
+            .as_deref()
+            .map(|raw| naive_utc_to_py_local(py, raw))
+            .transpose()
     }
 
     #[getter]
-    fn datetime_complete(&self) -> PyResult<Option<NaiveDateTime>> {
-        self.with_trial(|trial| match trial.datetime_complete.as_ref() {
-            Some(raw) => Ok(Some(parse_naive_datetime(raw)?)),
-            None => Ok(None),
-        })
+    fn datetime_complete<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        let stored = self.with_trial(|trial| Ok(trial.datetime_complete.clone()))?;
+        stored
+            .as_deref()
+            .map(|raw| naive_utc_to_py_local(py, raw))
+            .transpose()
     }
 
     #[getter]
@@ -754,10 +761,56 @@ fn trial_state_from_ref(state_values: &TrialStateValues) -> PyTrialState {
     }
 }
 
-fn parse_naive_datetime(value: &str) -> PyResult<NaiveDateTime> {
-    NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S%.f")
-        .or_else(|_| NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S"))
-        .map_err(|e| PyValueError::new_err(format!("Failed to parse datetime: {e}")))
+// Design Note:
+// PersistedTrial carries timezone-naive UTC, while FrozenTrial exposes timezone-naive local time.
+// The two conversions below are done through Python's `datetime` module rather than a Rust
+// datetime crate, for two reasons: the timezone database is then guaranteed to be the same one
+// Optuna uses, and the storage layer stays free of timezone handling. Note that the storage calls
+// in `storage::binding` run under `Python::detach`, so this conversion has to live here at the
+// boundary, where the GIL is held, rather than inside the storage layer.
+//
+// These mirror `optuna.storages._rdb.models.TrialModel.datetime_start`, which is
+//     stored.replace(tzinfo=timezone.utc).astimezone().replace(tzinfo=None)
+// on the way out and
+//     value.astimezone(timezone.utc).replace(tzinfo=None)
+// on the way in.
+
+fn naive_replace_tzinfo<'py>(
+    value: &Bound<'py, PyAny>,
+    tzinfo: Bound<'py, PyAny>,
+) -> PyResult<Bound<'py, PyAny>> {
+    let kwargs = PyDict::new(value.py());
+    kwargs.set_item("tzinfo", tzinfo)?;
+    value.call_method("replace", (), Some(&kwargs))
+}
+
+fn utc_timezone(py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
+    py.import("datetime")?.getattr("timezone")?.getattr("utc")
+}
+
+/// Converts a timezone-naive UTC timestamp into the timezone-naive local datetime users see.
+fn naive_utc_to_py_local<'py>(py: Python<'py>, value: &str) -> PyResult<Bound<'py, PyAny>> {
+    let parsed = py
+        .import("datetime")?
+        .getattr("datetime")?
+        .call_method1("fromisoformat", (value,))
+        .map_err(|e| PyValueError::new_err(format!("Failed to parse datetime {value:?}: {e}")))?;
+    let aware = naive_replace_tzinfo(&parsed, utc_timezone(py)?)?;
+    let local = aware.call_method0("astimezone")?;
+    naive_replace_tzinfo(&local, py.None().into_bound(py))
+}
+
+/// Converts a datetime coming from Python into the timezone-naive UTC timestamp storages hold.
+///
+/// A naive input is read as local time, which is what `datetime.astimezone` does and therefore
+/// what Optuna does.
+fn py_datetime_to_naive_utc(value: &Bound<'_, PyAny>) -> PyResult<String> {
+    let py = value.py();
+    let aware = value.call_method1("astimezone", (utc_timezone(py)?,))?;
+    let naive = naive_replace_tzinfo(&aware, py.None().into_bound(py))?;
+    naive
+        .call_method1("isoformat", (" ", "microseconds"))?
+        .extract()
 }
 
 pub fn pyobject_to_persisted_trial_with_category_labels(
@@ -786,15 +839,21 @@ pub fn pyobject_to_persisted_trial_with_category_labels(
         PyTrialState::FAIL => TrialStateValues::Fail,
     };
     let datetime_start = match trial.getattr("datetime_start") {
-        Ok(value) => value.extract::<Option<NaiveDateTime>>()?,
+        Ok(value) => value.extract::<Option<Bound<'_, PyAny>>>()?,
         Err(_) => None,
     };
     let datetime_complete = match trial.getattr("datetime_complete") {
-        Ok(value) => value.extract::<Option<NaiveDateTime>>()?,
+        Ok(value) => value.extract::<Option<Bound<'_, PyAny>>>()?,
         Err(_) => None,
     };
-    persisted_trial.datetime_start = datetime_start.map(|dt| dt.to_string());
-    persisted_trial.datetime_complete = datetime_complete.map(|dt| dt.to_string());
+    persisted_trial.datetime_start = datetime_start
+        .as_ref()
+        .map(py_datetime_to_naive_utc)
+        .transpose()?;
+    persisted_trial.datetime_complete = datetime_complete
+        .as_ref()
+        .map(py_datetime_to_naive_utc)
+        .transpose()?;
 
     let intermediate_values = match trial.getattr("intermediate_values") {
         Ok(value) => value.extract::<HashMap<u32, f64>>()?,

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -161,6 +161,8 @@ pub fn py_create_trial(
         system_attrs.unwrap_or_default(),
     );
 
+    // Local time, matching optuna.trial.create_trial and PersistedTrial's representation. The
+    // storage backends convert to UTC when they persist the trial.
     let now = Local::now().naive_local().to_string();
     if matches!(state, PyTrialState::WAITING) {
         trial.datetime_start = None;

--- a/rustuna_storage/Cargo.toml
+++ b/rustuna_storage/Cargo.toml
@@ -13,8 +13,6 @@ rustuna_core = { workspace = true }
 rusqlite = "0.37.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
-chrono = { workspace = true }
 libc = "0.2"
 tempfile = "3.8"
 
-[dev-dependencies]

--- a/rustuna_storage/src/datetime.rs
+++ b/rustuna_storage/src/datetime.rs
@@ -1,0 +1,168 @@
+//! Conversions between the in-memory and the persisted representation of trial datetimes.
+//!
+//! Rustuna follows the same layering as Optuna (5.0.0rc1 and later):
+//!
+//! - `PersistedTrial::datetime_start` / `datetime_complete` are **timezone-naive local time**, so
+//!   that `FrozenTrial.datetime_start` keeps returning local time to users.
+//! - [`crate::sqlite3::SQLite3Storage`] persists **timezone-naive UTC**. Timezone-aware column
+//!   types would need a schema migration where they are supported at all, so the offset is dropped
+//!   and the value is normalized to UTC instead.
+//! - [`crate::journal::JournalStorage`] persists **timezone-aware UTC**, because a journal log is
+//!   JSON and can carry the offset without any schema concerns.
+//!
+//! Every conversion happens at a persistence boundary, so nothing outside this module needs to
+//! know which encoding a backend uses.
+
+use chrono::{DateTime, Local, NaiveDateTime, SecondsFormat, TimeZone, Utc};
+use rustuna_core::{Error, ErrorKind, Result};
+
+/// Format used for naive datetimes, matching SQLite's `strftime('%Y-%m-%d %H:%M:%f', ...)` and
+/// Python's `str(datetime)`.
+const NAIVE_FORMAT: &str = "%Y-%m-%d %H:%M:%S%.f";
+
+fn invalid(value: &str) -> Error {
+    Error::with_reason(
+        ErrorKind::StorageError,
+        format!("Failed to parse datetime: {value}"),
+    )
+}
+
+fn parse_naive(value: &str) -> Result<NaiveDateTime> {
+    NaiveDateTime::parse_from_str(value, NAIVE_FORMAT)
+        .or_else(|_| NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S"))
+        .or_else(|_| NaiveDateTime::parse_from_str(value, "%Y-%m-%dT%H:%M:%S%.f"))
+        .map_err(|_| invalid(value))
+}
+
+fn format_naive(value: NaiveDateTime) -> String {
+    value.format(NAIVE_FORMAT).to_string()
+}
+
+/// Interprets a naive local datetime, resolving the ambiguity of a DST fold towards the earlier
+/// instant the way `datetime.astimezone()` does in Python.
+fn local_to_utc(value: NaiveDateTime) -> Result<DateTime<Utc>> {
+    let local = Local
+        .from_local_datetime(&value)
+        .earliest()
+        // A local time skipped by a DST jump forward has no instant at all; map it through the
+        // offset in effect just before the gap rather than failing the whole read.
+        .or_else(|| Local.from_local_datetime(&value).latest())
+        .ok_or_else(|| invalid(&format_naive(value)))?;
+    Ok(local.with_timezone(&Utc))
+}
+
+/// Converts naive local time (as held by `PersistedTrial`) into the naive UTC stored by SQLite.
+pub fn naive_local_to_naive_utc(value: &str) -> Result<String> {
+    Ok(format_naive(local_to_utc(parse_naive(value)?)?.naive_utc()))
+}
+
+/// Converts the naive UTC stored by SQLite back into the naive local time held by
+/// `PersistedTrial`.
+pub fn naive_utc_to_naive_local(value: &str) -> Result<String> {
+    let utc = Utc.from_utc_datetime(&parse_naive(value)?);
+    Ok(format_naive(utc.with_timezone(&Local).naive_local()))
+}
+
+/// Converts naive local time into the timezone-aware UTC written to a journal log.
+///
+/// The output matches Python's `datetime.isoformat(timespec="microseconds")` on an aware UTC
+/// datetime, so Optuna can read logs written by Rustuna.
+pub fn naive_local_to_aware_utc(value: &str) -> Result<String> {
+    Ok(local_to_utc(parse_naive(value)?)?.to_rfc3339_opts(SecondsFormat::Micros, false))
+}
+
+/// Converts a datetime read from a journal log into the naive local time held by
+/// `PersistedTrial`.
+///
+/// Logs written before Rustuna and Optuna moved to aware UTC carry a naive local datetime with no
+/// offset. Those are read back as local time, which is what they were, so old journals keep
+/// reporting the same wall-clock values.
+pub fn journal_datetime_to_naive_local(value: &str) -> Result<String> {
+    match DateTime::parse_from_rfc3339(value) {
+        Ok(aware) => Ok(format_naive(aware.with_timezone(&Local).naive_local())),
+        Err(_) => Ok(format_naive(parse_naive(value)?)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn naive_local_and_naive_utc_round_trip() -> Result<()> {
+        let local = "2024-01-02 03:04:05.678";
+        let utc = naive_local_to_naive_utc(local)?;
+        assert_eq!(naive_utc_to_naive_local(&utc)?, local);
+        Ok(())
+    }
+
+    #[test]
+    fn naive_utc_conversion_applies_the_local_offset() -> Result<()> {
+        let local = "2024-01-02 03:04:05.678";
+        let utc = naive_local_to_naive_utc(local)?;
+        // The stored value differs from the local one by exactly the local offset.
+        let offset = Local
+            .from_local_datetime(&parse_naive(local)?)
+            .earliest()
+            .expect("unambiguous local time")
+            .offset()
+            .local_minus_utc();
+        assert_eq!(
+            parse_naive(&utc)?,
+            parse_naive(local)? - chrono::Duration::seconds(offset as i64)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn aware_utc_round_trips_and_carries_an_offset() -> Result<()> {
+        let local = "2024-06-02 03:04:05.678";
+        let aware = naive_local_to_aware_utc(local)?;
+        assert!(
+            aware.ends_with("+00:00"),
+            "journal datetimes must be aware UTC: {aware}"
+        );
+        assert_eq!(journal_datetime_to_naive_local(&aware)?, local);
+        Ok(())
+    }
+
+    #[test]
+    fn journal_datetimes_written_by_optuna_are_accepted() -> Result<()> {
+        // datetime.now(tz=timezone.utc).isoformat(timespec="microseconds")
+        let value = "2024-01-02T03:04:05.678000+00:00";
+        let local = journal_datetime_to_naive_local(value)?;
+        assert_eq!(
+            parse_naive(&local)?,
+            DateTime::parse_from_rfc3339(value)
+                .expect("valid rfc3339")
+                .with_timezone(&Local)
+                .naive_local()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn journal_datetimes_from_older_logs_are_read_as_local_time() -> Result<()> {
+        // Logs written before the move to aware UTC carry naive local time.
+        assert_eq!(
+            journal_datetime_to_naive_local("2024-01-02 03:04:05.678")?,
+            "2024-01-02 03:04:05.678"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn seconds_only_datetimes_are_accepted() -> Result<()> {
+        assert_eq!(
+            naive_utc_to_naive_local("2024-01-02 03:04:05")?,
+            naive_utc_to_naive_local("2024-01-02 03:04:05.000")?
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_datetimes_are_rejected() {
+        assert!(naive_utc_to_naive_local("not-a-datetime").is_err());
+        assert!(naive_local_to_aware_utc("").is_err());
+    }
+}

--- a/rustuna_storage/src/datetime.rs
+++ b/rustuna_storage/src/datetime.rs
@@ -1,87 +1,69 @@
-//! Conversions between the in-memory and the persisted representation of trial datetimes.
+//! Datetime encoding used by journal logs.
 //!
-//! Rustuna follows the same layering as Optuna (5.0.0rc1 and later):
-//!
-//! - `PersistedTrial::datetime_start` / `datetime_complete` are **timezone-naive local time**, so
-//!   that `FrozenTrial.datetime_start` keeps returning local time to users.
-//! - [`crate::sqlite3::SQLite3Storage`] persists **timezone-naive UTC**. Timezone-aware column
-//!   types would need a schema migration where they are supported at all, so the offset is dropped
-//!   and the value is normalized to UTC instead.
-//! - [`crate::journal::JournalStorage`] persists **timezone-aware UTC**, because a journal log is
-//!   JSON and can carry the offset without any schema concerns.
-//!
-//! Every conversion happens at a persistence boundary, so nothing outside this module needs to
-//! know which encoding a backend uses.
+//! `PersistedTrial` carries timezone-naive UTC (see `rustuna_core::datetime`), which
+//! [`crate::sqlite3::SQLite3Storage`] stores as-is. Journal logs instead carry timezone-aware UTC,
+//! matching Optuna, because a log entry is JSON and can spell out the offset without the schema
+//! concerns a database column has.
 
-use chrono::{DateTime, Local, NaiveDateTime, SecondsFormat, TimeZone, Utc};
-use rustuna_core::{Error, ErrorKind, Result};
+use rustuna_core::datetime::now_naive_utc;
 
-/// Format used for naive datetimes, matching SQLite's `strftime('%Y-%m-%d %H:%M:%f', ...)` and
-/// Python's `str(datetime)`.
-const NAIVE_FORMAT: &str = "%Y-%m-%d %H:%M:%S%.f";
+/// Width of the `YYYY-MM-DDTHH:MM:SS` prefix every journal datetime starts with.
+const DATE_TIME_LEN: usize = 19;
 
-fn invalid(value: &str) -> Error {
-    Error::with_reason(
-        ErrorKind::StorageError,
-        format!("Failed to parse datetime: {value}"),
-    )
-}
-
-fn parse_naive(value: &str) -> Result<NaiveDateTime> {
-    NaiveDateTime::parse_from_str(value, NAIVE_FORMAT)
-        .or_else(|_| NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S"))
-        .or_else(|_| NaiveDateTime::parse_from_str(value, "%Y-%m-%dT%H:%M:%S%.f"))
-        .map_err(|_| invalid(value))
-}
-
-fn format_naive(value: NaiveDateTime) -> String {
-    value.format(NAIVE_FORMAT).to_string()
-}
-
-/// Interprets a naive local datetime, resolving the ambiguity of a DST fold towards the earlier
-/// instant the way `datetime.astimezone()` does in Python.
-fn local_to_utc(value: NaiveDateTime) -> Result<DateTime<Utc>> {
-    let local = Local
-        .from_local_datetime(&value)
-        .earliest()
-        // A local time skipped by a DST jump forward has no instant at all; map it through the
-        // offset in effect just before the gap rather than failing the whole read.
-        .or_else(|| Local.from_local_datetime(&value).latest())
-        .ok_or_else(|| invalid(&format_naive(value)))?;
-    Ok(local.with_timezone(&Utc))
-}
-
-/// Converts naive local time (as held by `PersistedTrial`) into the naive UTC stored by SQLite.
-pub fn naive_local_to_naive_utc(value: &str) -> Result<String> {
-    Ok(format_naive(local_to_utc(parse_naive(value)?)?.naive_utc()))
-}
-
-/// Converts the naive UTC stored by SQLite back into the naive local time held by
-/// `PersistedTrial`.
-pub fn naive_utc_to_naive_local(value: &str) -> Result<String> {
-    let utc = Utc.from_utc_datetime(&parse_naive(value)?);
-    Ok(format_naive(utc.with_timezone(&Local).naive_local()))
-}
-
-/// Converts naive local time into the timezone-aware UTC written to a journal log.
+/// Returns the current time in the timezone-aware UTC form journal logs carry.
 ///
-/// The output matches Python's `datetime.isoformat(timespec="microseconds")` on an aware UTC
-/// datetime, so Optuna can read logs written by Rustuna.
-pub fn naive_local_to_aware_utc(value: &str) -> Result<String> {
-    Ok(local_to_utc(parse_naive(value)?)?.to_rfc3339_opts(SecondsFormat::Micros, false))
+/// The output matches Optuna's `datetime.now(tz=timezone.utc).isoformat(timespec="microseconds")`.
+pub fn now_aware_utc() -> String {
+    naive_utc_to_aware_utc(&now_naive_utc())
 }
 
-/// Converts a datetime read from a journal log into the naive local time held by
-/// `PersistedTrial`.
+/// Rewrites a timezone-naive UTC timestamp as the timezone-aware form used by journal logs.
+pub fn naive_utc_to_aware_utc(value: &str) -> String {
+    format!("{}+00:00", value.replacen(' ', "T", 1))
+}
+
+/// Converts a datetime read from a journal log into the timezone-naive UTC that `PersistedTrial`
+/// holds.
 ///
-/// Logs written before Rustuna and Optuna moved to aware UTC carry a naive local datetime with no
-/// offset. Those are read back as local time, which is what they were, so old journals keep
-/// reporting the same wall-clock values.
-pub fn journal_datetime_to_naive_local(value: &str) -> Result<String> {
-    match DateTime::parse_from_rfc3339(value) {
-        Ok(aware) => Ok(format_naive(aware.with_timezone(&Local).naive_local())),
-        Err(_) => Ok(format_naive(parse_naive(value)?)),
+/// **The offset is dropped, not applied.** Optuna and Rustuna both write `+00:00`, so there is
+/// nothing to apply, and skipping it keeps this crate free of date arithmetic. The cost is that a
+/// log written by some other tool with a real offset would be read as though its wall-clock reading
+/// were already UTC. Accepting such a value unchanged is still better than rejecting it, since the
+/// datetimes are informational.
+///
+/// Logs predating Optuna 5.0.0rc1 carry a naive datetime with no offset at all. Those were local
+/// time and are likewise taken as UTC.
+pub fn journal_datetime_to_naive_utc(value: &str) -> String {
+    let bytes = value.as_bytes();
+    // Leave anything that is not shaped like a datetime exactly as it was found.
+    if bytes.len() < DATE_TIME_LEN
+        || bytes[4] != b'-'
+        || bytes[7] != b'-'
+        // RFC 3339 section 5.6 allows any of these to separate the date from the time.
+        || !matches!(bytes[10], b'T' | b't' | b' ')
+        || bytes[13] != b':'
+        || bytes[16] != b':'
+    {
+        return value.to_string();
     }
+
+    // Whatever follows the seconds is the fractional part plus the offset. Keep the digits of the
+    // former, at microsecond precision, and discard the latter.
+    let trailer = &value[DATE_TIME_LEN..];
+    let fraction = trailer
+        .strip_prefix('.')
+        .map(|digits| {
+            let end = digits
+                .find(|c: char| !c.is_ascii_digit())
+                .unwrap_or(digits.len());
+            &digits[..end.min(6)]
+        })
+        .unwrap_or("");
+    format!(
+        "{} {}.{fraction:0<6}",
+        &value[..10],
+        &value[11..DATE_TIME_LEN]
+    )
 }
 
 #[cfg(test)]
@@ -89,80 +71,88 @@ mod tests {
     use super::*;
 
     #[test]
-    fn naive_local_and_naive_utc_round_trip() -> Result<()> {
-        let local = "2024-01-02 03:04:05.678";
-        let utc = naive_local_to_naive_utc(local)?;
-        assert_eq!(naive_utc_to_naive_local(&utc)?, local);
-        Ok(())
-    }
-
-    #[test]
-    fn naive_utc_conversion_applies_the_local_offset() -> Result<()> {
-        let local = "2024-01-02 03:04:05.678";
-        let utc = naive_local_to_naive_utc(local)?;
-        // The stored value differs from the local one by exactly the local offset.
-        let offset = Local
-            .from_local_datetime(&parse_naive(local)?)
-            .earliest()
-            .expect("unambiguous local time")
-            .offset()
-            .local_minus_utc();
+    fn aware_utc_round_trips() {
+        let naive = "2024-01-02 03:04:05.678000";
         assert_eq!(
-            parse_naive(&utc)?,
-            parse_naive(local)? - chrono::Duration::seconds(offset as i64)
+            naive_utc_to_aware_utc(naive),
+            "2024-01-02T03:04:05.678000+00:00"
         );
-        Ok(())
-    }
-
-    #[test]
-    fn aware_utc_round_trips_and_carries_an_offset() -> Result<()> {
-        let local = "2024-06-02 03:04:05.678";
-        let aware = naive_local_to_aware_utc(local)?;
-        assert!(
-            aware.ends_with("+00:00"),
-            "journal datetimes must be aware UTC: {aware}"
-        );
-        assert_eq!(journal_datetime_to_naive_local(&aware)?, local);
-        Ok(())
-    }
-
-    #[test]
-    fn journal_datetimes_written_by_optuna_are_accepted() -> Result<()> {
-        // datetime.now(tz=timezone.utc).isoformat(timespec="microseconds")
-        let value = "2024-01-02T03:04:05.678000+00:00";
-        let local = journal_datetime_to_naive_local(value)?;
         assert_eq!(
-            parse_naive(&local)?,
-            DateTime::parse_from_rfc3339(value)
-                .expect("valid rfc3339")
-                .with_timezone(&Local)
-                .naive_local()
+            journal_datetime_to_naive_utc(&naive_utc_to_aware_utc(naive)),
+            naive
         );
-        Ok(())
     }
 
     #[test]
-    fn journal_datetimes_from_older_logs_are_read_as_local_time() -> Result<()> {
-        // Logs written before the move to aware UTC carry naive local time.
+    fn now_round_trips() {
+        let aware = now_aware_utc();
+        assert!(aware.ends_with("+00:00"), "{aware}");
+        assert_eq!(aware.as_bytes()[10], b'T', "{aware}");
+        let naive = journal_datetime_to_naive_utc(&aware);
+        assert_eq!(naive_utc_to_aware_utc(&naive), aware);
+    }
+
+    #[test]
+    fn accepts_the_shapes_optuna_writes() {
+        for input in [
+            "2024-01-02T03:04:05.678000+00:00",
+            "2024-01-02T03:04:05.678000Z",
+            "2024-01-02t03:04:05.678000z",
+            "2024-01-02 03:04:05.678000+00:00",
+            // Logs predating aware UTC.
+            "2024-01-02 03:04:05.678000",
+        ] {
+            assert_eq!(
+                journal_datetime_to_naive_utc(input),
+                "2024-01-02 03:04:05.678000",
+                "{input}"
+            );
+        }
+    }
+
+    #[test]
+    fn normalizes_fractional_precision() {
+        for (input, expected) in [
+            ("2024-01-02T03:04:05Z", "2024-01-02 03:04:05.000000"),
+            ("2024-01-02T03:04:05.5Z", "2024-01-02 03:04:05.500000"),
+            ("2024-01-02T03:04:05.06Z", "2024-01-02 03:04:05.060000"),
+            ("2024-01-02T03:04:05.007Z", "2024-01-02 03:04:05.007000"),
+            ("2024-01-02T03:04:05.000008Z", "2024-01-02 03:04:05.000008"),
+            // Finer than microseconds is truncated, as Python's datetime does.
+            (
+                "2024-01-02T03:04:05.123456789Z",
+                "2024-01-02 03:04:05.123456",
+            ),
+        ] {
+            assert_eq!(journal_datetime_to_naive_utc(input), expected, "{input}");
+        }
+    }
+
+    #[test]
+    fn an_offset_is_dropped_rather_than_applied() {
+        // Documented limitation: nothing Rustuna or Optuna writes has a non-UTC offset, and
+        // honouring one would mean doing date arithmetic here.
         assert_eq!(
-            journal_datetime_to_naive_local("2024-01-02 03:04:05.678")?,
-            "2024-01-02 03:04:05.678"
+            journal_datetime_to_naive_utc("2024-01-02T03:04:05.678000+09:00"),
+            "2024-01-02 03:04:05.678000"
         );
-        Ok(())
-    }
-
-    #[test]
-    fn seconds_only_datetimes_are_accepted() -> Result<()> {
         assert_eq!(
-            naive_utc_to_naive_local("2024-01-02 03:04:05")?,
-            naive_utc_to_naive_local("2024-01-02 03:04:05.000")?
+            journal_datetime_to_naive_utc("2024-01-02T03:04:05.678000-05:30"),
+            "2024-01-02 03:04:05.678000"
         );
-        Ok(())
     }
 
     #[test]
-    fn invalid_datetimes_are_rejected() {
-        assert!(naive_utc_to_naive_local("not-a-datetime").is_err());
-        assert!(naive_local_to_aware_utc("").is_err());
+    fn values_that_are_not_datetimes_are_left_alone() {
+        for input in [
+            "",
+            "not-a-datetime",
+            "2024-01-02",
+            "2024/01/02T03:04:05Z",
+            "2024-01-02X03:04:05Z",
+            "2024-01-02T03-04:05Z",
+        ] {
+            assert_eq!(journal_datetime_to_naive_utc(input), input, "{input}");
+        }
     }
 }

--- a/rustuna_storage/src/journal/storage.rs
+++ b/rustuna_storage/src/journal/storage.rs
@@ -17,6 +17,7 @@ use rustuna_core::trial::{PersistedTrial, TrialStateValues};
 use rustuna_core::{Error, ErrorKind, Result};
 
 use super::{JournalBackend, JournalLog, JournalOperation};
+use crate::datetime::{journal_datetime_to_naive_local, naive_local_to_aware_utc};
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 /// Options for [`JournalStorage`].
@@ -146,10 +147,7 @@ impl Storage for JournalStorage {
     fn create_new_trial(&mut self, study_id: u32) -> Result<&PersistedTrial> {
         let mut fields = HashMap::new();
         fields.insert("study_id".to_string(), to_raw(&study_id)?);
-        fields.insert(
-            "datetime_start".to_string(),
-            to_raw(&chrono::Local::now().naive_local().to_string())?,
-        );
+        fields.insert("datetime_start".to_string(), to_raw(&now_aware_utc())?);
         self.write_log(JournalOperation::CreateTrial, fields)?;
         self.sync_with_backend()?;
         let trial_id = self
@@ -270,10 +268,19 @@ impl Storage for JournalStorage {
         );
         fields.insert(
             "datetime_start".to_string(),
-            to_raw(&template.datetime_start)?,
+            to_raw(
+                &template
+                    .datetime_start
+                    .as_deref()
+                    .map(naive_local_to_aware_utc)
+                    .transpose()?,
+            )?,
         );
         if let Some(ref dt) = template.datetime_complete {
-            fields.insert("datetime_complete".to_string(), to_raw(dt)?);
+            fields.insert(
+                "datetime_complete".to_string(),
+                to_raw(&naive_local_to_aware_utc(dt)?)?,
+            );
         }
         self.write_log(JournalOperation::CreateTrial, fields)?;
         self.sync_with_backend()?;
@@ -408,15 +415,9 @@ impl Storage for JournalStorage {
             && (!matches!(existing_trial.state_values, TrialStateValues::Running)
                 || existing_trial.datetime_start.is_none())
         {
-            fields.insert(
-                "datetime_start".to_string(),
-                to_raw(&chrono::Local::now().naive_local().to_string())?,
-            );
+            fields.insert("datetime_start".to_string(), to_raw(&now_aware_utc())?);
         } else if matches!(state_code, 1..=3) {
-            fields.insert(
-                "datetime_complete".to_string(),
-                to_raw(&chrono::Local::now().naive_local().to_string())?,
-            );
+            fields.insert("datetime_complete".to_string(), to_raw(&now_aware_utc())?);
         }
         self.write_log(JournalOperation::SetTrialStateValues, fields)?;
         self.sync_with_backend()?;
@@ -993,8 +994,14 @@ impl JournalReplayState {
         let user_attrs = get_optional_raw_map(&log.fields, "user_attrs")?;
         let system_attrs = get_optional_raw_map(&log.fields, "system_attrs")?;
         let intermediate_values = get_optional_raw_map(&log.fields, "intermediate_values")?;
-        let datetime_start = get_optional_string(&log.fields, "datetime_start")?;
-        let datetime_complete = get_optional_string(&log.fields, "datetime_complete")?;
+        let datetime_start = get_optional_string(&log.fields, "datetime_start")?
+            .as_deref()
+            .map(journal_datetime_to_naive_local)
+            .transpose()?;
+        let datetime_complete = get_optional_string(&log.fields, "datetime_complete")?
+            .as_deref()
+            .map(journal_datetime_to_naive_local)
+            .transpose()?;
         if !self.study_exists(study_id, log, worker_id)? {
             return Ok(());
         }
@@ -1183,8 +1190,14 @@ impl JournalReplayState {
         let trial_id = get_u32(&log.fields, "trial_id")?;
         let state_code = get_i64(&log.fields, "state")?;
         let values = get_optional_raw_vec(&log.fields, "values")?;
-        let datetime_start = get_optional_string(&log.fields, "datetime_start")?;
-        let datetime_complete = get_optional_string(&log.fields, "datetime_complete")?;
+        let datetime_start = get_optional_string(&log.fields, "datetime_start")?
+            .as_deref()
+            .map(journal_datetime_to_naive_local)
+            .transpose()?;
+        let datetime_complete = get_optional_string(&log.fields, "datetime_complete")?
+            .as_deref()
+            .map(journal_datetime_to_naive_local)
+            .transpose()?;
         if !self.trial_exists_and_updatable(trial_id, log, worker_id)? {
             return Ok(());
         }
@@ -1857,6 +1870,13 @@ fn get_string(fields: &HashMap<String, Box<RawValue>>, key: &str) -> Result<Stri
     raw_value_to_plain_string(get_raw(fields, key)?)
 }
 
+/// Current time in the timezone-aware UTC form journal logs are written in.
+///
+/// The output matches Optuna's `datetime.now(tz=timezone.utc).isoformat(timespec="microseconds")`.
+fn now_aware_utc() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Micros, false)
+}
+
 fn get_optional_string(
     fields: &HashMap<String, Box<RawValue>>,
     key: &str,
@@ -2101,6 +2121,65 @@ mod tests {
         let backend = InMemoryJournalBackend { logs: logs.clone() };
         let storage = JournalStorage::new(Box::new(backend))?;
         Ok((storage, logs))
+    }
+
+    #[test]
+    fn trial_datetimes_are_logged_as_aware_utc() -> Result<()> {
+        let (mut storage, logs) = new_storage()?;
+        let study_id = storage
+            .create_new_study("example", vec![Direction::Minimize])?
+            .id;
+        let trial_id = storage.create_new_trial(study_id)?.id;
+        storage.set_trial_state_values(trial_id, TrialStateValues::Complete(vec![1.0]))?;
+
+        let trial = storage.get_trial(trial_id)?;
+        let reported_start = trial.datetime_start.clone().expect("datetime_start is set");
+        let reported_complete = trial
+            .datetime_complete
+            .clone()
+            .expect("datetime_complete is set");
+
+        // Collect the datetimes as they appear in the log itself.
+        let logged: Vec<String> = {
+            let guard = logs.lock().expect("lock logs");
+            guard
+                .iter()
+                .flat_map(|log| {
+                    ["datetime_start", "datetime_complete"]
+                        .iter()
+                        .filter_map(|key| get_optional_string(&log.fields, key).ok().flatten())
+                        .collect::<Vec<_>>()
+                })
+                .collect()
+        };
+        assert_eq!(logged.len(), 2, "expected both datetimes in the log");
+
+        let parse = |value: &str| {
+            chrono::NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S%.f")
+                .expect("datetime is parseable")
+        };
+        let now_local = chrono::Local::now().naive_local();
+        let now_utc = chrono::Utc::now().naive_utc();
+
+        for value in &logged {
+            // Journal logs carry timezone-aware UTC, matching
+            // datetime.now(tz=timezone.utc).isoformat(timespec="microseconds") in Optuna.
+            let aware = chrono::DateTime::parse_from_rfc3339(value)
+                .unwrap_or_else(|_| panic!("logged datetime is not aware UTC: {value}"));
+            assert_eq!(aware.offset().local_minus_utc(), 0, "not UTC: {value}");
+            let skew = (now_utc - aware.naive_utc()).num_seconds().abs();
+            assert!(skew < 60, "logged datetime is not now: {value}");
+        }
+
+        // What PersistedTrial carries is local time, as with SQLite3Storage.
+        for value in [&reported_start, &reported_complete] {
+            let skew = (now_local - parse(value)).num_seconds().abs();
+            assert!(
+                skew < 60,
+                "datetime is not local time: {value} vs {now_local}"
+            );
+        }
+        Ok(())
     }
 
     #[test]

--- a/rustuna_storage/src/journal/storage.rs
+++ b/rustuna_storage/src/journal/storage.rs
@@ -17,7 +17,7 @@ use rustuna_core::trial::{PersistedTrial, TrialStateValues};
 use rustuna_core::{Error, ErrorKind, Result};
 
 use super::{JournalBackend, JournalLog, JournalOperation};
-use crate::datetime::{journal_datetime_to_naive_local, naive_local_to_aware_utc};
+use crate::datetime::{journal_datetime_to_naive_utc, naive_utc_to_aware_utc, now_aware_utc};
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 /// Options for [`JournalStorage`].
@@ -272,14 +272,13 @@ impl Storage for JournalStorage {
                 &template
                     .datetime_start
                     .as_deref()
-                    .map(naive_local_to_aware_utc)
-                    .transpose()?,
+                    .map(naive_utc_to_aware_utc),
             )?,
         );
         if let Some(ref dt) = template.datetime_complete {
             fields.insert(
                 "datetime_complete".to_string(),
-                to_raw(&naive_local_to_aware_utc(dt)?)?,
+                to_raw(&naive_utc_to_aware_utc(dt))?,
             );
         }
         self.write_log(JournalOperation::CreateTrial, fields)?;
@@ -996,12 +995,10 @@ impl JournalReplayState {
         let intermediate_values = get_optional_raw_map(&log.fields, "intermediate_values")?;
         let datetime_start = get_optional_string(&log.fields, "datetime_start")?
             .as_deref()
-            .map(journal_datetime_to_naive_local)
-            .transpose()?;
+            .map(journal_datetime_to_naive_utc);
         let datetime_complete = get_optional_string(&log.fields, "datetime_complete")?
             .as_deref()
-            .map(journal_datetime_to_naive_local)
-            .transpose()?;
+            .map(journal_datetime_to_naive_utc);
         if !self.study_exists(study_id, log, worker_id)? {
             return Ok(());
         }
@@ -1192,12 +1189,10 @@ impl JournalReplayState {
         let values = get_optional_raw_vec(&log.fields, "values")?;
         let datetime_start = get_optional_string(&log.fields, "datetime_start")?
             .as_deref()
-            .map(journal_datetime_to_naive_local)
-            .transpose()?;
+            .map(journal_datetime_to_naive_utc);
         let datetime_complete = get_optional_string(&log.fields, "datetime_complete")?
             .as_deref()
-            .map(journal_datetime_to_naive_local)
-            .transpose()?;
+            .map(journal_datetime_to_naive_utc);
         if !self.trial_exists_and_updatable(trial_id, log, worker_id)? {
             return Ok(());
         }
@@ -1870,13 +1865,6 @@ fn get_string(fields: &HashMap<String, Box<RawValue>>, key: &str) -> Result<Stri
     raw_value_to_plain_string(get_raw(fields, key)?)
 }
 
-/// Current time in the timezone-aware UTC form journal logs are written in.
-///
-/// The output matches Optuna's `datetime.now(tz=timezone.utc).isoformat(timespec="microseconds")`.
-fn now_aware_utc() -> String {
-    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Micros, false)
-}
-
 fn get_optional_string(
     fields: &HashMap<String, Box<RawValue>>,
     key: &str,
@@ -2154,31 +2142,27 @@ mod tests {
         };
         assert_eq!(logged.len(), 2, "expected both datetimes in the log");
 
-        let parse = |value: &str| {
-            chrono::NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S%.f")
-                .expect("datetime is parseable")
-        };
-        let now_local = chrono::Local::now().naive_local();
-        let now_utc = chrono::Utc::now().naive_utc();
-
         for value in &logged {
             // Journal logs carry timezone-aware UTC, matching
             // datetime.now(tz=timezone.utc).isoformat(timespec="microseconds") in Optuna.
-            let aware = chrono::DateTime::parse_from_rfc3339(value)
-                .unwrap_or_else(|_| panic!("logged datetime is not aware UTC: {value}"));
-            assert_eq!(aware.offset().local_minus_utc(), 0, "not UTC: {value}");
-            let skew = (now_utc - aware.naive_utc()).num_seconds().abs();
-            assert!(skew < 60, "logged datetime is not now: {value}");
-        }
-
-        // What PersistedTrial carries is local time, as with SQLite3Storage.
-        for value in [&reported_start, &reported_complete] {
-            let skew = (now_local - parse(value)).num_seconds().abs();
-            assert!(
-                skew < 60,
-                "datetime is not local time: {value} vs {now_local}"
+            assert!(value.ends_with("+00:00"), "not aware UTC: {value}");
+            assert_eq!(value.as_bytes()[10], b'T', "not RFC 3339: {value}");
+            assert_eq!(
+                value.len(),
+                "1970-01-01T00:00:00.000000+00:00".len(),
+                "not microsecond precision: {value}"
             );
         }
+
+        // What PersistedTrial carries is the very same instants as naive UTC, so the log entries
+        // are the reported values plus an explicit offset.
+        assert_eq!(
+            logged,
+            vec![
+                naive_utc_to_aware_utc(&reported_start),
+                naive_utc_to_aware_utc(&reported_complete),
+            ]
+        );
         Ok(())
     }
 

--- a/rustuna_storage/src/lib.rs
+++ b/rustuna_storage/src/lib.rs
@@ -6,6 +6,7 @@
 //! `rustuna_core::storage::Storage` and `rustuna_core::trial_queue::TrialQueue` traits.
 
 pub mod cache;
+pub mod datetime;
 pub mod directory_queue;
 pub mod journal;
 pub mod sqlite3;

--- a/rustuna_storage/src/sqlite3.rs
+++ b/rustuna_storage/src/sqlite3.rs
@@ -1,4 +1,5 @@
 use crate::cache::{CachedStorageBackend, DiscardedTrialsDiff};
+use crate::datetime::{naive_local_to_naive_utc, naive_utc_to_naive_local};
 use rusqlite::{params, Connection, Error as RusqliteError, OptionalExtension};
 use rustuna_core::attr::{AttrKey, Attrs, CategoryLabel};
 use rustuna_core::distribution::Distribution;
@@ -37,9 +38,10 @@ const TRIALS_STUDY_ID_NUMBER_INDEX_SQL: &str =
 const TRIALS_DISCARDED_AT_COLUMN_SQL: &str = "ALTER TABLE trials ADD COLUMN discarded_at DATETIME";
 const TRIALS_DISCARDED_AT_INDEX_SQL: &str =
     "CREATE INDEX IF NOT EXISTS trials_study_id_discarded_at_key ON trials (study_id, discarded_at)";
-// Naive UTC, so that the value is comparable as a string across processes and usable as a
-// synchronization cursor.
-const DISCARDED_AT_NOW_SQL: &str = "strftime('%Y-%m-%d %H:%M:%f', 'now')";
+// Naive UTC, matching Optuna's RDBStorage. `PersistedTrial` holds naive local time, so datetimes
+// are converted at this boundary; see `crate::datetime`. Using UTC on disk also makes
+// `discarded_at` comparable as a string across processes, which is what the discard cursor needs.
+const NOW_UTC_SQL: &str = "strftime('%Y-%m-%d %H:%M:%f', 'now')";
 type TrialRow = (u32, u32, String, Option<String>, Option<String>);
 
 impl SQLite3Storage {
@@ -270,7 +272,7 @@ impl CachedStorageBackend for SQLite3Storage {
             let updated = tx
                 .execute(
                     &format!(
-                        "UPDATE trials SET discarded_at = {DISCARDED_AT_NOW_SQL} \
+                        "UPDATE trials SET discarded_at = {NOW_UTC_SQL} \
                          WHERE trial_id = ? AND discarded_at IS NULL"
                     ),
                     params![trial_id],
@@ -439,8 +441,10 @@ impl CachedStorageBackend for SQLite3Storage {
             .map_err(|_| Error::new(ErrorKind::StorageError))?;
         guard
             .execute(
-                "INSERT INTO trials (number, study_id, state, datetime_start, datetime_complete) \
-             VALUES (NULL, ?, ?, strftime('%Y-%m-%d %H:%M:%f','now','localtime'), NULL)",
+                &format!(
+                    "INSERT INTO trials (number, study_id, state, datetime_start, datetime_complete) \
+                     VALUES (NULL, ?, ?, {NOW_UTC_SQL}, NULL)"
+                ),
                 params![study_id, "RUNNING"],
             )
             .map_err(|e| {
@@ -491,7 +495,10 @@ impl CachedStorageBackend for SQLite3Storage {
             })?;
 
         let mut trial = PersistedTrial::new(trial_id, study_id, number);
-        trial.datetime_start = datetime_start;
+        trial.datetime_start = datetime_start
+            .as_deref()
+            .map(naive_utc_to_naive_local)
+            .transpose()?;
         Ok(trial)
     }
 
@@ -554,8 +561,16 @@ impl CachedStorageBackend for SQLite3Storage {
             .execute(
                 "UPDATE trials SET datetime_start = ?, datetime_complete = ? WHERE trial_id = ?",
                 params![
-                    template.datetime_start,
-                    template.datetime_complete,
+                    template
+                        .datetime_start
+                        .as_deref()
+                        .map(naive_local_to_naive_utc)
+                        .transpose()?,
+                    template
+                        .datetime_complete
+                        .as_deref()
+                        .map(naive_local_to_naive_utc)
+                        .transpose()?,
                     trial_id
                 ],
             )
@@ -649,7 +664,7 @@ impl CachedStorageBackend for SQLite3Storage {
             TrialStateValues::Complete(values) => {
                 guard
                     .execute(
-                        "UPDATE trials SET state = ?, datetime_complete = strftime('%Y-%m-%d %H:%M:%f','now','localtime') WHERE trial_id = ?",
+                        &format!("UPDATE trials SET state = ?, datetime_complete = {NOW_UTC_SQL} WHERE trial_id = ?"),
                         params!["COMPLETE", trial_id],
                     )
                     .map_err(|e| Error::with_reason(ErrorKind::StorageError, format!("Database query failed: {e}")))?;
@@ -678,7 +693,7 @@ impl CachedStorageBackend for SQLite3Storage {
             TrialStateValues::Pruned => {
                 guard
                     .execute(
-                        "UPDATE trials SET state = ?, datetime_complete = strftime('%Y-%m-%d %H:%M:%f','now','localtime') WHERE trial_id = ?",
+                        &format!("UPDATE trials SET state = ?, datetime_complete = {NOW_UTC_SQL} WHERE trial_id = ?"),
                         params!["PRUNED", trial_id],
                     )
                     .map_err(|e| Error::with_reason(ErrorKind::StorageError, format!("Database query failed: {e}")))?;
@@ -686,7 +701,7 @@ impl CachedStorageBackend for SQLite3Storage {
             TrialStateValues::Fail => {
                 guard
                     .execute(
-                        "UPDATE trials SET state = ?, datetime_complete = strftime('%Y-%m-%d %H:%M:%f','now','localtime') WHERE trial_id = ?",
+                        &format!("UPDATE trials SET state = ?, datetime_complete = {NOW_UTC_SQL} WHERE trial_id = ?"),
                         params!["FAIL", trial_id],
                     )
                     .map_err(|e| Error::with_reason(ErrorKind::StorageError, format!("Database query failed: {e}")))?;
@@ -1022,8 +1037,14 @@ impl CachedStorageBackend for SQLite3Storage {
         trial.distributions = distributions;
         trial.intermediate_values = intermediate_values;
         trial.attrs = attrs;
-        trial.datetime_start = datetime_start;
-        trial.datetime_complete = datetime_complete;
+        trial.datetime_start = datetime_start
+            .as_deref()
+            .map(naive_utc_to_naive_local)
+            .transpose()?;
+        trial.datetime_complete = datetime_complete
+            .as_deref()
+            .map(naive_utc_to_naive_local)
+            .transpose()?;
         Ok(trial)
     }
 
@@ -1596,8 +1617,14 @@ impl CachedStorageBackend for SQLite3Storage {
             trial.distributions = distributions;
             trial.intermediate_values = intermediate_values;
             trial.attrs = attrs;
-            trial.datetime_start = datetime_start;
-            trial.datetime_complete = datetime_complete;
+            trial.datetime_start = datetime_start
+                .as_deref()
+                .map(naive_utc_to_naive_local)
+                .transpose()?;
+            trial.datetime_complete = datetime_complete
+                .as_deref()
+                .map(naive_utc_to_naive_local)
+                .transpose()?;
             trials.push(trial);
         }
 
@@ -1983,6 +2010,79 @@ mod tests {
 
     fn init_storage() -> Result<SQLite3Storage> {
         init_storage_with_option(SQLite3StorageOptions::default())
+    }
+
+    #[test]
+    fn trial_datetimes_are_stored_as_naive_utc() -> Result<()> {
+        let mut storage = init_storage()?;
+        let study_id = storage
+            .create_new_study("example", vec![Direction::Minimize])?
+            .id;
+        let trial = storage.create_new_trial(study_id)?;
+        let trial_id = trial.id;
+        let reported_start = trial.datetime_start.clone().expect("datetime_start is set");
+        storage.set_trial_state_values(trial_id, TrialStateValues::Complete(vec![1.0]))?;
+        let trial = storage.get_trial(trial_id)?;
+        let reported_complete = trial
+            .datetime_complete
+            .clone()
+            .expect("datetime_complete is set");
+        assert_eq!(
+            trial.datetime_start.as_deref(),
+            Some(reported_start.as_str())
+        );
+
+        let (stored_start, stored_complete): (String, String) = {
+            let guard = storage
+                .conn
+                .lock()
+                .map_err(|_| Error::new(ErrorKind::StorageError))?;
+            guard
+                .query_row(
+                    "SELECT datetime_start, datetime_complete FROM trials WHERE trial_id = ?",
+                    params![trial_id],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .map_err(|e| Error::with_reason(ErrorKind::StorageError, e.to_string()))?
+        };
+
+        // The references below come from chrono rather than from NOW_UTC_SQL, so that flipping
+        // that constant back to local time makes this test fail instead of moving with it.
+        let parse = |value: &str| {
+            chrono::NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S%.f")
+                .expect("datetime is parseable")
+        };
+        let seconds_from = |value: &str, reference: chrono::NaiveDateTime| {
+            (reference - parse(value)).num_seconds().abs()
+        };
+
+        // PersistedTrial carries local time, which is what FrozenTrial.datetime_start reports.
+        let now_local = chrono::Local::now().naive_local();
+        assert!(
+            seconds_from(&reported_start, now_local) < 60,
+            "datetime_start is not local time: {reported_start} vs {now_local}"
+        );
+        assert!(
+            seconds_from(&reported_complete, now_local) < 60,
+            "datetime_complete is not local time: {reported_complete} vs {now_local}"
+        );
+
+        // The columns hold the same instants in UTC.
+        let now_utc = chrono::Utc::now().naive_utc();
+        assert!(
+            seconds_from(&stored_start, now_utc) < 60,
+            "stored datetime_start is not UTC: {stored_start} vs {now_utc}"
+        );
+        assert!(
+            seconds_from(&stored_complete, now_utc) < 60,
+            "stored datetime_complete is not UTC: {stored_complete} vs {now_utc}"
+        );
+        assert_eq!(naive_utc_to_naive_local(&stored_start)?, reported_start);
+        assert_eq!(
+            naive_utc_to_naive_local(&stored_complete)?,
+            reported_complete
+        );
+        Ok(())
     }
 
     fn init_storage_with_option(options: SQLite3StorageOptions) -> Result<SQLite3Storage> {

--- a/rustuna_storage/src/sqlite3.rs
+++ b/rustuna_storage/src/sqlite3.rs
@@ -1,7 +1,7 @@
 use crate::cache::{CachedStorageBackend, DiscardedTrialsDiff};
-use crate::datetime::{naive_local_to_naive_utc, naive_utc_to_naive_local};
 use rusqlite::{params, Connection, Error as RusqliteError, OptionalExtension};
 use rustuna_core::attr::{AttrKey, Attrs, CategoryLabel};
+use rustuna_core::datetime::now_naive_utc;
 use rustuna_core::distribution::Distribution;
 use rustuna_core::study::{Direction, PersistedStudy};
 use rustuna_core::trial::{PersistedTrial, TrialStateValues};
@@ -38,10 +38,7 @@ const TRIALS_STUDY_ID_NUMBER_INDEX_SQL: &str =
 const TRIALS_DISCARDED_AT_COLUMN_SQL: &str = "ALTER TABLE trials ADD COLUMN discarded_at DATETIME";
 const TRIALS_DISCARDED_AT_INDEX_SQL: &str =
     "CREATE INDEX IF NOT EXISTS trials_study_id_discarded_at_key ON trials (study_id, discarded_at)";
-// Naive UTC, matching Optuna's RDBStorage. `PersistedTrial` holds naive local time, so datetimes
-// are converted at this boundary; see `crate::datetime`. Using UTC on disk also makes
-// `discarded_at` comparable as a string across processes, which is what the discard cursor needs.
-const NOW_UTC_SQL: &str = "strftime('%Y-%m-%d %H:%M:%f', 'now')";
+
 type TrialRow = (u32, u32, String, Option<String>, Option<String>);
 
 impl SQLite3Storage {
@@ -271,11 +268,8 @@ impl CachedStorageBackend for SQLite3Storage {
             // making them replay a discard they have applied.
             let updated = tx
                 .execute(
-                    &format!(
-                        "UPDATE trials SET discarded_at = {NOW_UTC_SQL} \
-                         WHERE trial_id = ? AND discarded_at IS NULL"
-                    ),
-                    params![trial_id],
+                    "UPDATE trials SET discarded_at = ? WHERE trial_id = ? AND discarded_at IS NULL",
+                    params![now_naive_utc(), trial_id],
                 )
                 .map_err(|e| {
                     Error::with_reason(
@@ -441,11 +435,9 @@ impl CachedStorageBackend for SQLite3Storage {
             .map_err(|_| Error::new(ErrorKind::StorageError))?;
         guard
             .execute(
-                &format!(
-                    "INSERT INTO trials (number, study_id, state, datetime_start, datetime_complete) \
-                     VALUES (NULL, ?, ?, {NOW_UTC_SQL}, NULL)"
-                ),
-                params![study_id, "RUNNING"],
+                "INSERT INTO trials (number, study_id, state, datetime_start, datetime_complete) \
+                 VALUES (NULL, ?, ?, ?, NULL)",
+                params![study_id, "RUNNING", now_naive_utc()],
             )
             .map_err(|e| {
                 Error::with_reason(
@@ -495,10 +487,7 @@ impl CachedStorageBackend for SQLite3Storage {
             })?;
 
         let mut trial = PersistedTrial::new(trial_id, study_id, number);
-        trial.datetime_start = datetime_start
-            .as_deref()
-            .map(naive_utc_to_naive_local)
-            .transpose()?;
+        trial.datetime_start = datetime_start;
         Ok(trial)
     }
 
@@ -561,16 +550,8 @@ impl CachedStorageBackend for SQLite3Storage {
             .execute(
                 "UPDATE trials SET datetime_start = ?, datetime_complete = ? WHERE trial_id = ?",
                 params![
-                    template
-                        .datetime_start
-                        .as_deref()
-                        .map(naive_local_to_naive_utc)
-                        .transpose()?,
-                    template
-                        .datetime_complete
-                        .as_deref()
-                        .map(naive_local_to_naive_utc)
-                        .transpose()?,
+                    template.datetime_start,
+                    template.datetime_complete,
                     trial_id
                 ],
             )
@@ -664,10 +645,15 @@ impl CachedStorageBackend for SQLite3Storage {
             TrialStateValues::Complete(values) => {
                 guard
                     .execute(
-                        &format!("UPDATE trials SET state = ?, datetime_complete = {NOW_UTC_SQL} WHERE trial_id = ?"),
-                        params!["COMPLETE", trial_id],
+                        "UPDATE trials SET state = ?, datetime_complete = ? WHERE trial_id = ?",
+                        params!["COMPLETE", now_naive_utc(), trial_id],
                     )
-                    .map_err(|e| Error::with_reason(ErrorKind::StorageError, format!("Database query failed: {e}")))?;
+                    .map_err(|e| {
+                        Error::with_reason(
+                            ErrorKind::StorageError,
+                            format!("Database query failed: {e}"),
+                        )
+                    })?;
 
                 if !values.is_empty() {
                     let placeholders = values
@@ -693,18 +679,28 @@ impl CachedStorageBackend for SQLite3Storage {
             TrialStateValues::Pruned => {
                 guard
                     .execute(
-                        &format!("UPDATE trials SET state = ?, datetime_complete = {NOW_UTC_SQL} WHERE trial_id = ?"),
-                        params!["PRUNED", trial_id],
+                        "UPDATE trials SET state = ?, datetime_complete = ? WHERE trial_id = ?",
+                        params!["PRUNED", now_naive_utc(), trial_id],
                     )
-                    .map_err(|e| Error::with_reason(ErrorKind::StorageError, format!("Database query failed: {e}")))?;
+                    .map_err(|e| {
+                        Error::with_reason(
+                            ErrorKind::StorageError,
+                            format!("Database query failed: {e}"),
+                        )
+                    })?;
             }
             TrialStateValues::Fail => {
                 guard
                     .execute(
-                        &format!("UPDATE trials SET state = ?, datetime_complete = {NOW_UTC_SQL} WHERE trial_id = ?"),
-                        params!["FAIL", trial_id],
+                        "UPDATE trials SET state = ?, datetime_complete = ? WHERE trial_id = ?",
+                        params!["FAIL", now_naive_utc(), trial_id],
                     )
-                    .map_err(|e| Error::with_reason(ErrorKind::StorageError, format!("Database query failed: {e}")))?;
+                    .map_err(|e| {
+                        Error::with_reason(
+                            ErrorKind::StorageError,
+                            format!("Database query failed: {e}"),
+                        )
+                    })?;
             }
             TrialStateValues::Running => {
                 guard
@@ -1037,14 +1033,8 @@ impl CachedStorageBackend for SQLite3Storage {
         trial.distributions = distributions;
         trial.intermediate_values = intermediate_values;
         trial.attrs = attrs;
-        trial.datetime_start = datetime_start
-            .as_deref()
-            .map(naive_utc_to_naive_local)
-            .transpose()?;
-        trial.datetime_complete = datetime_complete
-            .as_deref()
-            .map(naive_utc_to_naive_local)
-            .transpose()?;
+        trial.datetime_start = datetime_start;
+        trial.datetime_complete = datetime_complete;
         Ok(trial)
     }
 
@@ -1617,14 +1607,8 @@ impl CachedStorageBackend for SQLite3Storage {
             trial.distributions = distributions;
             trial.intermediate_values = intermediate_values;
             trial.attrs = attrs;
-            trial.datetime_start = datetime_start
-                .as_deref()
-                .map(naive_utc_to_naive_local)
-                .transpose()?;
-            trial.datetime_complete = datetime_complete
-                .as_deref()
-                .map(naive_utc_to_naive_local)
-                .transpose()?;
+            trial.datetime_start = datetime_start;
+            trial.datetime_complete = datetime_complete;
             trials.push(trial);
         }
 
@@ -2012,12 +1996,31 @@ mod tests {
         init_storage_with_option(SQLite3StorageOptions::default())
     }
 
+    /// Reads SQLite's own idea of the current UTC time, truncated to whole seconds.
+    ///
+    /// It is an independent reference for the timestamps Rustuna binds from Rust: a column holding
+    /// local time would sit an offset away from it on any machine that is not on UTC. Seconds are
+    /// the finest common precision, since `strftime` stops at milliseconds.
+    fn database_utc_second(storage: &SQLite3Storage) -> Result<String> {
+        let guard = storage
+            .conn
+            .lock()
+            .map_err(|_| Error::new(ErrorKind::StorageError))?;
+        let now: String = guard
+            .query_row("SELECT strftime('%Y-%m-%d %H:%M:%f', 'now')", [], |row| {
+                row.get(0)
+            })
+            .map_err(|e| Error::with_reason(ErrorKind::StorageError, e.to_string()))?;
+        Ok(now[..19].to_string())
+    }
+
     #[test]
     fn trial_datetimes_are_stored_as_naive_utc() -> Result<()> {
         let mut storage = init_storage()?;
         let study_id = storage
             .create_new_study("example", vec![Direction::Minimize])?
             .id;
+        let before = database_utc_second(&storage)?;
         let trial = storage.create_new_trial(study_id)?;
         let trial_id = trial.id;
         let reported_start = trial.datetime_start.clone().expect("datetime_start is set");
@@ -2046,42 +2049,20 @@ mod tests {
                 .map_err(|e| Error::with_reason(ErrorKind::StorageError, e.to_string()))?
         };
 
-        // The references below come from chrono rather than from NOW_UTC_SQL, so that flipping
-        // that constant back to local time makes this test fail instead of moving with it.
-        let parse = |value: &str| {
-            chrono::NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S%.f")
-                .expect("datetime is parseable")
-        };
-        let seconds_from = |value: &str, reference: chrono::NaiveDateTime| {
-            (reference - parse(value)).num_seconds().abs()
-        };
+        // PersistedTrial and the columns hold the same naive UTC value, with no conversion.
+        assert_eq!(stored_start, reported_start);
+        assert_eq!(stored_complete, reported_complete);
 
-        // PersistedTrial carries local time, which is what FrozenTrial.datetime_start reports.
-        let now_local = chrono::Local::now().naive_local();
-        assert!(
-            seconds_from(&reported_start, now_local) < 60,
-            "datetime_start is not local time: {reported_start} vs {now_local}"
-        );
-        assert!(
-            seconds_from(&reported_complete, now_local) < 60,
-            "datetime_complete is not local time: {reported_complete} vs {now_local}"
-        );
-
-        // The columns hold the same instants in UTC.
-        let now_utc = chrono::Utc::now().naive_utc();
-        assert!(
-            seconds_from(&stored_start, now_utc) < 60,
-            "stored datetime_start is not UTC: {stored_start} vs {now_utc}"
-        );
-        assert!(
-            seconds_from(&stored_complete, now_utc) < 60,
-            "stored datetime_complete is not UTC: {stored_complete} vs {now_utc}"
-        );
-        assert_eq!(naive_utc_to_naive_local(&stored_start)?, reported_start);
-        assert_eq!(
-            naive_utc_to_naive_local(&stored_complete)?,
-            reported_complete
-        );
+        // Naive UTC of a fixed width sorts chronologically, so bracketing the stored values
+        // between two readings of the database clock needs no date arithmetic.
+        let after = database_utc_second(&storage)?;
+        for value in [&stored_start, &stored_complete] {
+            let second = &value[..19];
+            assert!(
+                before.as_str() <= second && second <= after.as_str(),
+                "{value} is not UTC (database clock went {before} -> {after})"
+            );
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

* Like https://github.com/optuna/optuna/pull/6776, this PR normalizes datetime to timezone-naive UTC
* Remove `chrono` crate dependency and use `std::Time` instead.
* Fix the bug of datetime_start and datetime_complete are None in `rustuna.storages.InMemoryStorage`.
