### PR TITLE
Remove redundant user attribute cache in `PyTrial`

### DIFF
--- a/rustuna_core/src/trial.rs
+++ b/rustuna_core/src/trial.rs
@@ -231,6 +231,16 @@ impl Trial {
         let key = AttrKey::User(key.into());
         self.cached_trial.attrs.get(&key)
     }
+    /// Returns user attributes stored on the trial.
+    pub fn get_user_attrs(&self) -> HashMap<String, String> {
+        let mut user_attrs = HashMap::with_capacity(self.cached_trial.attrs.len());
+        for (key, value) in &self.cached_trial.attrs {
+            if let AttrKey::User(key) = key {
+                user_attrs.insert(key.to_string(), value.clone());
+            }
+        }
+        user_attrs
+    }
 
     /// Sets a single user attribute on the trial.
     pub fn set_user_attr(&mut self, key: &str, value: String) -> Result<()> {
@@ -552,6 +562,10 @@ mod tests {
         guard.set_trial_attrs(trial.id, attrs, false)?;
 
         // Check the attributes
+        assert_eq!(
+            trial.get_user_attrs(),
+            HashMap::from([(String::from("key"), String::from("user"))])
+        );
         let trial = guard.get_trial(trial.id)?;
         assert_eq!(
             trial.attrs.get(&AttrKey::User("key".into())),

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -231,14 +231,12 @@ impl PyTrialState {
 pub struct PyTrial {
     trial: Trial,
     storage_pyobj: Py<PyAny>,
-    cached_user_attrs: RwLock<HashMap<String, String>>,
 }
 impl PyTrial {
     pub fn new(trial: Trial, storage_pyobj: Py<PyAny>) -> Self {
         PyTrial {
             trial,
             storage_pyobj,
-            cached_user_attrs: RwLock::new(HashMap::new()),
         }
     }
 }
@@ -326,30 +324,18 @@ impl PyTrial {
     }
     #[pyo3(signature = (key, value))]
     pub fn set_user_attr(&mut self, key: &str, value: String) -> PyResult<()> {
-        self.trial.set_user_attr(key, value.clone()).map_err(|e| {
+        self.trial.set_user_attr(key, value).map_err(|e| {
             PyRuntimeError::new_err(format!("Failed to set user attr: {:?}", e.kind))
         })?;
-
-        let mut cache = self.cached_user_attrs.write().map_err(|_| {
-            PyRuntimeError::new_err("Failed to acquire write lock for cached_user_attrs")
-        })?;
-        cache.insert(key.to_string(), value);
         Ok(())
     }
 
     fn set_user_attrs(&mut self, attrs: Py<PyAny>) -> PyResult<()> {
         let user_attrs: HashMap<String, String> = Python::attach(|py| attrs.bind(py).extract())?;
 
-        self.trial.set_user_attrs(user_attrs.clone()).map_err(|e| {
+        self.trial.set_user_attrs(user_attrs).map_err(|e| {
             PyRuntimeError::new_err(format!("Failed to set user attrs: {:?}", e.kind))
         })?;
-
-        let mut cache = self.cached_user_attrs.write().map_err(|e| {
-            PyRuntimeError::new_err(format!(
-                "Failed to acquire write lock for cached_user_attrs: {e:?}"
-            ))
-        })?;
-        cache.extend(user_attrs);
         Ok(())
     }
     #[pyo3(signature = (constraints))]
@@ -366,10 +352,7 @@ impl PyTrial {
 
     #[getter]
     pub fn user_attrs(&self) -> PyResult<HashMap<String, String>> {
-        let cache = self.cached_user_attrs.read().map_err(|_| {
-            PyRuntimeError::new_err("Failed to acquire read lock for cached_user_attrs")
-        })?;
-        Ok(cache.clone())
+        Ok(self.trial.get_user_attrs())
     }
 }
 


### PR DESCRIPTION
## Summary

- Implement `Trial::get_user_attrs`
- Remove the redundant `PyTrial.cached_user_attrs` cache
- Remove unnecessary clones from user attribute setters

## Motivation

`PyTrial` maintained a separate user attribute cache in addition to `Trial::cached_trial.attrs`. User attributes are now retrieved directly from the trial cache.