### PR TITLE
Simplify Rustuna converter by removing OptunaAttrsView

### DIFF
--- a/rustuna_pyo3/rustuna/converter/_attrs.py
+++ b/rustuna_pyo3/rustuna/converter/_attrs.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Iterator, Mapping
 from typing import Any
 
 # Optuna exposes attrs as `dict[str, Any]`, while Rustuna stores them as `dict[str, str]`, so this
@@ -29,76 +28,3 @@ def to_rustuna_attrs(
         for k, v in attrs.items()
         if not k.startswith(_OPTUNA_ATTR_PREFIX)
     }
-
-
-class OptunaAttrsView(dict[str, Any]):
-    def __init__(self, raw: Mapping[str, str]) -> None:
-        super().__init__()
-        self._raw = raw
-        self._keys = tuple(
-            key[len(_OPTUNA_ATTR_PREFIX) :]
-            for key in raw.keys()
-            if key.startswith(_OPTUNA_ATTR_PREFIX)
-        )
-        self._cache: dict[str, Any] = {}
-
-    def _raw_key(self, key: str) -> str:
-        return _OPTUNA_ATTR_PREFIX + key
-
-    def __setitem__(self, key: str, value: Any) -> None:
-        if key not in self._keys:
-            self._keys += (key,)
-        self._cache[key] = value
-
-    def __contains__(self, key: object) -> bool:
-        return isinstance(key, str) and key in self._keys
-
-    def __getitem__(self, key: str) -> Any:
-        if key in self._cache:
-            return self._cache[key]
-        raw = self._raw[self._raw_key(key)]
-        decoded = json.loads(raw)
-        self._cache[key] = decoded
-        return decoded
-
-    def __iter__(self) -> Iterator[str]:
-        return iter(self._keys)
-
-    def __len__(self) -> int:
-        return len(self._keys)
-
-    def get(self, key: str, default: Any = None) -> Any:
-        try:
-            return self[key]
-        except KeyError:
-            return default
-
-    def items(self):  # type: ignore[override]
-        return ((key, self[key]) for key in self)
-
-    def values(self):  # type: ignore[override]
-        return (self[key] for key in self)
-
-    def keys(self):  # type: ignore[override]
-        return iter(self)
-
-    def __copy__(self) -> dict[str, Any]:
-        return dict(self.items())
-
-    def __deepcopy__(self, memo: dict[int, Any]) -> dict[str, Any]:
-        copied = dict(self.items())
-        memo[id(self)] = copied
-        return copied
-
-    def __repr__(self) -> str:
-        return repr(dict(self.items()))
-
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, dict):
-            if len(self) != len(other):
-                return False
-            for key in self:
-                if other.get(key) != self[key]:
-                    return False
-            return True
-        return NotImplemented

--- a/rustuna_pyo3/rustuna/converter/_study.py
+++ b/rustuna_pyo3/rustuna/converter/_study.py
@@ -8,7 +8,7 @@ from optuna import Study as _OptunaStudy
 
 import rustuna
 
-from ._attrs import to_optuna_attrs
+from ._attrs import _OPTUNA_ATTR_PREFIX, to_optuna_attrs
 from ._storage import ToOptunaStorage
 from ._trial import (
     to_frozen_trial,
@@ -70,11 +70,12 @@ class ToOptunaStudy(_OptunaStudy):
 
     @property
     def user_attrs(self) -> dict[str, Any]:
+        # TODO(c-bata): Align the behavior with FrozenTrialLike.user_attrs.
         attrs = self._rustuna_study.user_attrs
         raw_attrs = {
             key: value
             for key, value in attrs.items()
-            if not key.startswith("optuna_attr:")
+            if not key.startswith(_OPTUNA_ATTR_PREFIX)
         }
         raw_attrs.update(to_optuna_attrs(attrs))
         return raw_attrs

--- a/rustuna_pyo3/rustuna/converter/_trial.py
+++ b/rustuna_pyo3/rustuna/converter/_trial.py
@@ -11,7 +11,7 @@ from optuna.trial import FrozenTrial
 
 import rustuna
 
-from ._attrs import OptunaAttrsView, to_rustuna_attrs
+from ._attrs import to_optuna_attrs, to_rustuna_attrs
 from ._distribution import (
     to_optuna_distributions,
     to_rustuna_distribution,
@@ -242,7 +242,7 @@ class FrozenTrialLike(FrozenTrial):
             return self.__user_attrs
 
         user_attrs = self._persisted_trial.user_attrs
-        self.__user_attrs = OptunaAttrsView(user_attrs)
+        self.__user_attrs = to_optuna_attrs(dict(user_attrs))
         return self.__user_attrs
 
     @user_attrs.setter
@@ -255,7 +255,7 @@ class FrozenTrialLike(FrozenTrial):
             return self.__system_attrs
 
         system_attrs = self._persisted_trial.system_attrs
-        self.__system_attrs = OptunaAttrsView(system_attrs)
+        self.__system_attrs = to_optuna_attrs(dict(system_attrs))
         return self.__system_attrs
 
     @system_attrs.setter


### PR DESCRIPTION
## Summary

- Remove `OptunaAttrsView` to simplify the converter module.