### PR TITLE
Vectorize log PDF calculation

### DIFF
--- a/rustuna_core/src/parzen_estimator/probability_distributions.rs
+++ b/rustuna_core/src/parzen_estimator/probability_distributions.rs
@@ -12,41 +12,41 @@ pub(crate) struct TruncNormDistributions {
     pub sigmas: Vec<f64>,
     pub low: f64,
     pub high: f64,
-    /// Precomputed: log_diff_cdf((low - mu_k) / sigma_k, (high - mu_k) / sigma_k)
-    ln_masses: Vec<f64>,
-    /// Precomputed: sigma_k.ln()
-    ln_sigmas: Vec<f64>,
+    /// Precomputed: NEG_HALF_LOG_2PI - ln(sigma_k) - ln_mass_k, i.e. every term that does not
+    /// depend on x. `-inf` for a kernel with no probability mass.
+    log_consts: Vec<f64>,
 }
 
 impl TruncNormDistributions {
     pub(crate) fn new(mus: Vec<f64>, sigmas: Vec<f64>, low: f64, high: f64) -> Self {
-        let ln_masses = mus
+        let log_consts = mus
             .iter()
             .zip(sigmas.iter())
             .map(|(&mu, &sigma)| {
-                truncnorm::log_diff_cdf((low - mu) / sigma, (high - mu) / sigma)
-                    .unwrap_or(f64::NEG_INFINITY)
+                let ln_mass = truncnorm::log_diff_cdf((low - mu) / sigma, (high - mu) / sigma)
+                    .unwrap_or(f64::NEG_INFINITY);
+                if ln_mass == f64::NEG_INFINITY {
+                    f64::NEG_INFINITY
+                } else {
+                    NEG_HALF_LOG_2PI - sigma.ln() - ln_mass
+                }
             })
             .collect();
-        let ln_sigmas = sigmas.iter().map(|&s| s.ln()).collect();
         Self {
             mus,
             sigmas,
             low,
             high,
-            ln_masses,
-            ln_sigmas,
+            log_consts,
         }
     }
 
-    /// Log PDF of the k-th kernel at x (without bounds check).
-    pub(crate) fn log_pdf(&self, x: f64, k: usize) -> f64 {
-        let ln_mass = self.ln_masses[k];
-        if ln_mass == f64::NEG_INFINITY {
-            return f64::NEG_INFINITY;
+    /// Adds each kernel's log PDF at x into `acc`.
+    pub(crate) fn accumulate_log_pdf(&self, x: f64, acc: &mut [f64]) {
+        for (k, a) in acc.iter_mut().enumerate() {
+            let z = (x - self.mus[k]) / self.sigmas[k];
+            *a += self.log_consts[k] - 0.5 * z * z;
         }
-        let z = (x - self.mus[k]) / self.sigmas[k];
-        NEG_HALF_LOG_2PI - 0.5 * z * z - self.ln_sigmas[k] - ln_mass
     }
 }
 
@@ -56,43 +56,44 @@ pub(crate) struct TruncLogNormDistributions {
     pub sigmas: Vec<f64>,
     pub low: f64,
     pub high: f64,
-    /// Precomputed: log_diff_cdf((ln(low) - mu_k) / sigma_k, (ln(high) - mu_k) / sigma_k)
-    ln_masses: Vec<f64>,
-    /// Precomputed: sigma_k.ln()
-    ln_sigmas: Vec<f64>,
+    /// Precomputed: NEG_HALF_LOG_2PI - ln(sigma_k) - ln_mass_k, i.e. every term that does not
+    /// depend on x. `-inf` for a kernel with no probability mass.
+    log_consts: Vec<f64>,
 }
 
 impl TruncLogNormDistributions {
     pub(crate) fn new(mus: Vec<f64>, sigmas: Vec<f64>, low: f64, high: f64) -> Self {
         let ln_low = low.ln();
         let ln_high = high.ln();
-        let ln_masses = mus
+        let log_consts = mus
             .iter()
             .zip(sigmas.iter())
             .map(|(&mu, &sigma)| {
-                truncnorm::log_diff_cdf((ln_low - mu) / sigma, (ln_high - mu) / sigma)
-                    .unwrap_or(f64::NEG_INFINITY)
+                let ln_mass =
+                    truncnorm::log_diff_cdf((ln_low - mu) / sigma, (ln_high - mu) / sigma)
+                        .unwrap_or(f64::NEG_INFINITY);
+                if ln_mass == f64::NEG_INFINITY {
+                    f64::NEG_INFINITY
+                } else {
+                    NEG_HALF_LOG_2PI - sigma.ln() - ln_mass
+                }
             })
             .collect();
-        let ln_sigmas = sigmas.iter().map(|&s| s.ln()).collect();
         Self {
             mus,
             sigmas,
             low,
             high,
-            ln_masses,
-            ln_sigmas,
+            log_consts,
         }
     }
 
-    /// Log PDF of the k-th kernel at ln_x (without bounds check, Jacobian excluded).
-    pub(crate) fn log_pdf(&self, ln_x: f64, k: usize) -> f64 {
-        let ln_mass = self.ln_masses[k];
-        if ln_mass == f64::NEG_INFINITY {
-            return f64::NEG_INFINITY;
+    /// Adds each kernel's log PDF at ln_x into `acc`.
+    pub(crate) fn accumulate_log_pdf(&self, ln_x: f64, acc: &mut [f64]) {
+        for (k, a) in acc.iter_mut().enumerate() {
+            let z = (ln_x - self.mus[k]) / self.sigmas[k];
+            *a += self.log_consts[k] - 0.5 * z * z - ln_x;
         }
-        let z = (ln_x - self.mus[k]) / self.sigmas[k];
-        NEG_HALF_LOG_2PI - 0.5 * z * z - self.ln_sigmas[k] - ln_mass
     }
 }
 
@@ -425,34 +426,13 @@ impl MixtureOfProductDistribution {
                     if x_val < d.low || x_val > d.high {
                         return f64::NEG_INFINITY;
                     }
-                    for (k, weight) in weighted_log_pdf.iter_mut().enumerate().take(n) {
-                        if *weight == f64::NEG_INFINITY {
-                            continue;
-                        }
-                        let lp = d.log_pdf(x_val, k);
-                        if lp == f64::NEG_INFINITY {
-                            *weight = f64::NEG_INFINITY;
-                        } else {
-                            *weight += lp;
-                        }
-                    }
+                    d.accumulate_log_pdf(x_val, &mut weighted_log_pdf);
                 }
                 Distributions::TruncLogNorm(d) => {
                     if x_val <= 0.0 || x_val < d.low || x_val > d.high {
                         return f64::NEG_INFINITY;
                     }
-                    let ln_x = x_val.ln();
-                    for (k, weight) in weighted_log_pdf.iter_mut().enumerate().take(n) {
-                        if *weight == f64::NEG_INFINITY {
-                            continue;
-                        }
-                        let lp = d.log_pdf(ln_x, k);
-                        if lp == f64::NEG_INFINITY {
-                            *weight = f64::NEG_INFINITY;
-                        } else {
-                            *weight += lp - ln_x;
-                        }
-                    }
+                    d.accumulate_log_pdf(x_val.ln(), &mut weighted_log_pdf);
                 }
                 Distributions::DiscreteTruncNorm(d) => {
                     for (k, weight) in weighted_log_pdf.iter_mut().enumerate().take(n) {


### PR DESCRIPTION
Calculating the log PDF is a computationally intensive task within TPE, and improving its performance is crucial. This PR addresses the issue by preventing branching operations from occurring during these heavy computations, thereby achieving speed improvements.

## Benchmark

- master

```
n_params  n_trials    total [ms]  per trial [us]
      40       500         410.3         820.5
      40      1000        1457.6        1457.6
      40      2000        5691.5        2845.7
```

- PR

```
n_params  n_trials    total [ms]  per trial [us]
      40       500         260.1         520.1
      40      1000         867.1         867.1
      40      2000        3334.2        1667.1
```

<details>

```rust
use std::hint::black_box;
use std::time::{Duration, Instant};

use rustuna_core::storage::InMemoryStorage;
use rustuna_core::study::{create_study, Direction};
use rustuna_core::Result;
use rustuna_sampler::tpe::TpeSampler;

const N_TRIALS: [usize; 3] = [500, 1000, 2000];
const N_PARAMS: [usize; 1] = [40];

fn run_study(n_trials: usize, n_params: usize) -> Result<Duration> {
    let storage = InMemoryStorage::new();
    let study = create_study(
        "tpe-benchmark",
        storage,
        TpeSampler::seed_from_u64(0),
        vec![Direction::Minimize],
    )?;

    let start = Instant::now();
    study.optimize(
        |mut trial| {
            let mut value = 0.0;
            for i in 0..n_params {
                let x = trial.suggest_float(&format!("x{i}"), -10.0, 10.0)?;
                value += x * x;
            }
            Ok(vec![black_box(value)])
        },
        n_trials,
    )?;
    Ok(start.elapsed())
}

fn main() -> Result<()> {
    println!(
        "{:>8}  {:>8}  {:>12}  {:>12}",
        "n_params", "n_trials", "total [ms]", "per trial [us]"
    );
    for n_params in N_PARAMS {
        for n_trials in N_TRIALS {
            let duration = run_study(n_trials, n_params)?;
            println!(
                "{:>8}  {:>8}  {:>12.1}  {:>12.1}",
                n_params,
                n_trials,
                duration.as_secs_f64() * 1e3,
                duration.as_secs_f64() * 1e6 / n_trials as f64,
            );
        }
    }
    Ok(())
}
```

</details>