### PR TITLE
Support the `target` argument in Python importance APIs

### DIFF
--- a/rustuna_importance/src/common.rs
+++ b/rustuna_importance/src/common.rs
@@ -144,7 +144,7 @@ pub(crate) fn resolve_target(
 
 pub(crate) fn get_filtered_trials(
     study: &Study,
-    target: &dyn Fn(&PersistedTrial) -> f64,
+    target: Option<&dyn Fn(&PersistedTrial) -> f64>,
 ) -> Result<Vec<PersistedTrial>> {
     let mut guard = study.storage.write().map_err(|e| {
         Error::with_reason(
@@ -158,7 +158,7 @@ pub(crate) fn get_filtered_trials(
         .iter()
         .flatten()
         .filter(|t| matches!(t.state_values, TrialStateValues::Complete(_)))
-        .filter(|t| target(t).is_finite())
+        .filter(|t| resolve_target(target)(t).is_finite())
         .cloned()
         .collect::<Vec<_>>();
     Ok(completed_trials)

--- a/rustuna_importance/src/ped_anova.rs
+++ b/rustuna_importance/src/ped_anova.rs
@@ -119,16 +119,16 @@ impl PedAnovaImportanceEvaluator {
         study: &Study,
         trials: &'a [PersistedTrial],
         quantile: f64,
-        target: &dyn Fn(&PersistedTrial) -> f64,
+        target: Option<&dyn Fn(&PersistedTrial) -> f64>,
     ) -> Vec<&'a PersistedTrial> {
         if quantile == 1.0 {
             return trials.iter().collect();
         }
-        let is_lower_better = study.directions[0] == Direction::Minimize;
+        let is_lower_better = target.is_some() || study.directions[0] == Direction::Minimize;
         let objective_values = trials
             .iter()
             .map(|t| {
-                let v = target(t);
+                let v = common::resolve_target(target)(t);
                 if is_lower_better {
                     v
                 } else {
@@ -196,8 +196,7 @@ impl ImportanceEvaluator for PedAnovaImportanceEvaluator {
         study: &Study,
         opts: ImportanceOptions,
     ) -> Result<HashMap<String, f64>> {
-        let target = common::resolve_target(opts.target);
-        let trials = common::get_filtered_trials(study, target)?;
+        let trials = common::get_filtered_trials(study, opts.target)?;
         common::ensure_target_for_multi_objective(&trials, opts.target)?;
         let params = resolve_params(&trials, opts.params)?;
 
@@ -206,9 +205,9 @@ impl ImportanceEvaluator for PedAnovaImportanceEvaluator {
         }
 
         let target_trials =
-            self.get_top_quantile_trials(study, &trials, self.target_quantile, target);
+            self.get_top_quantile_trials(study, &trials, self.target_quantile, opts.target);
         let region_trials =
-            self.get_top_quantile_trials(study, &trials, self.region_quantile, target);
+            self.get_top_quantile_trials(study, &trials, self.region_quantile, opts.target);
         if target_trials.is_empty() {
             return Ok(params.into_iter().map(|name| (name, 0.0)).collect());
         }

--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -389,7 +389,7 @@ class PedAnovaImportanceEvaluator:
     Implements the PED-ANOVA hyperparameter importance evaluation algorithm.
 
     PED-ANOVA fits Parzen estimators to completed trials in the top
-    ``target_quantile`` fraction. The importance can be interpreted as how important each
+    `target_quantile` fraction. The importance can be interpreted as how important each
     hyperparameter is for achieving performance within that fraction.
 
     For further information about the PED-ANOVA algorithm, please refer to the following paper:
@@ -467,13 +467,39 @@ class PedAnovaImportanceEvaluator:
         self,
         study: Study,
         params: list[str] | None = None,
-    ) -> dict[str, float]: ...
+        *,
+        target: Callable[[PersistedTrial], float] | None = None,
+    ) -> dict[str, float]:
+        """Evaluate parameter importances based on completed trials in the given study.
+
+        Note:
+            This method is not meant to be called by library users. Use
+            [get_param_importances][rustuna.importance.get_param_importances] to evaluate
+            parameter importances from user code.
+
+        Args:
+            study:
+                An optimized study.
+            params:
+                A list of names of parameters to assess. If `None`, all parameters that appear
+                in completed trials, including conditional parameters, are assessed.
+            target:
+                A function that returns the value used to evaluate importances. If `None`,
+                objective values are used for single-objective optimization. For multi-objective
+                optimization, this argument must be specified to return a single float value for
+                each trial. `PedAnovaImportanceEvaluator` assumes lower `target` values are better.
+
+        Returns:
+            A `dict` where the keys are parameter names and the values are assessed importances.
+
+        """
 
 def get_param_importances(
     study: Study,
     *,
     evaluator: PedAnovaImportanceEvaluator | None = None,
     params: list[str] | None = None,
+    target: Callable[[PersistedTrial], float] | None = None,
     normalize: bool = True,
 ) -> dict[str, float]:
     """Evaluate parameter importances using PED-ANOVA based on completed trials in the given study.
@@ -508,6 +534,11 @@ def get_param_importances(
         params:
             A list of names of parameters to assess. If `None`, all parameters that appear in
             completed trials are assessed, including conditional parameters.
+        target:
+            A function that returns the value used to evaluate importances.
+            If `None`, objective values are used for single-objective optimization.
+            For multi-objective optimization, this argument must be specified to return
+            a single float value for each trial.
         normalize:
             A boolean option to specify whether the sum of the importance values should be
             normalized to 1.0.

--- a/rustuna_pyo3/rustuna/converter/_importance.py
+++ b/rustuna_pyo3/rustuna/converter/_importance.py
@@ -8,6 +8,7 @@ from optuna.trial import FrozenTrial
 
 import rustuna
 from rustuna.converter._storage import ToRustunaStorage
+from rustuna.converter._trial import to_frozen_trial
 
 
 class ToOptunaImportanceEvaluator(BaseImportanceEvaluator):
@@ -17,7 +18,6 @@ class ToOptunaImportanceEvaluator(BaseImportanceEvaluator):
     ) -> None:
         self._evaluator = evaluator
 
-    # TODO(kAIto47802): Support the `target` argument in Rustuna's PED-ANOVA evaluator.
     def evaluate(
         self,
         study: optuna.Study,
@@ -28,4 +28,13 @@ class ToOptunaImportanceEvaluator(BaseImportanceEvaluator):
         rustuna_study = rustuna.load_study(
             study_name=study.study_name, storage=ToRustunaStorage(study._storage)
         )
-        return self._evaluator.evaluate(rustuna_study, params=params)
+        rustuna_target = None if target is None else _to_rustuna_target(target)
+        return self._evaluator.evaluate(
+            rustuna_study, params=params, target=rustuna_target
+        )
+
+
+def _to_rustuna_target(
+    target: Callable[[FrozenTrial], float],
+) -> Callable[[rustuna.trial.PersistedTrial], float]:
+    return lambda trial: target(to_frozen_trial(trial))

--- a/rustuna_pyo3/src/importance.rs
+++ b/rustuna_pyo3/src/importance.rs
@@ -4,10 +4,10 @@ use pyo3::exceptions::PyUserWarning;
 use pyo3::prelude::*;
 use pyo3::PyResult;
 
+use rustuna_core::trial::PersistedTrial;
 use rustuna_importance::{
     get_param_importances_with, ImportanceEvaluator, ImportanceOptions, PedAnovaImportanceEvaluator,
 };
-use rustuna_core::trial::PersistedTrial;
 
 use crate::exception::err_to_exceptions;
 use crate::study::PyStudy;
@@ -25,7 +25,9 @@ pub fn py_get_param_importances(
 ) -> PyResult<HashMap<String, f64>> {
     let rust_target = convert_py_target(py, study, target)?;
     let options = ImportanceOptions {
-        target: rust_target.as_ref().map(|target| target as &dyn Fn(&PersistedTrial) -> f64),
+        target: rust_target
+            .as_ref()
+            .map(|target| target as &dyn Fn(&PersistedTrial) -> f64),
         normalize,
         params,
     };
@@ -80,7 +82,9 @@ impl PyPedAnovaImportanceEvaluator {
     ) -> PyResult<HashMap<String, f64>> {
         let rust_target = convert_py_target(py, study, target)?;
         let options = ImportanceOptions {
-            target: rust_target.as_ref().map(|target| target as &dyn Fn(&PersistedTrial) -> f64),
+            target: rust_target
+                .as_ref()
+                .map(|target| target as &dyn Fn(&PersistedTrial) -> f64),
             normalize: true,
             params,
         };
@@ -92,24 +96,25 @@ impl PyPedAnovaImportanceEvaluator {
     }
 }
 
-
 fn convert_py_target(
     py: Python<'_>,
     study: &PyStudy,
     target: Option<Py<PyAny>>,
 ) -> PyResult<Option<impl Fn(&PersistedTrial) -> f64>> {
-    let target_values = target.map(|target| {
-        study.py_get_trials(Some(vec![PyTrialState::COMPLETE]))?
-            .into_iter()
-            .map(|trial| {
-                let trial_id = trial.with_trial(|t| Ok(t.id))?;
-                let py_trial = Py::new(py, trial)?;
-                let value = target.call1(py, (py_trial,))?.extract::<f64>(py)?;
-                Ok((trial_id, value))
-            })
-            .collect::<PyResult<HashMap<_, _>>>()
-    })
-    .transpose()?;
-    let rust_target = target_values.map(|values| { move |trial: &PersistedTrial | values[&trial.id]});
+    let target_values = target
+        .map(|target| {
+            study
+                .py_get_trials(Some(vec![PyTrialState::COMPLETE]))?
+                .into_iter()
+                .map(|trial| {
+                    let trial_id = trial.with_trial(|t| Ok(t.id))?;
+                    let py_trial = Py::new(py, trial)?;
+                    let value = target.call1(py, (py_trial,))?.extract::<f64>(py)?;
+                    Ok((trial_id, value))
+                })
+                .collect::<PyResult<HashMap<_, _>>>()
+        })
+        .transpose()?;
+    let rust_target = target_values.map(|values| move |trial: &PersistedTrial| values[&trial.id]);
     Ok(rust_target)
 }

--- a/rustuna_pyo3/src/importance.rs
+++ b/rustuna_pyo3/src/importance.rs
@@ -83,3 +83,25 @@ impl PyPedAnovaImportanceEvaluator {
         Ok(importances)
     }
 }
+
+
+fn convert_py_target(
+    py: Python<'_>,
+    study: &PyStudy,
+    target: Option<Py<PyAny>>,
+) -> PyResult<Option<impl Fn(&PersistedTrial) -> f64>> {
+    let target_values = target.map(|target| {
+        study.py_get_trials(Some(vec![PyTrialState::COMPLETE]))?
+            .into_iter()
+            .map(|trial| {
+                let trial_id = trial.with_trial(|t| Ok(t.id))?;
+                let py_trial = Py::new(py, trial)?;
+                let value = target.call1(py, (py_trial,))?.extract::<f64>(py)?;
+                Ok((trial_id, value))
+            })
+            .collect::<PyResult<HashMap<_, _>>>()
+    })
+    .transpose()?;
+    let rust_target = target_values.map(|values| { move |trial: &PersistedTrial | values[&trial.id]});
+    Ok(rust_target)
+}

--- a/rustuna_pyo3/src/importance.rs
+++ b/rustuna_pyo3/src/importance.rs
@@ -115,6 +115,8 @@ fn convert_py_target(
                 .collect::<PyResult<HashMap<_, _>>>()
         })
         .transpose()?;
-    let rust_target = target_values.map(|values| move |trial: &PersistedTrial| values[&trial.id]);
+    let rust_target = target_values.map(|values| {
+        move |trial: &PersistedTrial| values.get(&trial.id).copied().unwrap_or(f64::NAN)
+    });
     Ok(rust_target)
 }

--- a/rustuna_pyo3/src/importance.rs
+++ b/rustuna_pyo3/src/importance.rs
@@ -68,14 +68,17 @@ impl PyPedAnovaImportanceEvaluator {
         Ok(Self { evaluator })
     }
 
-    #[pyo3(signature = (study, params = None))]
+    #[pyo3(signature = (study, params = None, * , target = None))]
     fn evaluate(
         &self,
+        py: Python<'_>,
         study: &PyStudy,
         params: Option<Vec<String>>,
+        target: Option<Py<PyAny>>,
     ) -> PyResult<HashMap<String, f64>> {
+        let rust_target = convert_py_target(py, study, target)?;
         let options = ImportanceOptions {
-            target: None,
+            target: rust_target.as_ref().map(|target| target as &dyn Fn(&PersistedTrial) -> f64),
             normalize: true,
             params,
         };

--- a/rustuna_pyo3/src/importance.rs
+++ b/rustuna_pyo3/src/importance.rs
@@ -12,15 +12,18 @@ use crate::exception::err_to_exceptions;
 use crate::study::PyStudy;
 
 #[pyfunction]
-#[pyo3(name = "get_param_importances", signature = (study, *, evaluator = None, params = None, normalize = true))]
+#[pyo3(name = "get_param_importances", signature = (study, *, evaluator = None, params = None, target = None, normalize = true))]
 pub fn py_get_param_importances(
+    py: Python<'_>,
     study: &PyStudy,
     evaluator: Option<&PyPedAnovaImportanceEvaluator>,
     params: Option<Vec<String>>,
+    target: Option<Py<PyAny>>,
     normalize: bool,
 ) -> PyResult<HashMap<String, f64>> {
+    let rust_target = convert_py_target(py, study, target)?;
     let options = ImportanceOptions {
-        target: None,
+        target: rust_target.as_ref().map(|target| target as &dyn Fn(&PersistedTrial) -> f64),
         normalize,
         params,
     };

--- a/rustuna_pyo3/src/importance.rs
+++ b/rustuna_pyo3/src/importance.rs
@@ -7,9 +7,11 @@ use pyo3::PyResult;
 use rustuna_importance::{
     get_param_importances_with, ImportanceEvaluator, ImportanceOptions, PedAnovaImportanceEvaluator,
 };
+use rustuna_core::trial::PersistedTrial;
 
 use crate::exception::err_to_exceptions;
 use crate::study::PyStudy;
+use crate::trial::PyTrialState;
 
 #[pyfunction]
 #[pyo3(name = "get_param_importances", signature = (study, *, evaluator = None, params = None, target = None, normalize = true))]

--- a/rustuna_pyo3/src/importance.rs
+++ b/rustuna_pyo3/src/importance.rs
@@ -72,7 +72,7 @@ impl PyPedAnovaImportanceEvaluator {
         Ok(Self { evaluator })
     }
 
-    #[pyo3(signature = (study, params = None, * , target = None))]
+    #[pyo3(signature = (study, params = None, *, target = None))]
     fn evaluate(
         &self,
         py: Python<'_>,

--- a/rustuna_pyo3/tests/test_importance.py
+++ b/rustuna_pyo3/tests/test_importance.py
@@ -19,43 +19,6 @@ class TestBasicImportanceEvaluator(BasicImportanceEvaluatorTestCase):
     def evaluator(self, request: SubRequest) -> Callable[..., BaseImportanceEvaluator]:
         return lambda: ToOptunaImportanceEvaluator(request.param())
 
-    # TODO(kAIto47802): Remove these skip once Rustuna's PED-ANOVA supports target.
-    @pytest.mark.filterwarnings("ignore::UserWarning")
-    @pytest.mark.parametrize("inf_value", [float("inf"), -float("inf")])
-    @pytest.mark.parametrize(
-        "target_idx",
-        [
-            pytest.param(
-                0,
-                marks=pytest.mark.skip(reason="Rustuna does not support target yet"),
-            ),
-            pytest.param(
-                1,
-                marks=pytest.mark.skip(reason="Rustuna does not support target yet"),
-            ),
-            None,
-        ],
-    )
-    def test_evaluator_with_infinite(
-        self,
-        evaluator: Callable[..., BaseImportanceEvaluator],
-        inf_value: float,
-        target_idx: int | None,
-    ) -> None:
-        super().test_evaluator_with_infinite(
-            evaluator,
-            inf_value,
-            target_idx,
-        )
-
-    # TODO(kAIto47802): Remove this skip once Rustuna's PED-ANOVA supports target.
-    @pytest.mark.skip(reason="Rustuna does not support target yet")
-    def test_importance_evaluator_with_target(
-        self,
-        evaluator: Callable[..., BaseImportanceEvaluator],
-    ) -> None:
-        super().test_importance_evaluator_with_target(evaluator)
-
 
 class TestConditionalImportanceEvaluator(ConditionalImportanceEvaluatorTestCase):
     @pytest.fixture(params=[PedAnovaImportanceEvaluator])


### PR DESCRIPTION
## Motivation

The Rust importance API already supports custom target functions, but the Python bindings did not expose this functionality.