### PR TITLE
Fix attribute conversion between Rustuna and Optuna through `ToOptunaStudy`.

### DIFF
--- a/rustuna_core/src/trial.rs
+++ b/rustuna_core/src/trial.rs
@@ -9,6 +9,7 @@ use crate::study::Direction;
 use crate::{Error, ErrorKind, Result};
 
 const CONSTRAINTS_KEY: &str = "constraints";
+const CONSTRAINTS_PREFIX: &str = "constraints:";
 
 /// A trial object used while evaluating an objective function.
 ///
@@ -406,8 +407,8 @@ impl PersistedTrial {
         let mut constraints_dict: HashMap<String, f64> = HashMap::new();
         for (key, value) in &self.attrs {
             if let AttrKey::System(key_system) = key {
-                if key_system.as_str().starts_with(CONSTRAINTS_KEY) {
-                    let key: String = key_system.as_str()[CONSTRAINTS_KEY.len() + 1..].into();
+                if let Some(key) = key_system.as_str().strip_prefix(CONSTRAINTS_PREFIX) {
+                    let key: String = key.into();
                     let value: f64 = value.parse::<f64>().map_err(|e| {
                         Error::with_reason(
                             ErrorKind::Unexpected,

--- a/rustuna_pyo3/rustuna/converter/_attrs.py
+++ b/rustuna_pyo3/rustuna/converter/_attrs.py
@@ -3,28 +3,38 @@ from __future__ import annotations
 import json
 from typing import Any
 
-# Optuna exposes attrs as `dict[str, Any]`, while Rustuna stores them as `dict[str, str]`, so this
-# converter reserves the below prefix for Optuna-facing attrs and stores their values as JSON.
-# Prefixed keys are round-tripped through the compatibility layer, while non-prefixed keys remain
-# Rustuna-internal attrs and are not exposed as Optuna attrs.
-_OPTUNA_ATTR_PREFIX = "optuna_attr:"
+# Optuna exposes attrs as `dict[str, Any]`, while Rustuna stores them as
+# `dict[str, str]`. String values are stored under their original keys so that
+# Rustuna-native and Optuna-originated string attrs have the same representation.
+# Non-string Optuna values are JSON-encoded under their original keys and are
+# accompanied by a marker key. The marker lets `to_optuna_attrs` restore the
+# original type without attempting to JSON-decode ordinary Rustuna strings.
+#
+# The marker key is an implementation detail and is omitted when converting
+# attrs back to Optuna. Rustuna may also store internal system attrs, such as
+# categorical labels; callers exposing attrs through Optuna are responsible for
+# filtering those Rustuna-specific attributes when necessary.
+_PREFIX_REQUIRE_JSON_ENCODE = "optuna_json_encoded:"
 
 
-def to_optuna_attrs(
-    attrs: dict[str, str],
-) -> dict[str, Any]:
-    return {
-        k[len(_OPTUNA_ATTR_PREFIX) :]: json.loads(v)
-        for k, v in attrs.items()
-        if k.startswith(_OPTUNA_ATTR_PREFIX)
-    }
+def to_optuna_attrs(attrs: dict[str, str]) -> dict[str, Any]:
+    converted = {}
+    for key, value in attrs.items():
+        if key.startswith(_PREFIX_REQUIRE_JSON_ENCODE):
+            continue
+        if _PREFIX_REQUIRE_JSON_ENCODE + key in attrs:
+            converted[key] = json.loads(value)
+        else:
+            converted[key] = value
+    return converted
 
 
-def to_rustuna_attrs(
-    attrs: dict[str, Any],
-) -> dict[str, str]:
-    return {
-        _OPTUNA_ATTR_PREFIX + k: json.dumps(v)
-        for k, v in attrs.items()
-        if not k.startswith(_OPTUNA_ATTR_PREFIX)
-    }
+def to_rustuna_attrs(attrs: dict[str, Any]) -> dict[str, str]:
+    converted = {}
+    for key, value in attrs.items():
+        if isinstance(value, str):
+            converted[key] = value
+            continue
+        converted[key] = json.dumps(value)
+        converted[_PREFIX_REQUIRE_JSON_ENCODE + key] = "true"
+    return converted

--- a/rustuna_pyo3/rustuna/converter/_attrs.py
+++ b/rustuna_pyo3/rustuna/converter/_attrs.py
@@ -17,7 +17,8 @@ from typing import Any
 # categorical labels; callers exposing attrs through Optuna are responsible for
 # filtering those Rustuna-specific attributes when necessary.
 _PREFIX_REQUIRE_JSON_ENCODE = "optuna_json_encoded:"
-_CONSTRAINTS_PREFIX = "constraints:"
+_CONSTRAINTS_KEY = "constraints"
+_CONSTRAINTS_PREFIX = f"{_CONSTRAINTS_KEY}:"
 
 
 def to_optuna_attrs(attrs: dict[str, str]) -> dict[str, Any]:
@@ -27,7 +28,8 @@ def to_optuna_attrs(attrs: dict[str, str]) -> dict[str, Any]:
             continue
         if _PREFIX_REQUIRE_JSON_ENCODE + key in attrs:
             converted[key] = json.loads(value)
-        elif key.startswith(_CONSTRAINTS_PREFIX) and isinstance(value, str):
+        elif key.startswith(_CONSTRAINTS_PREFIX):
+            # Convert Rustuna constraints to Optuna constraints
             converted[key] = float(value)
         else:
             converted[key] = value
@@ -42,4 +44,10 @@ def to_rustuna_attrs(attrs: dict[str, Any]) -> dict[str, str]:
             continue
         converted[key] = json.dumps(value)
         converted[_PREFIX_REQUIRE_JSON_ENCODE + key] = "true"
+
+    # Convert Optuna's legacy constraint to Rustuna constraints
+    if _CONSTRAINTS_KEY in converted:
+        constraints = json.loads(converted.pop(_CONSTRAINTS_KEY))
+        for i, c in enumerate(constraints):
+            converted[_CONSTRAINTS_PREFIX + str(i)] = str(c)
     return converted

--- a/rustuna_pyo3/rustuna/converter/_attrs.py
+++ b/rustuna_pyo3/rustuna/converter/_attrs.py
@@ -9,12 +9,15 @@ from typing import Any
 # Non-string Optuna values are JSON-encoded under their original keys and are
 # accompanied by a marker key. The marker lets `to_optuna_attrs` restore the
 # original type without attempting to JSON-decode ordinary Rustuna strings.
+# Constraint attrs are the exception: Rustuna stores them as strings, while
+# Optuna exposes constraint values as floats.
 #
 # The marker key is an implementation detail and is omitted when converting
 # attrs back to Optuna. Rustuna may also store internal system attrs, such as
 # categorical labels; callers exposing attrs through Optuna are responsible for
 # filtering those Rustuna-specific attributes when necessary.
 _PREFIX_REQUIRE_JSON_ENCODE = "optuna_json_encoded:"
+_CONSTRAINTS_PREFIX = "constraints:"
 
 
 def to_optuna_attrs(attrs: dict[str, str]) -> dict[str, Any]:
@@ -24,6 +27,8 @@ def to_optuna_attrs(attrs: dict[str, str]) -> dict[str, Any]:
             continue
         if _PREFIX_REQUIRE_JSON_ENCODE + key in attrs:
             converted[key] = json.loads(value)
+        elif key.startswith(_CONSTRAINTS_PREFIX) and isinstance(value, str):
+            converted[key] = float(value)
         else:
             converted[key] = value
     return converted

--- a/rustuna_pyo3/rustuna/converter/_study.py
+++ b/rustuna_pyo3/rustuna/converter/_study.py
@@ -8,7 +8,7 @@ from optuna import Study as _OptunaStudy
 
 import rustuna
 
-from ._attrs import _OPTUNA_ATTR_PREFIX, to_optuna_attrs
+from ._attrs import to_optuna_attrs
 from ._storage import ToOptunaStorage
 from ._trial import (
     to_frozen_trial,
@@ -70,12 +70,4 @@ class ToOptunaStudy(_OptunaStudy):
 
     @property
     def user_attrs(self) -> dict[str, Any]:
-        # TODO(c-bata): Align the behavior with FrozenTrialLike.user_attrs.
-        attrs = self._rustuna_study.user_attrs
-        raw_attrs = {
-            key: value
-            for key, value in attrs.items()
-            if not key.startswith(_OPTUNA_ATTR_PREFIX)
-        }
-        raw_attrs.update(to_optuna_attrs(attrs))
-        return raw_attrs
+        return to_optuna_attrs(self._rustuna_study.user_attrs)

--- a/rustuna_pyo3/tests/converter_tests/test_constraints.py
+++ b/rustuna_pyo3/tests/converter_tests/test_constraints.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import optuna
-import pytest
 
 import rustuna
 from rustuna.converter import ToOptunaStudy
@@ -40,3 +39,33 @@ def test_rustuna_constraints_to_optuna() -> None:
 
     frozen_trial = optuna_study.trials[persisted_trial.number]
     assert frozen_trial.constraints == persisted_trial.constraints
+
+
+def test_optuna_constraints_to_rustuna_with_constraints_func() -> None:
+    def objective(trial: optuna.Trial) -> tuple[float, float]:
+        # Binh and Korn function with constraints.
+        x = trial.suggest_float("x", -15, 30)
+        y = trial.suggest_float("y", -15, 30)
+        v0 = 4 * x**2 + 4 * y**2
+        v1 = (x - 5) ** 2 + (y - 5) ** 2
+
+        # Modified constraints function.
+        trial.set_user_attr("constraint", (1000 - v0,))
+        return v0, v1
+
+    def constraints(trial: optuna.trial.FrozenTrial) -> tuple[float]:
+        return trial.user_attrs["constraint"]
+
+    rustuna_study = rustuna.create_study(
+        storage=rustuna.storages.InMemoryStorage(),
+        directions=["minimize", "minimize"],
+    )
+    optuna_study = ToOptunaStudy(rustuna_study)
+    optuna_study.sampler = optuna.samplers.NSGAIISampler(
+        population_size=20,
+        constraints_func=constraints,
+    )
+    optuna_study.optimize(objective, n_trials=50)
+
+    for t in rustuna_study.trials[1:]:
+        assert len(t.constraints) == 1

--- a/rustuna_pyo3/tests/converter_tests/test_constraints.py
+++ b/rustuna_pyo3/tests/converter_tests/test_constraints.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import optuna
+import pytest
+
+import rustuna
+from rustuna.converter import ToOptunaStudy
+
+
+def test_optuna_constraints_to_rustuna() -> None:
+    rustuna_study = rustuna.create_study(
+        storage=rustuna.storages.InMemoryStorage(),
+        directions=["minimize"],
+    )
+    optuna_study = ToOptunaStudy(rustuna_study)
+
+    trial = optuna_study.ask()
+    trial.set_constraint("c0", 0.5)
+    trial.set_constraint("c1", 10.0)
+    frozen_trial = optuna_study.tell(
+        trial, state=optuna.trial.TrialState.COMPLETE, values=1.0
+    )
+
+    persisted_trial = rustuna_study.trials[frozen_trial.number]
+    assert frozen_trial.constraints == persisted_trial.constraints
+
+
+def test_rustuna_constraints_to_optuna() -> None:
+    rustuna_study = rustuna.create_study(
+        storage=rustuna.storages.InMemoryStorage(),
+        directions=["minimize"],
+    )
+    optuna_study = ToOptunaStudy(rustuna_study)
+
+    trial = rustuna_study.ask()
+    trial.set_constraints({"c0": 0.5, "c1": 10.0})
+    persisted_trial = rustuna_study.tell(
+        trial.number, state=rustuna.trial.TrialState.COMPLETE, values=1.0
+    )
+
+    frozen_trial = optuna_study.trials[persisted_trial.number]
+    assert frozen_trial.constraints == persisted_trial.constraints

--- a/rustuna_pyo3/tests/storage_tests/test_to_optuna_storage.py
+++ b/rustuna_pyo3/tests/storage_tests/test_to_optuna_storage.py
@@ -8,7 +8,7 @@ import pytest
 from optuna.distributions import FloatDistribution
 from optuna.exceptions import UpdateFinishedTrialError
 from optuna.study import StudyDirection
-from optuna.testing.pytest_storages import StorageTestCase
+from optuna.testing.pytest_storages import StorageTestCase, _setup_studies
 from optuna.trial._frozen import FrozenTrial
 from optuna.trial._state import TrialState
 from pytest import FixtureRequest
@@ -38,6 +38,29 @@ def storage(request: FixtureRequest) -> Generator[BaseStorage, None, None]:
 
 
 class TestRustunaStorage(StorageTestCase):
+    def test_get_all_studies(self, storage: BaseStorage) -> None:
+        expected_frozen_studies, _ = _setup_studies(
+            storage, n_study=10, n_trial=10, seed=46
+        )
+        frozen_studies = storage.get_all_studies()
+        assert len(frozen_studies) == len(expected_frozen_studies)
+        for _, expected_frozen_study in expected_frozen_studies.items():
+            frozen_study = next(
+                s
+                for s in frozen_studies
+                if s.study_name == expected_frozen_study.study_name
+            )
+            assert frozen_study.direction == expected_frozen_study.direction
+            assert frozen_study.study_name == expected_frozen_study.study_name
+            assert frozen_study.user_attrs == expected_frozen_study.user_attrs
+            # Rustuna stores categorical choices as internal system attributes.
+            system_attrs = {
+                key: value
+                for key, value in frozen_study.system_attrs.items()
+                if not key.startswith("category_labels:")
+            }
+            assert system_attrs == expected_frozen_study.system_attrs
+
     def test_delete_study(self, storage: BaseStorage) -> None:
         study_id = storage.create_new_study(directions=[StudyDirection.MINIMIZE])
         storage.create_new_trial(study_id)


### PR DESCRIPTION
## Changes

- Preserve string attributes under their original keys.
- JSON-encode non-string Optuna attributes in Rustuna storage with a marker key.
- Restore JSON-encoded attributes when converting them back to Optuna.
- Convert Rustuna-native constraint attributes (`constraints:<name>`) back to `float`.

## Motivation

Rustuna stores attributes as `dict[str, str]`, while Optuna allows JSON-compatible values.

The previous converter only handled Optuna-specific prefixed attributes, which caused Rustuna-native attributes to be lost when exposed through Optuna. Rustuna constraints are stored as strings internally, but Optuna expects constraint values to be floats. This change preserves the expected Optuna behavior while keeping Rustuna's storage representation unchanged.