### PR TITLE
Reverse loop order to improve cache efficiency

### DIFF
--- a/rustuna_sampler/src/tpe/sampler.rs
+++ b/rustuna_sampler/src/tpe/sampler.rs
@@ -533,8 +533,8 @@ impl TpeSampler {
             .collect();
         let mut active_counts: Vec<u32> = vec![0; n_trials];
 
-        for (param_idx, key) in sorted_keys.iter().enumerate() {
-            for (trial_idx, t) in trials.iter().enumerate() {
+        for (trial_idx, t) in trials.iter().enumerate() {
+            for (param_idx, key) in sorted_keys.iter().enumerate() {
                 if let Some(&v) = t.internal_params.get(*key) {
                     observations_vec[param_idx].push(v);
                     active_counts[trial_idx] += 1;


### PR DESCRIPTION
By reversing the loop order between trials and parameters within `TpeSampler`, we can improve cache efficiency for `internal_params`. This optimization particularly reduces processing time for large `n_trials`.

## Benchmark

- master

```
n_params  n_trials    total [ms]  per trial [us]
      40       100          49.8         498.1
      40      1000        1463.0        1463.0
      40     10000      189557.0       18955.7
```

- PR

```
n_params  n_trials    total [ms]  per trial [us]
      40       100          48.9         489.4
      40      1000        1403.2        1403.2
      40     10000      145480.5       14548.0
```

<details>

```rust
use std::hint::black_box;
use std::time::{Duration, Instant};

use rustuna_core::storage::InMemoryStorage;
use rustuna_core::study::{create_study, Direction};
use rustuna_core::Result;
use rustuna_sampler::tpe::TpeSampler;

const N_TRIALS: [usize; 3] = [100, 1000, 10000];
const N_PARAMS: [usize; 1] = [40];

fn run_study(n_trials: usize, n_params: usize) -> Result<Duration> {
    let storage = InMemoryStorage::new();
    let study = create_study(
        "tpe-benchmark",
        storage,
        TpeSampler::seed_from_u64(0),
        vec![Direction::Minimize],
    )?;

    let start = Instant::now();
    study.optimize(
        |mut trial| {
            let mut value = 0.0;
            for i in 0..n_params {
                let x = trial.suggest_float(&format!("x{i}"), -10.0, 10.0)?;
                value += x * x;
            }
            Ok(vec![black_box(value)])
        },
        n_trials,
    )?;
    Ok(start.elapsed())
}

fn main() -> Result<()> {
    println!(
        "{:>8}  {:>8}  {:>12}  {:>12}",
        "n_params", "n_trials", "total [ms]", "per trial [us]"
    );
    for n_params in N_PARAMS {
        for n_trials in N_TRIALS {
            let duration = run_study(n_trials, n_params)?;
            println!(
                "{:>8}  {:>8}  {:>12.1}  {:>12.1}",
                n_params,
                n_trials,
                duration.as_secs_f64() * 1e3,
                duration.as_secs_f64() * 1e6 / n_trials as f64,
            );
        }
    }
    Ok(())
}
```

</details>