### PR TITLE
Implement bin sort with `minsigma`

### DIFF
--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -135,6 +135,44 @@ pub(crate) trait CategoricalDistributionBuilder {
 pub(crate) struct DefaultNumericalDistributionBuilder;
 pub(crate) struct DefaultCategoricalDistributionBuilder;
 
+/// Each observation's larger distance to its two sorted neighbors, floored at `minsigma`, or
+/// `None` for some observations are outside the search space.
+///
+/// A neighbor nearer than `minsigma` cannot lift that floor, and binning at that width hides
+/// exactly those: within a bin only the extremes can have a farther neighbor, and it is the
+/// adjacent non-empty bin's extreme. The per-bin extremes therefore give every bandwidth.
+fn binned_sigmas(obs: &[f64], low: f64, high: f64) -> Option<Vec<f64>> {
+    let n_bins = 100.min(obs.len() + 2);
+    let minsigma = (high - low) / n_bins as f64;
+
+    let mut bins = vec![(f64::INFINITY, 0_usize, f64::NEG_INFINITY, 0_usize); n_bins];
+    for (i, &v) in obs.iter().enumerate() {
+        if !(low..=high).contains(&v) {
+            // The observation is outside the search space.
+            return None;
+        }
+        let bin = &mut bins[(((v - low) / minsigma) as usize).min(n_bins - 1)];
+        if v < bin.0 {
+            (bin.0, bin.1) = (v, i);
+        }
+        if v >= bin.2 {
+            (bin.2, bin.3) = (v, i);
+        }
+    }
+
+    let mut sigmas = vec![minsigma; obs.len()];
+    let (mut prev_max, mut next_min) = (f64::NAN, f64::NAN);
+    for bin in bins.iter().filter(|b| b.0 <= b.2) {
+        sigmas[bin.1] = sigmas[bin.1].max(bin.0 - prev_max);
+        prev_max = bin.2;
+    }
+    for bin in bins.iter().rev().filter(|b| b.0 <= b.2) {
+        sigmas[bin.3] = sigmas[bin.3].max(next_min - bin.2);
+        next_min = bin.0;
+    }
+    Some(sigmas)
+}
+
 impl NumericalDistributionBuilder for DefaultNumericalDistributionBuilder {
     fn calculate_numerical_distribution(
         &self,
@@ -177,7 +215,11 @@ impl NumericalDistributionBuilder for DefaultNumericalDistributionBuilder {
         let mut sigmas = Vec::with_capacity(mus.len() + 1); // +1 for prior
         if mus.len() == 1 {
             // Case: prior only
-            sigmas.push(adj_high - adj_low);
+        } else if mus.len() == 2 {
+            // No inter-observation neighbor exists, so fall back to endpoint distances.
+            sigmas.push((mus[0] - adj_low).max(adj_high - mus[0]));
+        } else if let Some(binned) = binned_sigmas(&mus[..mus.len() - 1], adj_low, adj_high) {
+            sigmas = binned;
         } else {
             let m = mus.len() - 1; // exclude prior
             let mut idx_vals: Vec<(usize, f64)> = (0..m).map(|i| (i, mus[i])).collect();
@@ -185,12 +227,9 @@ impl NumericalDistributionBuilder for DefaultNumericalDistributionBuilder {
             let sorted_obs: Vec<f64> = idx_vals.iter().map(|&(_, v)| v).collect();
 
             // consider_endpoints=False: boundary observations use only the neighbor distance.
-            // When m == 1, no inter-observation neighbor exists, so fall back to endpoint distances.
             sigmas.resize(m, 0.0);
             for (j, &(orig_idx, _)) in idx_vals.iter().enumerate() {
-                sigmas[orig_idx] = if m == 1 {
-                    (sorted_obs[0] - adj_low).max(adj_high - sorted_obs[0])
-                } else if j == 0 {
+                sigmas[orig_idx] = if j == 0 {
                     sorted_obs[1] - sorted_obs[0]
                 } else if j == m - 1 {
                     sorted_obs[m - 1] - sorted_obs[m - 2]
@@ -198,8 +237,6 @@ impl NumericalDistributionBuilder for DefaultNumericalDistributionBuilder {
                     (sorted_obs[j] - sorted_obs[j - 1]).max(sorted_obs[j + 1] - sorted_obs[j])
                 };
             }
-            // Sigma for prior
-            sigmas.push(adj_high - adj_low);
 
             // Clamp (minsigma, maxsigma)
             let maxsigma = adj_high - adj_low;
@@ -208,6 +245,9 @@ impl NumericalDistributionBuilder for DefaultNumericalDistributionBuilder {
                 *s = s.clamp(minsigma, maxsigma);
             }
         }
+
+        // Sigma for prior
+        sigmas.push(adj_high - adj_low);
 
         match (step_opt, log) {
             (None, false) => {
@@ -271,7 +311,41 @@ impl CategoricalDistributionBuilder for DefaultCategoricalDistributionBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::SeedableRng;
+    use rand::{Rng, SeedableRng};
+
+    #[test]
+    fn binned_sigmas_matches_a_naive_scan() {
+        // The larger distance to the two neighbors in sorted order, floored.
+        let naive = |obs: &[f64], minsigma: f64| {
+            let n = obs.len();
+            let mut order: Vec<usize> = (0..n).collect();
+            order.sort_by(|&a, &b| obs[a].total_cmp(&obs[b]));
+            let mut want = vec![0.0; n];
+            for (j, &i) in order.iter().enumerate() {
+                // A missing neighbor leaves NaN, which `max` discards.
+                let gap = |k: usize| (obs[order[k]] - obs[i]).abs();
+                let left = if j > 0 { gap(j - 1) } else { f64::NAN };
+                let right = if j + 1 < n { gap(j + 1) } else { f64::NAN };
+                want[i] = left.max(right).max(minsigma);
+            }
+            want
+        };
+
+        let (low, high) = (-10.0, 10.0);
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+        for m in [2, 3, 7, 64, 500] {
+            for spread in [1.0, 1e-4, 1e-9] {
+                // Endpoints, a duplicate, and a cluster far tighter than one bin, so that the
+                // neighbor rule and its tie-breaking are both exercised.
+                let mut obs: Vec<f64> = (0..m).map(|_| rng.gen_range(-spread..spread)).collect();
+                (obs[0], obs[m - 1], obs[m / 2]) = (low, high, obs[m / 3]);
+
+                let minsigma = (high - low) / (100.0_f64.min(2.0 + m as f64));
+                let binned = binned_sigmas(&obs, low, high).unwrap();
+                assert_eq!(binned, naive(&obs, minsigma), "m = {m}, spread = {spread}");
+            }
+        }
+    }
 
     #[test]
     fn build_parzen_estimator() {

--- a/rustuna_core/src/parzen_estimator/model.rs
+++ b/rustuna_core/src/parzen_estimator/model.rs
@@ -136,12 +136,17 @@ pub(crate) struct DefaultNumericalDistributionBuilder;
 pub(crate) struct DefaultCategoricalDistributionBuilder;
 
 /// Each observation's larger distance to its two sorted neighbors, floored at `minsigma`, or
-/// `None` for some observations are outside the search space.
+/// `None` if fewer than two observations are given or some of them are outside the search space.
 ///
 /// A neighbor nearer than `minsigma` cannot lift that floor, and binning at that width hides
 /// exactly those: within a bin only the extremes can have a farther neighbor, and it is the
 /// adjacent non-empty bin's extreme. The per-bin extremes therefore give every bandwidth.
 fn binned_sigmas(obs: &[f64], low: f64, high: f64) -> Option<Vec<f64>> {
+    if obs.len() < 2 {
+        // No inter-observation neighbor exists; the caller falls back to endpoint distances.
+        return None;
+    }
+
     let n_bins = 100.min(obs.len() + 2);
     let minsigma = (high - low) / n_bins as f64;
 
@@ -215,11 +220,11 @@ impl NumericalDistributionBuilder for DefaultNumericalDistributionBuilder {
         let mut sigmas = Vec::with_capacity(mus.len() + 1); // +1 for prior
         if mus.len() == 1 {
             // Case: prior only
-        } else if mus.len() == 2 {
-            // No inter-observation neighbor exists, so fall back to endpoint distances.
-            sigmas.push((mus[0] - adj_low).max(adj_high - mus[0]));
+            sigmas.push(adj_high - adj_low);
         } else if let Some(binned) = binned_sigmas(&mus[..mus.len() - 1], adj_low, adj_high) {
             sigmas = binned;
+            // Sigma for prior
+            sigmas.push(adj_high - adj_low);
         } else {
             let m = mus.len() - 1; // exclude prior
             let mut idx_vals: Vec<(usize, f64)> = (0..m).map(|i| (i, mus[i])).collect();
@@ -227,9 +232,12 @@ impl NumericalDistributionBuilder for DefaultNumericalDistributionBuilder {
             let sorted_obs: Vec<f64> = idx_vals.iter().map(|&(_, v)| v).collect();
 
             // consider_endpoints=False: boundary observations use only the neighbor distance.
+            // When m == 1, no inter-observation neighbor exists, so fall back to endpoint distances.
             sigmas.resize(m, 0.0);
             for (j, &(orig_idx, _)) in idx_vals.iter().enumerate() {
-                sigmas[orig_idx] = if j == 0 {
+                sigmas[orig_idx] = if m == 1 {
+                    (sorted_obs[0] - adj_low).max(adj_high - sorted_obs[0])
+                } else if j == 0 {
                     sorted_obs[1] - sorted_obs[0]
                 } else if j == m - 1 {
                     sorted_obs[m - 1] - sorted_obs[m - 2]
@@ -237,6 +245,8 @@ impl NumericalDistributionBuilder for DefaultNumericalDistributionBuilder {
                     (sorted_obs[j] - sorted_obs[j - 1]).max(sorted_obs[j + 1] - sorted_obs[j])
                 };
             }
+            // Sigma for prior
+            sigmas.push(adj_high - adj_low);
 
             // Clamp (minsigma, maxsigma)
             let maxsigma = adj_high - adj_low;
@@ -245,9 +255,6 @@ impl NumericalDistributionBuilder for DefaultNumericalDistributionBuilder {
                 *s = s.clamp(minsigma, maxsigma);
             }
         }
-
-        // Sigma for prior
-        sigmas.push(adj_high - adj_low);
 
         match (step_opt, log) {
             (None, false) => {


### PR DESCRIPTION
The sorting process for calculating bandwidth is consuming significant computation time. By distributing observations into bins of width `minsigma`, I have simplified and accelerated this sorting operation.

## Benchmark

- master

```
n_params  n_trials    total [ms]  per trial [us]
      40       500         410.3         820.5
      40      1000        1457.6        1457.6
      40      2000        5691.5        2845.7
```

- PR

```
n_params  n_trials    total [ms]  per trial [us]
      40       500         383.9         767.8
      40      1000        1287.8        1287.8
      40      2000        4898.1        2449.1
```

<details>

```rust
use std::hint::black_box;
use std::time::{Duration, Instant};

use rustuna_core::storage::InMemoryStorage;
use rustuna_core::study::{create_study, Direction};
use rustuna_core::Result;
use rustuna_sampler::tpe::TpeSampler;

const N_TRIALS: [usize; 3] = [500, 1000, 2000];
const N_PARAMS: [usize; 1] = [40];

fn run_study(n_trials: usize, n_params: usize) -> Result<Duration> {
    let storage = InMemoryStorage::new();
    let study = create_study(
        "tpe-benchmark",
        storage,
        TpeSampler::seed_from_u64(0),
        vec![Direction::Minimize],
    )?;

    let start = Instant::now();
    study.optimize(
        |mut trial| {
            let mut value = 0.0;
            for i in 0..n_params {
                let x = trial.suggest_float(&format!("x{i}"), -10.0, 10.0)?;
                value += x * x;
            }
            Ok(vec![black_box(value)])
        },
        n_trials,
    )?;
    Ok(start.elapsed())
}

fn main() -> Result<()> {
    println!(
        "{:>8}  {:>8}  {:>12}  {:>12}",
        "n_params", "n_trials", "total [ms]", "per trial [us]"
    );
    for n_params in N_PARAMS {
        for n_trials in N_TRIALS {
            let duration = run_study(n_trials, n_params)?;
            println!(
                "{:>8}  {:>8}  {:>12.1}  {:>12.1}",
                n_params,
                n_trials,
                duration.as_secs_f64() * 1e3,
                duration.as_secs_f64() * 1e6 / n_trials as f64,
            );
        }
    }
    Ok(())
}
```

</details>