### PR TITLE
add constraints for nsgaii sampler

### DIFF
--- a/rustuna_core/src/study.rs
+++ b/rustuna_core/src/study.rs
@@ -563,35 +563,44 @@ pub fn get_pareto_front(study: &Study) -> Result<Vec<u32>> {
 
     // TODO(HideakiImamura): Use Vec::with_capacity() to reduce the number of memory allocations.
     let mut pareto_front_numbers = vec![];
-    trials.iter().for_each(|trial| {
+    trials.iter().try_for_each(|trial| {
         let mut dominated = false;
-        let trial_values = match trial.state_values {
-            TrialStateValues::Complete(ref v) => v,
-            _ => panic!("Unexpected state"),
+        let TrialStateValues::Complete(ref trial_values) = trial.state_values else {
+            return Ok(());
         };
         for other in trials.iter() {
-            let other_values = match other.state_values {
-                TrialStateValues::Complete(ref v) => v,
-                _ => panic!("Unexpected state"),
+            let TrialStateValues::Complete(ref other_values) = other.state_values else {
+                continue;
             };
-            if dominates(other_values, trial_values, &study.directions) {
+            if dominates(other_values, trial_values, &study.directions)? {
                 dominated = true;
                 break;
             }
         }
-
         if !dominated {
             pareto_front_numbers.push(trial.number);
         }
-    });
+        Ok(())
+    })?;
 
     Ok(pareto_front_numbers)
 }
 
 /// Returns whether `values0` dominates `values1` under the given directions.
-pub fn dominates(values0: &[f64], values1: &[f64], directions: &[Direction]) -> bool {
-    assert_eq!(values0.len(), values1.len());
-    assert_eq!(values0.len(), directions.len());
+/// Returns an error if `values0` or `values1` contains `f64::NAN`.
+pub fn dominates(values0: &[f64], values1: &[f64], directions: &[Direction]) -> Result<bool> {
+    if values0.len() != values1.len() || values0.len() != directions.len() {
+        return Err(Error::with_reason(
+            ErrorKind::Unexpected,
+            "The length of values0, values1 and directions are different.".to_string(),
+        ));
+    }
+    if values0.iter().any(|x| x.is_nan()) || values1.iter().any(|x| x.is_nan()) {
+        return Err(Error::with_reason(
+            ErrorKind::Unexpected,
+            "values0, values1 should not contain f64::NAN.".to_string(),
+        ));
+    }
 
     let mut equal = true;
     for ((v0, v1), d) in values0.iter().zip(values1).zip(directions) {
@@ -603,10 +612,10 @@ pub fn dominates(values0: &[f64], values1: &[f64], directions: &[Direction]) -> 
             Direction::Maximize => *v0 < *v1,
         };
         if v1_dominate_v0 {
-            return false; // Early return
+            return Ok(false); // Early return
         }
     }
-    !equal
+    Ok(!equal)
 }
 
 #[cfg(test)]
@@ -807,10 +816,12 @@ mod tests {
     #[test]
     fn test_dominates() {
         let directions = vec![Direction::Minimize, Direction::Maximize];
-        assert!(dominates(&[1.0, 2.0], &[2.0, 1.0], &directions));
-        assert!(!dominates(&[2.0, 1.0], &[1.0, 2.0], &directions));
-        assert!(!dominates(&[1.0, 2.0], &[1.0, 2.0], &directions));
-        assert!(!dominates(&[2.0, 1.0], &[2.0, 1.0], &directions));
+        assert!(dominates(&[1.0, 2.0], &[2.0, 1.0], &directions).unwrap());
+        assert!(!dominates(&[2.0, 1.0], &[1.0, 2.0], &directions).unwrap());
+        assert!(!dominates(&[1.0, 2.0], &[1.0, 2.0], &directions).unwrap());
+        assert!(!dominates(&[2.0, 1.0], &[2.0, 1.0], &directions).unwrap());
+        assert!(dominates(&[1.0], &[2.0, 1.0], &directions).is_err());
+        assert!(dominates(&[f64::NAN, 1.0], &[2.0, 1.0], &directions).is_err());
     }
 
     #[test]

--- a/rustuna_core/src/study.rs
+++ b/rustuna_core/src/study.rs
@@ -5,7 +5,7 @@ use crate::attr::{extract_fixed_params, fixed_params_to_attrs, AttrKey, Attrs, C
 use crate::distribution::Distribution;
 use crate::sampler::{Context as SamplerContext, Sampler};
 use crate::storage::Storage;
-use crate::trial::{PersistedTrial, Trial, TrialStateValues};
+use crate::trial::{validate_trials, PersistedTrial, Trial, TrialStateValues};
 use crate::trial_queue::{InMemoryTrialQueue, TrialQueue};
 use crate::{Error, ErrorKind, Result};
 
@@ -561,6 +561,8 @@ pub fn get_pareto_front(study: &Study) -> Result<Vec<u32>> {
         .filter(|t| matches!(t.state_values, TrialStateValues::Complete(ref _v)))
         .collect::<Vec<_>>();
 
+    validate_trials(&trials, &study.directions)?;
+
     // TODO(HideakiImamura): Use Vec::with_capacity() to reduce the number of memory allocations.
     let mut pareto_front_numbers = vec![];
     trials.iter().try_for_each(|trial| {
@@ -572,7 +574,7 @@ pub fn get_pareto_front(study: &Study) -> Result<Vec<u32>> {
             let TrialStateValues::Complete(ref other_values) = other.state_values else {
                 continue;
             };
-            if dominates(other_values, trial_values, &study.directions)? {
+            if dominates(other_values, trial_values, &study.directions) {
                 dominated = true;
                 break;
             }
@@ -587,20 +589,13 @@ pub fn get_pareto_front(study: &Study) -> Result<Vec<u32>> {
 }
 
 /// Returns whether `values0` dominates `values1` under the given directions.
-/// Returns an error if `values0` or `values1` contains `f64::NAN`.
-pub fn dominates(values0: &[f64], values1: &[f64], directions: &[Direction]) -> Result<bool> {
-    if values0.len() != values1.len() || values0.len() != directions.len() {
-        return Err(Error::with_reason(
-            ErrorKind::Unexpected,
-            "The length of values0, values1 and directions are different.".to_string(),
-        ));
-    }
-    if values0.iter().any(|x| x.is_nan()) || values1.iter().any(|x| x.is_nan()) {
-        return Err(Error::with_reason(
-            ErrorKind::Unexpected,
-            "values0, values1 should not contain f64::NAN.".to_string(),
-        ));
-    }
+/// Validate `values0` and `values1` have the same length and neither of them contains f64::NAN
+/// by `rustuna_core::trial::validate_trials` before calling this function.
+pub fn dominates(values0: &[f64], values1: &[f64], directions: &[Direction]) -> bool {
+    debug_assert_eq!(values0.len(), values1.len());
+    debug_assert_eq!(values0.len(), directions.len());
+    debug_assert!(values0.iter().all(|x| !x.is_nan()));
+    debug_assert!(values1.iter().all(|x| !x.is_nan()));
 
     let mut equal = true;
     for ((v0, v1), d) in values0.iter().zip(values1).zip(directions) {
@@ -612,10 +607,10 @@ pub fn dominates(values0: &[f64], values1: &[f64], directions: &[Direction]) -> 
             Direction::Maximize => *v0 < *v1,
         };
         if v1_dominate_v0 {
-            return Ok(false); // Early return
+            return false; // Early return
         }
     }
-    Ok(!equal)
+    !equal
 }
 
 #[cfg(test)]
@@ -816,12 +811,10 @@ mod tests {
     #[test]
     fn test_dominates() {
         let directions = vec![Direction::Minimize, Direction::Maximize];
-        assert!(dominates(&[1.0, 2.0], &[2.0, 1.0], &directions).unwrap());
-        assert!(!dominates(&[2.0, 1.0], &[1.0, 2.0], &directions).unwrap());
-        assert!(!dominates(&[1.0, 2.0], &[1.0, 2.0], &directions).unwrap());
-        assert!(!dominates(&[2.0, 1.0], &[2.0, 1.0], &directions).unwrap());
-        assert!(dominates(&[1.0], &[2.0, 1.0], &directions).is_err());
-        assert!(dominates(&[f64::NAN, 1.0], &[2.0, 1.0], &directions).is_err());
+        assert!(dominates(&[1.0, 2.0], &[2.0, 1.0], &directions));
+        assert!(!dominates(&[2.0, 1.0], &[1.0, 2.0], &directions));
+        assert!(!dominates(&[1.0, 2.0], &[1.0, 2.0], &directions));
+        assert!(!dominates(&[2.0, 1.0], &[2.0, 1.0], &directions));
     }
 
     #[test]

--- a/rustuna_core/src/trial.rs
+++ b/rustuna_core/src/trial.rs
@@ -465,6 +465,46 @@ impl TrialStateValues {
     }
 }
 
+/// validate `trials` as follows.
+/// 1. each completed trial's values has the same size.
+/// 2. each completed trial's values has the same size as directions.
+/// 3. each completed trial's values does not contain f64::NAN.
+pub fn validate_trials(trials: &Vec<&PersistedTrial>, directions: &[Direction]) -> Result<()> {
+    let first_completed_trial_values = trials.iter().find_map(|t| match &t.state_values {
+        TrialStateValues::Complete(v) => Some(v),
+        _ => None,
+    });
+    let Some(first_completed_trial_values) = first_completed_trial_values else {
+        return Ok(());
+    };
+    let values_size = first_completed_trial_values.len();
+
+    if trials.iter().any(|t| match &t.state_values {
+        TrialStateValues::Complete(values) => values.len() != values_size,
+        _ => false,
+    }) {
+        Err(Error::with_reason(
+            ErrorKind::Unexpected,
+            "Some completed trials' values have different sizes.".to_string(),
+        ))
+    } else if values_size != directions.len() {
+        Err(Error::with_reason(
+            ErrorKind::Unexpected,
+            "Some completed trial's values has different size from directions.".to_string(),
+        ))
+    } else if trials.iter().any(|t| match &t.state_values {
+        TrialStateValues::Complete(values) => values.iter().all(|x| x.is_nan()),
+        _ => false,
+    }) {
+        Err(Error::with_reason(
+            ErrorKind::Unexpected,
+            "Some trial's values contain f64::NAN.".to_string(),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rustuna_sampler/src/nsgaii.rs
+++ b/rustuna_sampler/src/nsgaii.rs
@@ -396,7 +396,7 @@ fn constrained_dominates(
 
     let constraints0 = trial0.constraints()?;
     let satisfy_constraints0 = constraints0.values().all(|x| *x <= 0.0);
-    let constraints1 = trial0.constraints()?;
+    let constraints1 = trial1.constraints()?;
     let satisfy_constraints1 = constraints1.values().all(|x| *x <= 0.0);
 
     if satisfy_constraints0 && satisfy_constraints1 {
@@ -423,9 +423,9 @@ fn fast_non_dominated_sort(
 
     let population_trials = population_numbers
         .iter()
-        .map(|n| {
+        .map(|i| {
             trials
-                .get(*n as usize)
+                .get(*i as usize)
                 .and_then(|trial| trial.as_ref())
                 .ok_or_else(|| Error::new(ErrorKind::TrialDiscarded))
         })

--- a/rustuna_sampler/src/nsgaii.rs
+++ b/rustuna_sampler/src/nsgaii.rs
@@ -7,7 +7,6 @@ use rustuna_core::attr::{AttrKey, Attrs};
 use rustuna_core::distribution::Distribution;
 use rustuna_core::sampler::{Context, Sampler};
 use rustuna_core::storage::Storage;
-use rustuna_core::study::dominates;
 use rustuna_core::study::Direction;
 use rustuna_core::trial::{PersistedTrial, TrialStateValues};
 use rustuna_core::Result;
@@ -400,7 +399,14 @@ fn constrained_dominates(
     let satisfy_constraints1 = constraints1.values().all(|x| *x <= 0.0);
 
     if satisfy_constraints0 && satisfy_constraints1 {
-        return Ok(dominates(values0, values1, directions));
+        return Ok(values0
+            .iter()
+            .zip(values1)
+            .zip(directions)
+            .all(|((v0, v1), d)| match d {
+                Direction::Minimize => *v0 < *v1,
+                Direction::Maximize => *v0 > *v1,
+            }));
     }
     if satisfy_constraints0 {
         return Ok(true);

--- a/rustuna_sampler/src/nsgaii.rs
+++ b/rustuna_sampler/src/nsgaii.rs
@@ -679,4 +679,34 @@ mod tests {
             "Optimization with constraints should complete without panicking"
         );
     }
+
+    #[test]
+    fn test_uncompleted_trial() -> Result<()> {
+        let storage = InMemoryStorage::new();
+        let directions = vec![Direction::Minimize, Direction::Minimize];
+        let study = create_study(
+            "uncompleted_trial",
+            storage,
+            NSGAIISampler::new(2, None, 1.0, 1.0),
+            directions,
+        )
+        .unwrap();
+
+        let n_trials = 50;
+        for _ in 0..n_trials {
+            let mut trial = study.ask()?;
+            let x = trial.suggest_int("x", 1, 2)?;
+            let y = trial.suggest_int("y", 1, 2)?;
+            let v0 = (x as f64 - 1.5).powi(2);
+            let v1 = (y as f64 - 1.5).powi(2);
+            if x == 1 {
+                study.tell(trial.number, TrialStateValues::Complete(vec![v0, v1]))?;
+            } else {
+                study.tell(trial.number, TrialStateValues::Fail)?;
+            }
+        }
+
+        assert!(study.get_trials()?.len() == n_trials);
+        Ok(())
+    }
 }

--- a/rustuna_sampler/src/nsgaii.rs
+++ b/rustuna_sampler/src/nsgaii.rs
@@ -8,6 +8,7 @@ use rustuna_core::distribution::Distribution;
 use rustuna_core::sampler::{Context, Sampler};
 use rustuna_core::storage::Storage;
 use rustuna_core::study::dominates;
+use rustuna_core::study::Direction;
 use rustuna_core::trial::{PersistedTrial, TrialStateValues};
 use rustuna_core::Result;
 use rustuna_core::{Error, ErrorKind};
@@ -370,23 +371,63 @@ impl Sampler for NSGAIISampler {
     }
 }
 
+/// Return whether `trial0` constrained-dominates `trial1`.
+///
+/// A trial x is said to constrained-dominate a trial y, if any of the following conditions is
+/// true:
+/// 1) Trial x is feasible and trial y is not.
+/// 2) Trial x and y are both infeasible, but solution x has a smaller overall constraint
+///    violation.
+/// 3) Trial x and y are feasible and trial x dominates trial y.
+///
+fn constrained_dominates(
+    trial0: &PersistedTrial,
+    trial1: &PersistedTrial,
+    directions: &[Direction],
+) -> Result<bool> {
+    let values0 = match &trial0.state_values {
+        TrialStateValues::Complete(values) => values,
+        _ => return Ok(false),
+    };
+    let values1 = match &trial1.state_values {
+        TrialStateValues::Complete(values) => values,
+        _ => return Ok(true),
+    };
+
+    let constraints0 = trial0.constraints()?;
+    let satisfy_constraints0 = constraints0.values().all(|x| *x <= 0.0);
+    let constraints1 = trial0.constraints()?;
+    let satisfy_constraints1 = constraints1.values().all(|x| *x <= 0.0);
+
+    if satisfy_constraints0 && satisfy_constraints1 {
+        return Ok(dominates(values0, values1, directions));
+    }
+    if satisfy_constraints0 {
+        return Ok(true);
+    }
+    if satisfy_constraints1 {
+        return Ok(false);
+    }
+
+    let violation0: f64 = constraints0.values().filter(|&x| *x > 0.0).sum();
+    let violation1: f64 = constraints1.values().filter(|&x| *x > 0.0).sum();
+    Ok(violation0 < violation1)
+}
+
 fn fast_non_dominated_sort(
     ctx: &Context,
     trials: &[Option<PersistedTrial>],
     population_numbers: &[u32],
 ) -> Result<Vec<Vec<u32>>> {
     let n = population_numbers.len();
-    let population_values = population_numbers
+
+    let population_trials = population_numbers
         .iter()
         .map(|n| {
-            let trial = trials
+            trials
                 .get(*n as usize)
                 .and_then(|trial| trial.as_ref())
-                .ok_or_else(|| Error::new(ErrorKind::TrialDiscarded))?;
-            match &trial.state_values {
-                TrialStateValues::Complete(values) => Ok(values.clone()),
-                _ => Ok(vec![f64::NAN; ctx.directions.len()]),
-            }
+                .ok_or_else(|| Error::new(ErrorKind::TrialDiscarded))
         })
         .collect::<Result<Vec<_>>>()?;
 
@@ -398,18 +439,14 @@ fn fast_non_dominated_sort(
             if i >= j {
                 continue;
             }
-            if dominates(
-                &population_values[i],
-                &population_values[j],
-                &ctx.directions,
-            ) {
+            if constrained_dominates(population_trials[i], population_trials[j], &ctx.directions)? {
                 dominates_list[i].push(j);
                 dominated_count[j] += 1;
-            } else if dominates(
-                &population_values[j],
-                &population_values[i],
+            } else if constrained_dominates(
+                population_trials[j],
+                population_trials[i],
                 &ctx.directions,
-            ) {
+            )? {
                 dominates_list[j].push(i);
                 dominated_count[i] += 1;
             }
@@ -612,5 +649,34 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_constraints() {
+        let storage = InMemoryStorage::new();
+        let directions = vec![Direction::Minimize, Direction::Minimize];
+        let study = create_study(
+            "constraints",
+            storage,
+            NSGAIISampler::new(2, None, 1.0, 1.0),
+            directions,
+        )
+        .unwrap();
+        let n_trials = 10;
+        let result = study.optimize(
+            |mut t| {
+                let x = t.suggest_float("x", -15.0, 30.0)?;
+                let y = t.suggest_float("y", -15.0, 30.0)?;
+                let v0 = 4.0 * x.powi(2) + 4.0 * y.powi(2);
+                let v1 = (x - 5.0).powi(2) + (y - 5.0).powi(2);
+                t.set_constraints(HashMap::from([(String::from("c0"), 1000.0 - v0)]))?;
+                Ok(vec![v0, v1])
+            },
+            n_trials,
+        );
+        assert!(
+            result.is_ok(),
+            "Optimization with constraints should complete without panicking"
+        );
     }
 }

--- a/rustuna_sampler/src/nsgaii.rs
+++ b/rustuna_sampler/src/nsgaii.rs
@@ -7,6 +7,7 @@ use rustuna_core::attr::{AttrKey, Attrs};
 use rustuna_core::distribution::Distribution;
 use rustuna_core::sampler::{Context, Sampler};
 use rustuna_core::storage::Storage;
+use rustuna_core::study::dominates;
 use rustuna_core::study::Direction;
 use rustuna_core::trial::{PersistedTrial, TrialStateValues};
 use rustuna_core::Result;
@@ -399,14 +400,7 @@ fn constrained_dominates(
     let satisfy_constraints1 = constraints1.values().all(|x| *x <= 0.0);
 
     if satisfy_constraints0 && satisfy_constraints1 {
-        return Ok(values0
-            .iter()
-            .zip(values1)
-            .zip(directions)
-            .all(|((v0, v1), d)| match d {
-                Direction::Minimize => *v0 < *v1,
-                Direction::Maximize => *v0 > *v1,
-            }));
+        return dominates(values0, values1, directions);
     }
     if satisfy_constraints0 {
         return Ok(true);

--- a/rustuna_sampler/src/nsgaii.rs
+++ b/rustuna_sampler/src/nsgaii.rs
@@ -9,6 +9,7 @@ use rustuna_core::sampler::{Context, Sampler};
 use rustuna_core::storage::Storage;
 use rustuna_core::study::dominates;
 use rustuna_core::study::Direction;
+use rustuna_core::trial::validate_trials;
 use rustuna_core::trial::{PersistedTrial, TrialStateValues};
 use rustuna_core::Result;
 use rustuna_core::{Error, ErrorKind};
@@ -381,26 +382,26 @@ impl Sampler for NSGAIISampler {
 /// 3) Trial x and y are feasible and trial x dominates trial y.
 ///
 fn constrained_dominates(
-    (values0, constraints0): &(&Vec<f64>, HashMap<String, f64>),
-    (values1, constraints1): &(&Vec<f64>, HashMap<String, f64>),
+    values_feasible_violation_0: &Option<(&[f64], bool, f64)>,
+    values_feasible_violation_1: &Option<(&[f64], bool, f64)>,
     directions: &[Direction],
-) -> Result<bool> {
-    let satisfy_constraints0 = constraints0.values().all(|x| *x <= 0.0);
-    let satisfy_constraints1 = constraints1.values().all(|x| *x <= 0.0);
+) -> bool {
+    let Some((values0, feasible0, violation0)) = values_feasible_violation_0 else {
+        return false;
+    };
+    let Some((values1, feasible1, violation1)) = values_feasible_violation_1 else {
+        return true;
+    };
 
-    if satisfy_constraints0 && satisfy_constraints1 {
-        return dominates(values0, values1, directions);
+    if *feasible0 && *feasible1 {
+        dominates(values0, values1, directions)
+    } else if *feasible0 {
+        true
+    } else if *feasible1 {
+        false
+    } else {
+        *violation0 < *violation1
     }
-    if satisfy_constraints0 {
-        return Ok(true);
-    }
-    if satisfy_constraints1 {
-        return Ok(false);
-    }
-
-    let violation0: f64 = constraints0.values().filter(|&x| *x > 0.0).sum();
-    let violation1: f64 = constraints1.values().filter(|&x| *x > 0.0).sum();
-    Ok(violation0 < violation1)
 }
 
 fn fast_non_dominated_sort(
@@ -410,26 +411,28 @@ fn fast_non_dominated_sort(
 ) -> Result<Vec<Vec<u32>>> {
     let n = population_numbers.len();
 
-    let worst_values: Vec<f64> = ctx
-        .directions
-        .iter()
-        .map(|d| match d {
-            Direction::Minimize => f64::MAX,
-            Direction::Maximize => f64::MIN,
-        })
-        .collect();
-    let worst_constraints = HashMap::from([(String::from(""), 1.0)]); // 1.0 is positive value so infeasible
-    let population_values_constraints = population_numbers
+    let population_trials = population_numbers
         .iter()
         .map(|i| {
-            let trial = trials
+            trials
                 .get(*i as usize)
                 .and_then(|trial| trial.as_ref())
-                .ok_or_else(|| Error::new(ErrorKind::TrialDiscarded))?;
-            match &trial.state_values {
-                TrialStateValues::Complete(values) => Ok((values, trial.constraints()?)),
-                _ => Ok((&worst_values, worst_constraints.clone())),
+                .ok_or_else(|| Error::new(ErrorKind::TrialDiscarded))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    validate_trials(&population_trials, &ctx.directions)?;
+
+    let population_infos = population_trials
+        .iter()
+        .map(|t| match &t.state_values {
+            TrialStateValues::Complete(values) => {
+                let constraints = t.constraints()?;
+                let is_feasible = constraints.values().all(|x| *x <= 0.0);
+                let violation = constraints.values().filter(|&x| *x > 0.0).sum();
+                Ok(Some((values.as_slice(), is_feasible, violation)))
             }
+            _ => Ok(None),
         })
         .collect::<Result<Vec<_>>>()?;
 
@@ -441,18 +444,14 @@ fn fast_non_dominated_sort(
             if i >= j {
                 continue;
             }
-            if constrained_dominates(
-                &population_values_constraints[i],
-                &population_values_constraints[j],
-                &ctx.directions,
-            )? {
+            if constrained_dominates(&population_infos[i], &population_infos[j], &ctx.directions) {
                 dominates_list[i].push(j);
                 dominated_count[j] += 1;
             } else if constrained_dominates(
-                &population_values_constraints[j],
-                &population_values_constraints[i],
+                &population_infos[j],
+                &population_infos[i],
                 &ctx.directions,
-            )? {
+            ) {
                 dominates_list[j].push(i);
                 dominated_count[i] += 1;
             }

--- a/rustuna_sampler/src/nsgaii.rs
+++ b/rustuna_sampler/src/nsgaii.rs
@@ -381,22 +381,11 @@ impl Sampler for NSGAIISampler {
 /// 3) Trial x and y are feasible and trial x dominates trial y.
 ///
 fn constrained_dominates(
-    trial0: &PersistedTrial,
-    trial1: &PersistedTrial,
+    (values0, constraints0): &(&Vec<f64>, HashMap<String, f64>),
+    (values1, constraints1): &(&Vec<f64>, HashMap<String, f64>),
     directions: &[Direction],
 ) -> Result<bool> {
-    let values0 = match &trial0.state_values {
-        TrialStateValues::Complete(values) => values,
-        _ => return Ok(false),
-    };
-    let values1 = match &trial1.state_values {
-        TrialStateValues::Complete(values) => values,
-        _ => return Ok(true),
-    };
-
-    let constraints0 = trial0.constraints()?;
     let satisfy_constraints0 = constraints0.values().all(|x| *x <= 0.0);
-    let constraints1 = trial1.constraints()?;
     let satisfy_constraints1 = constraints1.values().all(|x| *x <= 0.0);
 
     if satisfy_constraints0 && satisfy_constraints1 {
@@ -421,13 +410,26 @@ fn fast_non_dominated_sort(
 ) -> Result<Vec<Vec<u32>>> {
     let n = population_numbers.len();
 
-    let population_trials = population_numbers
+    let worst_values: Vec<f64> = ctx
+        .directions
+        .iter()
+        .map(|d| match d {
+            Direction::Minimize => f64::MAX,
+            Direction::Maximize => f64::MIN,
+        })
+        .collect();
+    let worst_constraints = HashMap::from([(String::from(""), 1.0)]); // 1.0 is positive value so infeasible
+    let population_values_constraints = population_numbers
         .iter()
         .map(|i| {
-            trials
+            let trial = trials
                 .get(*i as usize)
                 .and_then(|trial| trial.as_ref())
-                .ok_or_else(|| Error::new(ErrorKind::TrialDiscarded))
+                .ok_or_else(|| Error::new(ErrorKind::TrialDiscarded))?;
+            match &trial.state_values {
+                TrialStateValues::Complete(values) => Ok((values, trial.constraints()?)),
+                _ => Ok((&worst_values, worst_constraints.clone())),
+            }
         })
         .collect::<Result<Vec<_>>>()?;
 
@@ -439,12 +441,16 @@ fn fast_non_dominated_sort(
             if i >= j {
                 continue;
             }
-            if constrained_dominates(population_trials[i], population_trials[j], &ctx.directions)? {
+            if constrained_dominates(
+                &population_values_constraints[i],
+                &population_values_constraints[j],
+                &ctx.directions,
+            )? {
                 dominates_list[i].push(j);
                 dominated_count[j] += 1;
             } else if constrained_dominates(
-                population_trials[j],
-                population_trials[i],
+                &population_values_constraints[j],
+                &population_values_constraints[i],
                 &ctx.directions,
             )? {
                 dominates_list[j].push(i);


### PR DESCRIPTION
I  added the constrained NSGA-II sampler, described in [NSGA-II](https://ieeexplore.ieee.org/document/996017).
I checked the performance by the toy problem in https://github.com/optuna/optuna/pull/3506#issuecomment-1108464315

<details>
<summary>
benchmark code
</summary>

```python
import optuna

import matplotlib.pyplot as plt
import numpy as np
from matplotlib.figure import Figure
from optuna.visualization._hypervolume_history import (
    _get_hypervolume_history_info,
    _HypervolumeHistoryInfo,
)

import optuna.visualization.matplotlib
from optuna.visualization._pareto_front import _ParetoFrontInfo
from optuna.visualization.matplotlib import plot_pareto_front

n_trials = 500
n_repeat = 30
optuna_storage = optuna.storages.InMemoryStorage()

def _get_pareto_front_2d_patched(
    info: _ParetoFrontInfo,
    xlim: tuple[float | None, float | None] | None = None,
    ylim: tuple[float | None, float | None] | None = None
) -> Figure:
    fig, ax = plt.subplots()

    ax.set_xlabel(
        info.target_names[info.axis_order[0]], fontsize=13, fontproperties=None
    )
    ax.set_ylabel(
        info.target_names[info.axis_order[1]], fontsize=13, fontproperties=None
    )

    if len(info.infeasible_trials_with_values) > 0:
        ax.scatter(
            x=[values[info.axis_order[0]] for _, values in info.infeasible_trials_with_values],
            y=[values[info.axis_order[1]] for _, values in info.infeasible_trials_with_values],
            color="#2B2B2B",
            facecolors="#6E6E6E",
            alpha=0.7,
            label="Infeasible Trial",
        )
    if len(info.non_best_trials_with_values) > 0:
        ax.scatter(
            x=[values[info.axis_order[0]] for _, values in info.non_best_trials_with_values],
            y=[values[info.axis_order[1]] for _, values in info.non_best_trials_with_values],
            color="#963269",
            facecolors="#CC79A7",
            alpha=0.7,
            label="Feasible Trial",
        )
    if len(info.best_trials_with_values) > 0:
        ax.scatter(
            x=[values[info.axis_order[0]] for _, values in info.best_trials_with_values],
            y=[values[info.axis_order[1]] for _, values in info.best_trials_with_values],
            color="#1348AC",
            facecolors="#0072B2",
            alpha=0.7,
            label="Best Trial",
        )

    if info.non_best_trials_with_values is not None and ax.has_data():
        ax.legend(
            handlelength=0.8,
            handletextpad=0.4
        )

    ax.grid(which="major", color="gray", linestyle="--", linewidth=0.5)
    ax.tick_params(labelsize=12)

    if xlim is not None:
        ax.set_xlim(*xlim)
    if ylim is not None:
        ax.set_ylim(*ylim)

    return fig

def plot_results(
    data: dict[str, list[_HypervolumeHistoryInfo]],
    names: dict[str, str],
    colors: dict[str, str],
    markers: dict[str, str],
    marker_sizes: dict[str, float],
    legend_order: list[str],
    ylabel: str,
    trial_min: int | None = None,
    xlim: tuple[float, float] | None = None,
    ylim: tuple[float, float] | None = None,
    figsize: tuple[float, float] | None = None,
) -> Figure:
    fig, ax = plt.subplots(figsize=figsize)
    lines = {}
    names_list = {}
    for name, d in data.items():
        values = np.array([info.values for info in d])
        mean = np.mean(values, axis=0)
        std = np.std(values, axis=0) / np.sqrt(values.shape[0])
        dx = d[0].trial_numbers
        (line,) = ax.plot(
            dx[trial_min:],
            mean[trial_min:],
            colors[name],
            label=names[name],
            marker=markers[name],
            markersize=marker_sizes[name] * 1.2,
            markevery=8,
        )
        lines[name] = line
        names_list[name] = names[name]
        ax.fill_between(
            dx[trial_min:],
            (mean - std)[trial_min:],
            (mean + std)[trial_min:],
            alpha=0.2,
            color=colors[name],
        )
    ax.legend(
        handles=[lines[name] for name in legend_order],
        labels=[names_list[name] for name in legend_order],
        loc="lower right",
        fontsize=12,
        prop=None,
    )
    ax.set_xlabel("Number of Trials", fontsize=13, fontproperties=None)
    ax.set_ylabel(ylabel, fontsize=13, fontproperties=None)

    ax.grid(which="major", color="gray", linestyle="--", linewidth=0.5)
    ax.tick_params(labelsize=12)

    if xlim is not None:
        ax.set_xlim(*xlim)
    if ylim is not None:
        ax.set_ylim(*ylim)
    return fig


def objective(trial: optuna.Trial) -> float:
    x = trial.suggest_float("x", -15, 30)
    y = trial.suggest_float("y", -15, 30)

    v0 = 4 * x**2 + 4 * y**2
    v1 = (x - 5) ** 2 + (y - 5) ** 2
    trial.set_constraint("c0", 1000 - v0)
    return v0, v1



def objective_without_constraints(trial: optuna.Trial) -> float:
    x = trial.suggest_float("x", -15, 30)
    y = trial.suggest_float("y", -15, 30)

    v0 = 4 * x**2 + 4 * y**2
    v1 = (x - 5) ** 2 + (y - 5) ** 2
    return v0, v1


def main():
    optuna.visualization.matplotlib._pareto_front._get_pareto_front_2d = (
        lambda info: _get_pareto_front_2d_patched(
            info, xlim=(None, 4000), ylim=(None, 700)
        )
    )


    data = {
        "Rustuna NSGA-II with Constraints": [],
        "Rustuna NSGA-II without Constraints": [],
    }
    reference_point = np.array([7200, 1250], dtype=float)

    # Optuna NSGA-II with Constraints
    for i in range(n_repeat):
        study_name = f"Rustuna-NSGA-II-with-Constraints-with-seed={i}"
        sampler = optuna.samplers.NSGAIISampler(seed=i)
        study = optuna.create_study(
            storage=optuna_storage,
            sampler=sampler,
            study_name=study_name,
            directions=["minimize", "minimize"],
        )
        study.optimize(objective, n_trials=n_trials)
        fig = plot_pareto_front(study)
        fig.savefig(
            f"{study_name}_pareto_front.png",
            bbox_inches="tight",
            dpi=300,
        )
        data["Rustuna NSGA-II with Constraints"].append(
            _get_hypervolume_history_info(study, reference_point),
        )

    # Optuna NSGA-II without Constraints
    for i in range(n_repeat):
        study_name = f"Rustuna-NSGA-II-without-Constraints-with-seed={i}"
        sampler = optuna.samplers.NSGAIISampler(seed=i)
        temp_study = optuna.create_study(
            sampler=sampler,
            study_name=study_name,
            directions=["minimize", "minimize"],
        )
        temp_study.optimize(objective_without_constraints, n_trials=n_trials)

        study = optuna.create_study(
            storage=optuna_storage,
            study_name=study_name,
            directions=["minimize", "minimize"],
        )
        for trial in temp_study.trials:
            assert len(trial.constraints) == 0

            x = trial.params["x"]
            y = trial.params["y"]
            v0 = 4 * x ** 2 + 4 * y ** 2
            v1 = (x - 5) ** 2 + (y - 5) ** 2
            trial.set_constraint("c0", 1000 - v0)

            assert len(trial.constraints) > 0
            study.add_trial(trial)
        fig = plot_pareto_front(study)
        fig.savefig(
            f"{study_name}_pareto_front.png",
            bbox_inches="tight",
            dpi=300,
        )
        data["Rustuna NSGA-II without Constraints"].append(
            _get_hypervolume_history_info(study, reference_point),
        )

    sampler_names = {k: k for k in data}
    legend_order = list(sampler_names.keys())
    colors = {name: ["#0072B2", "#CC79A7", "#E69F00"][i] for i, name in enumerate(sampler_names)}
    markers = {name: ["*", "o", "D"][i] for i, name in enumerate(sampler_names)}
    marker_sizes = {name: [8.0, 5.1, 4.2][i] for i, name in enumerate(sampler_names)}
    fig = plot_results(
        data,
        names=sampler_names,
        colors=colors,
        markers=markers,
        marker_sizes=marker_sizes,
        legend_order=legend_order,
        ylabel="Hypervolume",
        xlim=(6, n_trials + 4),
        ylim=(6950000, 7250000),
        trial_min=10,
        figsize=(7.5, 4),
    )
    fig.savefig(
        f"hyper_volume.png",
        bbox_inches="tight",
        dpi=300,
    )


if __name__ == "__main__":
    main()
```

</details>


I checked the performance by parate fronts.

+ Without constraints:
<img width="1808" height="1337" alt="Rustuna-NSGA-II-without-Constraints-with-seed=0_pareto_front" src="https://github.com/user-attachments/assets/8e6f2ec4-d064-4a1e-b626-4f0f88f11d30" />

+ With constraints:
<img width="1808" height="1337" alt="Rustuna-NSGA-II-with-Constraints-with-seed=0_pareto_front" src="https://github.com/user-attachments/assets/9a019c89-3e0c-48be-8c2d-5d323b5caa88" />

The result with constraints explores feasible regions, compared to that without constraints.
Also, the performance is similar to NSGA-II results in https://github.com/optuna/optuna/pull/3506#issuecomment-1108464315.

I also checked the hypervolume.

<img width="2049" height="1178" alt="hyper_volume" src="https://github.com/user-attachments/assets/a6e58831-7d3b-496d-86bf-1ace6bd581d3" />

The hypervolume history with constraints are better than that without constraints.

