### PR TITLE
[DO NOT MERGE] Release storage lock before TPE model construction

### DIFF
--- a/rustuna_core/src/multi_objective/mod.rs
+++ b/rustuna_core/src/multi_objective/mod.rs
@@ -40,4 +40,4 @@ mod split;
 
 pub use hssp::hypervolume_subset_selection;
 pub use nds::fast_non_dominated_sort_partial;
-pub use split::split_trials_for_multi_objective;
+pub use split::{split_observation_indices_for_multi_objective, split_trials_for_multi_objective};

--- a/rustuna_core/src/multi_objective/split.rs
+++ b/rustuna_core/src/multi_objective/split.rs
@@ -11,7 +11,27 @@ pub fn split_trials_for_multi_objective<'a>(
     directions: &[Direction],
     gamma: usize,
 ) -> (Vec<&'a PersistedTrial>, Vec<&'a PersistedTrial>) {
-    let n = trials.len();
+    let values = trials
+        .iter()
+        .map(|trial| match &trial.state_values {
+            TrialStateValues::Complete(values) => values.as_slice(),
+            _ => panic!("Unexpected non-complete trial found during multi-objective split"),
+        })
+        .collect::<Vec<_>>();
+    let (good_indices, poor_indices) =
+        split_observation_indices_for_multi_objective(&values, directions, gamma);
+    let good_trials = good_indices.into_iter().map(|i| trials[i]).collect();
+    let poor_trials = poor_indices.into_iter().map(|i| trials[i]).collect();
+    (good_trials, poor_trials)
+}
+
+/// Splits objective observations into promising and non-promising index sets.
+pub fn split_observation_indices_for_multi_objective<T: AsRef<[f64]>>(
+    values: &[T],
+    directions: &[Direction],
+    gamma: usize,
+) -> (Vec<usize>, Vec<usize>) {
+    let n = values.len();
     assert!(
         gamma <= n,
         "gamma must be less than or equal to the number of trials"
@@ -21,18 +41,16 @@ pub fn split_trials_for_multi_objective<'a>(
         return (Vec::new(), Vec::new());
     }
     if gamma == n {
-        return (trials.to_vec(), Vec::new());
+        return ((0..n).collect(), Vec::new());
     }
 
     // Assume minimization (negate value if maximization)
-    let loss_values: Vec<Vec<f64>> = trials
+    let loss_values: Vec<Vec<f64>> = values
         .iter()
-        .map(|t| {
-            let vals = match &t.state_values {
-                TrialStateValues::Complete(v) => v.as_slice(),
-                _ => panic!("Unexpected non-complete trial found during multi-objective split"),
-            };
-            vals.iter()
+        .map(|values| {
+            values
+                .as_ref()
+                .iter()
                 .zip(directions.iter())
                 .map(|(&val, dir)| match dir {
                     Direction::Minimize => val,
@@ -47,19 +65,19 @@ pub fn split_trials_for_multi_objective<'a>(
         rank_to_indices.entry(rank).or_default().push(i);
     }
 
-    let mut good_trials = Vec::with_capacity(gamma);
-    let mut poor_trials = Vec::with_capacity(n - gamma);
+    let mut good_indices = Vec::with_capacity(gamma);
+    let mut poor_indices = Vec::with_capacity(n - gamma);
 
     let mut current_rank = 0usize;
-    while good_trials.len() + rank_to_indices.get(&current_rank).map_or(0, |v| v.len()) <= gamma {
+    while good_indices.len() + rank_to_indices.get(&current_rank).map_or(0, |v| v.len()) <= gamma {
         if let Some(indices) = rank_to_indices.get(&current_rank) {
             for &i in indices.iter() {
-                good_trials.push(trials[i]);
+                good_indices.push(i);
             }
         }
         current_rank += 1;
     }
-    let hss_subset_size = gamma - good_trials.len();
+    let hss_subset_size = gamma - good_indices.len();
     if hss_subset_size > 0 {
         let rank_i_loss_vals = rank_to_indices
             .get(&current_rank)
@@ -104,7 +122,7 @@ pub fn split_trials_for_multi_objective<'a>(
 
         let mut remaining = hss_subset_size;
         for &local in neg_inf_local.iter().take(remaining) {
-            good_trials.push(trials[rank_i_indices[local]]);
+            good_indices.push(rank_i_indices[local]);
         }
         remaining = remaining.saturating_sub(neg_inf_local.len());
 
@@ -138,7 +156,7 @@ pub fn split_trials_for_multi_objective<'a>(
                     take,
                 );
                 for &i in selected_indices.iter() {
-                    good_trials.push(trials[i]);
+                    good_indices.push(i);
                 }
                 remaining = remaining.saturating_sub(take);
             } else {
@@ -147,22 +165,37 @@ pub fn split_trials_for_multi_objective<'a>(
                 // which the outer guard already excluded). Defensive fallback.
                 let take = remaining.min(finite_local.len());
                 for &local in finite_local.iter().take(take) {
-                    good_trials.push(trials[rank_i_indices[local]]);
+                    good_indices.push(rank_i_indices[local]);
                 }
                 remaining = remaining.saturating_sub(take);
             }
         }
 
         for &local in pos_inf_local.iter().take(remaining) {
-            good_trials.push(trials[rank_i_indices[local]]);
+            good_indices.push(rank_i_indices[local]);
         }
     }
-    let good_numbers: HashSet<u32> = good_trials.iter().map(|t| t.number).collect();
-    for &trial in trials.iter() {
-        if !good_numbers.contains(&trial.number) {
-            poor_trials.push(trial);
+    let good_index_set: HashSet<usize> = good_indices.iter().copied().collect();
+    for index in 0..n {
+        if !good_index_set.contains(&index) {
+            poor_indices.push(index);
         }
     }
 
-    (good_trials, poor_trials)
+    (good_indices, poor_indices)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_observation_indices_returns_original_positions() {
+        let values = vec![vec![3.0], vec![1.0], vec![4.0], vec![2.0]];
+        let (good, poor) =
+            split_observation_indices_for_multi_objective(&values, &[Direction::Minimize], 2);
+
+        assert_eq!(good, vec![1, 3]);
+        assert_eq!(poor, vec![0, 2]);
+    }
 }

--- a/rustuna_core/src/sampler.rs
+++ b/rustuna_core/src/sampler.rs
@@ -34,14 +34,17 @@ pub struct Context {
 /// at the beginning of a trial with the inferred joint search space. Parameters not returned from
 /// that method, or all parameters when joint sampling is disabled, fall back to
 /// [`Sampler::sample_independent`].
-pub trait Sampler: Send {
+///
+/// A sampler can be shared by multiple optimization threads. Implementations must synchronize
+/// mutable state internally and keep immutable sampling work outside critical sections.
+pub trait Sampler: Send + Sync {
     /// Samples a single parameter independently.
     ///
     /// This method is used for parameters that are not covered by joint sampling. It is suitable
     /// for samplers such as random search or univariate TPE that decide each parameter
     /// separately.
     fn sample_independent(
-        &mut self,
+        &self,
         ctx: &Context,
         storage: Arc<RwLock<dyn Storage>>,
         name: &str,
@@ -57,7 +60,7 @@ pub trait Sampler: Send {
     /// This is the Rustuna counterpart of Optuna's `sample_relative`. The input search space is
     /// inferred from previously observed compatible parameters in the study.
     fn sample_joint(
-        &mut self,
+        &self,
         ctx: &Context,
         storage: Arc<RwLock<dyn Storage>>,
         search_space: &HashMap<String, Distribution>,
@@ -67,7 +70,7 @@ pub trait Sampler: Send {
     /// This corresponds to Optuna's `after_trial` hook. Rustuna calls it after the objective
     /// function returns and before the finalized state is written to storage.
     fn after_trial(
-        &mut self,
+        &self,
         _ctx: &Context,
         _storage: Arc<RwLock<dyn Storage>>,
         _state_values: &TrialStateValues,
@@ -161,7 +164,7 @@ fn sample_int_with_step(rng: &mut StdRng, low: i64, high: i64, step: i64, log: b
 
 impl Sampler for RandomSampler {
     fn sample_independent(
-        &mut self,
+        &self,
         _ctx: &Context,
         _storage: Arc<RwLock<dyn Storage>>,
         _name: &str,
@@ -178,7 +181,6 @@ impl Sampler for RandomSampler {
                 format!("Failed to acquire RNG guard: {e}"),
             )
         })?;
-
         match distribution {
             Distribution::Float {
                 low,
@@ -210,7 +212,7 @@ impl Sampler for RandomSampler {
     }
 
     fn sample_joint(
-        &mut self,
+        &self,
         _ctx: &Context,
         _storage: Arc<RwLock<dyn Storage>>,
         _search_space: &HashMap<String, Distribution>,
@@ -219,7 +221,7 @@ impl Sampler for RandomSampler {
     }
 
     fn after_trial(
-        &mut self,
+        &self,
         _ctx: &Context,
         _storage: Arc<RwLock<dyn Storage>>,
         _state_values: &TrialStateValues,
@@ -231,6 +233,7 @@ impl Sampler for RandomSampler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::thread;
 
     use crate::storage::InMemoryStorage;
     use crate::study::create_study;
@@ -241,7 +244,7 @@ mod tests {
     }
     impl Sampler for DummyJointSampler {
         fn sample_independent(
-            &mut self,
+            &self,
             _ctx: &Context,
             _storage: Arc<RwLock<dyn Storage>>,
             _name: &str,
@@ -255,7 +258,7 @@ mod tests {
         }
 
         fn sample_joint(
-            &mut self,
+            &self,
             _ctx: &Context,
             _storage: Arc<RwLock<dyn Storage>>,
             _search_space: &HashMap<String, Distribution>,
@@ -264,7 +267,7 @@ mod tests {
         }
 
         fn after_trial(
-            &mut self,
+            &self,
             _ctx: &Context,
             _storage: Arc<RwLock<dyn Storage>>,
             _state_values: &TrialStateValues,
@@ -277,6 +280,43 @@ mod tests {
         let x = t.suggest_float("x", -10.0, 10.0)?;
         let y = t.suggest_float("y", -10.0, 10.0)?;
         Ok(vec![x * x + y * y])
+    }
+
+    #[test]
+    fn random_sampler_can_be_shared_between_threads() -> Result<()> {
+        let sampler: Arc<dyn Sampler> = Arc::new(RandomSampler::seed_from_u64(0));
+        let storage: Arc<RwLock<dyn Storage>> = Arc::new(RwLock::new(InMemoryStorage::new()));
+        let distribution = Distribution::new_float(-1.0, 1.0, None, false);
+        let mut handles = Vec::new();
+
+        for thread_id in 0..4 {
+            let sampler = Arc::clone(&sampler);
+            let storage = Arc::clone(&storage);
+            let distribution = distribution.clone();
+            handles.push(thread::spawn(move || -> Result<()> {
+                for trial_number in 0..100 {
+                    let ctx = Context {
+                        study_id: 0,
+                        directions: vec![Direction::Minimize],
+                        trial_number,
+                        trial_id: thread_id * 100 + trial_number,
+                    };
+                    let value = sampler.sample_independent(
+                        &ctx,
+                        Arc::clone(&storage),
+                        "x",
+                        &distribution,
+                    )?;
+                    assert!((-1.0..1.0).contains(&value));
+                }
+                Ok(())
+            }));
+        }
+
+        for handle in handles {
+            handle.join().expect("sampling thread must not panic")?;
+        }
+        Ok(())
     }
 
     #[test]

--- a/rustuna_core/src/study.rs
+++ b/rustuna_core/src/study.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, RwLock};
 
 use crate::attr::{extract_fixed_params, fixed_params_to_attrs, AttrKey, Attrs, CategoryLabel};
 use crate::distribution::Distribution;
@@ -10,7 +10,7 @@ use crate::trial_queue::{InMemoryTrialQueue, TrialQueue};
 use crate::{Error, ErrorKind, Result};
 
 /// Creates a study backed by the given storage and sampler.
-pub fn create_study<S: Storage + Send + Sync + 'static, T: Sampler + Send + 'static>(
+pub fn create_study<S: Storage + Send + Sync + 'static, T: Sampler + 'static>(
     study_name: &str,
     mut storage: S,
     sampler: T,
@@ -18,7 +18,7 @@ pub fn create_study<S: Storage + Send + Sync + 'static, T: Sampler + Send + 'sta
 ) -> Result<Study> {
     let study_id = storage.create_new_study(study_name, directions.clone())?.id;
     let storage = Arc::new(RwLock::new(storage));
-    let sampler: Arc<Mutex<dyn Sampler>> = Arc::new(Mutex::new(sampler));
+    let sampler: Arc<dyn Sampler> = Arc::new(sampler);
     let queue = Arc::new(RwLock::new(InMemoryTrialQueue::new()));
     Ok(Study::new(
         study_id,
@@ -34,7 +34,7 @@ pub fn create_study<S: Storage + Send + Sync + 'static, T: Sampler + Send + 'sta
 pub fn create_study_with_arc(
     study_name: &str,
     storage: Arc<RwLock<dyn Storage>>,
-    sampler: Arc<Mutex<dyn Sampler>>,
+    sampler: Arc<dyn Sampler>,
     directions: Vec<Direction>,
 ) -> Result<Study> {
     let mut guard = storage.write().map_err(|e| {
@@ -69,7 +69,7 @@ pub struct Study {
     pub name: String,
     pub directions: Vec<Direction>,
     pub storage: Arc<RwLock<dyn Storage>>,
-    pub sampler: Arc<Mutex<dyn Sampler>>,
+    pub sampler: Arc<dyn Sampler>,
     pub queue: Arc<RwLock<dyn TrialQueue>>,
 }
 impl Study {
@@ -79,7 +79,7 @@ impl Study {
         name: String,
         directions: Vec<Direction>,
         storage: Arc<RwLock<dyn Storage>>,
-        sampler: Arc<Mutex<dyn Sampler>>,
+        sampler: Arc<dyn Sampler>,
         queue: Arc<RwLock<dyn TrialQueue>>,
     ) -> Self {
         Study {
@@ -96,7 +96,7 @@ impl Study {
     pub fn from_id(
         id: u32,
         storage: Arc<RwLock<dyn Storage>>,
-        sampler: Arc<Mutex<dyn Sampler>>,
+        sampler: Arc<dyn Sampler>,
     ) -> Result<Self> {
         let mut guard = storage.write().map_err(|e| {
             Error::with_reason(
@@ -116,7 +116,7 @@ impl Study {
     pub fn from_name(
         name: String,
         storage: Arc<RwLock<dyn Storage>>,
-        sampler: Arc<Mutex<dyn Sampler>>,
+        sampler: Arc<dyn Sampler>,
     ) -> Result<Self> {
         let mut guard = storage.write().map_err(|e| {
             Error::with_reason(
@@ -221,46 +221,40 @@ impl Study {
                 )
             };
 
-        let sampler = Arc::clone(&self.sampler);
-        let mut guard = sampler.lock().map_err(|e| {
-            Error::with_reason(
-                ErrorKind::Unexpected,
-                format!("Failed to acquire a sampler guard: {e}"),
-            )
-        })?;
-        let joint_params: HashMap<String, (Distribution, f64)> = if guard.support_joint_sampling() {
-            let joint_search_space = self
-                .storage
-                .write()
-                .map_err(|e| {
-                    Error::with_reason(
-                        ErrorKind::Unexpected,
-                        format!("Failed to acquire a storage guard: {e}"),
-                    )
-                })?
-                .get_joint_search_space(self.id)?;
+        let joint_params: HashMap<String, (Distribution, f64)> =
+            if self.sampler.support_joint_sampling() {
+                let joint_search_space = self
+                    .storage
+                    .write()
+                    .map_err(|e| {
+                        Error::with_reason(
+                            ErrorKind::Unexpected,
+                            format!("Failed to acquire a storage guard: {e}"),
+                        )
+                    })?
+                    .get_joint_search_space(self.id)?;
 
-            let ctx = SamplerContext {
-                study_id: self.id,
-                trial_number,
-                trial_id,
-                directions: self.directions.clone(),
-            };
-            let params = guard.sample_joint(&ctx, self.storage.clone(), &joint_search_space)?;
-            let mut joint_params = HashMap::new();
-            for (name, param_value) in params {
-                if !joint_search_space.contains_key(&name) {
-                    continue;
+                let ctx = SamplerContext {
+                    study_id: self.id,
+                    trial_number,
+                    trial_id,
+                    directions: self.directions.clone(),
+                };
+                let params =
+                    self.sampler
+                        .sample_joint(&ctx, self.storage.clone(), &joint_search_space)?;
+                let mut joint_params = HashMap::new();
+                for (name, param_value) in params {
+                    if !joint_search_space.contains_key(&name) {
+                        continue;
+                    }
+                    let distribution = joint_search_space[&name].clone();
+                    joint_params.insert(name, (distribution, param_value));
                 }
-                let distribution = joint_search_space[&name].clone();
-                joint_params.insert(name, (distribution, param_value));
-            }
-            joint_params
-        } else {
-            HashMap::new()
-        };
-
-        drop(guard);
+                joint_params
+            } else {
+                HashMap::new()
+            };
 
         let trial = Trial::new(
             trial_id,
@@ -295,15 +289,9 @@ impl Study {
             trial_number,
             trial_id,
         };
-        let after_trial_result = {
-            let mut sampler_guard = self.sampler.lock().map_err(|e| {
-                Error::with_reason(
-                    ErrorKind::Unexpected,
-                    format!("Failed to acquire a sampler guard: {e}"),
-                )
-            })?;
-            sampler_guard.after_trial(&ctx, self.storage.clone(), &state_values)
-        };
+        let after_trial_result =
+            self.sampler
+                .after_trial(&ctx, self.storage.clone(), &state_values);
 
         let mut storage_guard = self.storage.write().map_err(|e| {
             Error::with_reason(
@@ -619,6 +607,7 @@ mod tests {
     use crate::attr::AttrKey;
     use crate::distribution::Distribution;
     use crate::sampler::{Context as SamplerContext, Sampler};
+    use std::sync::Mutex;
     use std::thread;
 
     use crate::sampler::RandomSampler;
@@ -634,7 +623,7 @@ mod tests {
 
     impl Sampler for RecordingSampler {
         fn sample_independent(
-            &mut self,
+            &self,
             _ctx: &SamplerContext,
             _storage: Arc<RwLock<dyn Storage>>,
             _name: &str,
@@ -648,7 +637,7 @@ mod tests {
         }
 
         fn sample_joint(
-            &mut self,
+            &self,
             _ctx: &SamplerContext,
             _storage: Arc<RwLock<dyn Storage>>,
             _search_space: &HashMap<String, Distribution>,
@@ -657,7 +646,7 @@ mod tests {
         }
 
         fn after_trial(
-            &mut self,
+            &self,
             ctx: &SamplerContext,
             storage: Arc<RwLock<dyn Storage>>,
             state_values: &TrialStateValues,
@@ -993,10 +982,10 @@ mod tests {
     fn test_tell_calls_after_trial_before_storage_update() -> Result<()> {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
         let calls = Arc::new(Mutex::new(Vec::new()));
-        let sampler = Arc::new(Mutex::new(RecordingSampler {
+        let sampler = Arc::new(RecordingSampler {
             calls: calls.clone(),
             fail_after_trial: false,
-        }));
+        });
         let study = create_study_with_arc(
             "dummy-after-trial",
             storage.clone(),
@@ -1039,10 +1028,10 @@ mod tests {
     fn test_tell_persists_trial_even_if_after_trial_fails() -> Result<()> {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
         let calls = Arc::new(Mutex::new(Vec::new()));
-        let sampler = Arc::new(Mutex::new(RecordingSampler {
+        let sampler = Arc::new(RecordingSampler {
             calls,
             fail_after_trial: true,
-        }));
+        });
         let study = create_study_with_arc(
             "dummy-after-trial-failure",
             storage.clone(),

--- a/rustuna_core/src/trial.rs
+++ b/rustuna_core/src/trial.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, RwLock};
 
 use crate::attr::{category_labels_to_attrs, AttrKey, Attrs, CategoryLabel};
 use crate::distribution::Distribution;
@@ -22,7 +22,7 @@ pub struct Trial {
     pub datetime_complete: Option<String>,
     directions: Vec<Direction>,
     storage: Arc<RwLock<dyn Storage>>,
-    sampler: Arc<Mutex<dyn Sampler>>,
+    sampler: Arc<dyn Sampler>,
     joint_params: HashMap<String, (Distribution, f64)>,
     fixed_params: HashMap<String, CategoryLabel>,
     cached_trial: PersistedTrial,
@@ -38,7 +38,7 @@ impl Trial {
         datetime_complete: Option<String>,
         directions: Vec<Direction>,
         storage: Arc<RwLock<dyn Storage>>,
-        sampler: Arc<Mutex<dyn Sampler>>,
+        sampler: Arc<dyn Sampler>,
         joint_params: HashMap<String, (Distribution, f64)>,
         fixed_params: HashMap<String, CategoryLabel>,
     ) -> Self {
@@ -140,15 +140,9 @@ impl Trial {
             trial_id: self.id,
             directions: self.directions.clone(),
         };
-        let mut sampler_guard = self.sampler.lock().map_err(|e| {
-            Error::with_reason(
-                ErrorKind::SamplerError,
-                format!("Failed to acquire sampler guard: {e}"),
-            )
-        })?;
         let param_value =
-            sampler_guard.sample_independent(&context, self.storage.clone(), name, distribution)?;
-        drop(sampler_guard);
+            self.sampler
+                .sample_independent(&context, self.storage.clone(), name, distribution)?;
 
         let mut storage_guard = self.storage.write().map_err(|e| {
             Error::with_reason(
@@ -516,7 +510,7 @@ mod tests {
     #[test]
     fn test_enqueue_and_suggest_float() -> Result<()> {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
-        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
+        let sampler = Arc::new(RandomSampler::new());
         let directions = vec![Direction::Minimize];
         let study = create_study_with_arc("dummy", storage.clone(), sampler, directions)?;
 
@@ -533,7 +527,7 @@ mod tests {
     #[test]
     fn test_enqueue_and_suggest_int() -> Result<()> {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
-        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
+        let sampler = Arc::new(RandomSampler::new());
         let directions = vec![Direction::Minimize];
         let study = create_study_with_arc("dummy", storage.clone(), sampler, directions)?;
 
@@ -550,7 +544,7 @@ mod tests {
     #[test]
     fn test_enqueue_fallback_on_out_of_range() -> Result<()> {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
-        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
+        let sampler = Arc::new(RandomSampler::new());
         let directions = vec![Direction::Minimize];
         let study = create_study_with_arc("dummy", storage.clone(), sampler, directions)?;
 
@@ -567,7 +561,7 @@ mod tests {
     #[test]
     fn test_enqueue_mixed_with_normal_ask() -> Result<()> {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
-        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
+        let sampler = Arc::new(RandomSampler::new());
         let directions = vec![Direction::Minimize];
         let study = create_study_with_arc("dummy", storage.clone(), sampler, directions)?;
 
@@ -590,7 +584,7 @@ mod tests {
     #[test]
     fn test_enqueue_unspecified_param_sampled() -> Result<()> {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
-        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
+        let sampler = Arc::new(RandomSampler::new());
         let directions = vec![Direction::Minimize];
         let study = create_study_with_arc("dummy", storage.clone(), sampler, directions)?;
 
@@ -610,7 +604,7 @@ mod tests {
     #[test]
     fn test_trial_user_attr() -> Result<()> {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
-        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
+        let sampler = Arc::new(RandomSampler::new());
         let directions = vec![Direction::Minimize];
         let study = create_study_with_arc("dummy", storage.clone(), sampler, directions)?;
 
@@ -649,7 +643,7 @@ mod tests {
     #[test]
     fn test_set_constraints() -> Result<()> {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
-        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
+        let sampler = Arc::new(RandomSampler::new());
         let directions = vec![Direction::Minimize];
         let study = create_study_with_arc("dummy", storage.clone(), sampler, directions)?;
 

--- a/rustuna_pyo3/src/sampler/cmaes.rs
+++ b/rustuna_pyo3/src/sampler/cmaes.rs
@@ -235,7 +235,7 @@ impl CmaEsSampler {
 
 impl Sampler for CmaEsSampler {
     fn sample_independent(
-        &mut self,
+        &self,
         ctx: &Context,
         storage: Arc<RwLock<dyn Storage>>,
         name: &str,
@@ -257,7 +257,7 @@ impl Sampler for CmaEsSampler {
     }
 
     fn sample_joint(
-        &mut self,
+        &self,
         ctx: &Context,
         storage: Arc<RwLock<dyn Storage>>,
         search_space: &HashMap<String, Distribution>,
@@ -289,10 +289,10 @@ impl Sampler for CmaEsSampler {
 #[pyclass(name = "CmaEsSampler")]
 #[pyo3(module = "rustuna")]
 pub struct PyCmaEsSampler {
-    pub sampler: Arc<Mutex<dyn Sampler>>,
+    pub sampler: Arc<CmaEsSampler>,
 }
 
-// These methods release the GIL before acquiring the sampler mutex because
+// These methods release the GIL before acquiring the sampler's internal mutex because
 // `CmaEsSampler` re-attaches to Python internally. Acquiring the mutex while holding the GIL
 // could deadlock with another thread that holds the mutex and waits for the GIL.
 #[pymethods]
@@ -301,7 +301,7 @@ impl PyCmaEsSampler {
     #[pyo3(signature = (*, seed = None, popsize = None))]
     fn py_new(seed: Option<u64>, popsize: Option<usize>) -> Self {
         PyCmaEsSampler {
-            sampler: Arc::new(Mutex::new(CmaEsSampler::new(seed, popsize))),
+            sampler: Arc::new(CmaEsSampler::new(seed, popsize)),
         }
     }
 
@@ -324,10 +324,6 @@ impl PyCmaEsSampler {
         let distribution = distribution.distribution.clone();
         py.detach(|| {
             self.sampler
-                .lock()
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-                })?
                 .sample_independent(&context, arc_storage, &name, &distribution)
                 .map_err(|e| {
                     PyRuntimeError::new_err(format!("Failed to sample independent: {e:?}"))
@@ -350,10 +346,6 @@ impl PyCmaEsSampler {
             .collect();
         py.detach(|| {
             self.sampler
-                .lock()
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-                })?
                 .sample_joint(&context, arc_storage, &search_space)
                 .map_err(err_to_exceptions)
         })
@@ -381,10 +373,6 @@ impl PyCmaEsSampler {
         let context = ctx.context.clone();
         py.detach(|| {
             self.sampler
-                .lock()
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-                })?
                 .after_trial(&context, arc_storage, &state_values)
                 .map_err(|e| PyRuntimeError::new_err(format!("Failed to call after_trial: {e:?}")))
         })

--- a/rustuna_pyo3/src/sampler/nsgaii.rs
+++ b/rustuna_pyo3/src/sampler/nsgaii.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::Mutex;
 
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
@@ -18,7 +17,7 @@ use crate::trial::PyTrialState;
 #[pyclass(name = "NSGAIISampler")]
 #[pyo3(module = "rustuna")]
 pub struct PyNSGAIISampler {
-    pub sampler: Arc<Mutex<NSGAIISampler>>,
+    pub sampler: Arc<NSGAIISampler>,
 }
 #[pymethods]
 impl PyNSGAIISampler {
@@ -47,18 +46,13 @@ impl PyNSGAIISampler {
             ),
         };
         Ok(PyNSGAIISampler {
-            sampler: Arc::new(Mutex::new(rs_sampler)),
+            sampler: Arc::new(rs_sampler),
         })
     }
 
     #[getter]
-    fn support_joint_sampling(&self, py: Python<'_>) -> PyResult<bool> {
-        py.detach(|| {
-            let guard = self.sampler.lock().map_err(|e| {
-                PyRuntimeError::new_err(format!("Failed to acquire sampler lock: {e}"))
-            })?;
-            Ok(guard.support_joint_sampling())
-        })
+    fn support_joint_sampling(&self) -> bool {
+        self.sampler.support_joint_sampling()
     }
 
     fn sample_independent(
@@ -75,10 +69,6 @@ impl PyNSGAIISampler {
         let distribution = distribution.distribution.clone();
         py.detach(|| {
             self.sampler
-                .lock()
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-                })?
                 .sample_independent(&context, arc_storage, &name, &distribution)
                 .map_err(|e| {
                     PyRuntimeError::new_err(format!("Failed to sample independent: {e:?}"))
@@ -101,10 +91,6 @@ impl PyNSGAIISampler {
             .collect();
         py.detach(|| {
             self.sampler
-                .lock()
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-                })?
                 .sample_joint(&context, arc_storage, &search_space)
                 .map_err(|e| PyRuntimeError::new_err(format!("Failed to sample joint: {e:?}")))
         })
@@ -132,10 +118,6 @@ impl PyNSGAIISampler {
         let context = ctx.context.clone();
         py.detach(|| {
             self.sampler
-                .lock()
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-                })?
                 .after_trial(&context, arc_storage, &state_values)
                 .map_err(|e| PyRuntimeError::new_err(format!("Failed to call after_trial: {e:?}")))
         })

--- a/rustuna_pyo3/src/sampler/random.rs
+++ b/rustuna_pyo3/src/sampler/random.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
@@ -14,7 +14,7 @@ use crate::trial::PyTrialState;
 #[pyclass(name = "RandomSampler")]
 #[pyo3(module = "rustuna")]
 pub struct PyRandomSampler {
-    pub sampler: Arc<Mutex<RandomSampler>>,
+    pub sampler: Arc<RandomSampler>,
 }
 #[pymethods]
 impl PyRandomSampler {
@@ -26,7 +26,7 @@ impl PyRandomSampler {
             None => RandomSampler::new(),
         };
         Self {
-            sampler: Arc::new(Mutex::new(random_sampler)),
+            sampler: Arc::new(random_sampler),
         }
     }
 
@@ -49,10 +49,6 @@ impl PyRandomSampler {
         let distribution = distribution.distribution.clone();
         py.detach(|| {
             self.sampler
-                .lock()
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-                })?
                 .sample_independent(&context, arc_storage, &name, &distribution)
                 .map_err(|e| {
                     PyRuntimeError::new_err(format!("Failed to sample independent: {e:?}"))

--- a/rustuna_pyo3/src/sampler/to_rust.rs
+++ b/rustuna_pyo3/src/sampler/to_rust.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
@@ -18,16 +18,18 @@ use crate::trial::PyTrialState;
 // rustuna_core::sampler::Sampler. Rustuna can therefore use Python samplers through the same
 // interface as native Rust samplers.
 pub struct ToRustSampler {
-    obj: Py<PyAny>,
+    obj: Mutex<Py<PyAny>>,
 }
 impl ToRustSampler {
     pub fn new(obj: Py<PyAny>) -> Self {
-        ToRustSampler { obj }
+        ToRustSampler {
+            obj: Mutex::new(obj),
+        }
     }
 }
 impl Sampler for ToRustSampler {
     fn sample_independent(
-        &mut self,
+        &self,
         ctx: &SamplerContext,
         storage: Arc<std::sync::RwLock<dyn rustuna_core::storage::Storage>>,
         name: &str,
@@ -43,12 +45,17 @@ impl Sampler for ToRustSampler {
         let study_attrs = study.attrs.clone();
         drop(guard);
 
+        let obj = self.obj.lock().map_err(|e| {
+            rustuna_core::Error::with_reason(
+                rustuna_core::ErrorKind::SamplerError,
+                format!("Failed to acquire sampler object guard: {e}"),
+            )
+        })?;
         Python::attach(|py| {
             let py_ctx = PySamplerContext::from(ctx.clone());
             let py_storage = ToPythonStorage::new(storage.clone());
             let py_distribution = PyDistribution::new(distribution.clone(), name, &study_attrs);
-            let py_result = self
-                .obj
+            let py_result = obj
                 .call_method1(
                     py,
                     "sample_independent",
@@ -72,16 +79,18 @@ impl Sampler for ToRustSampler {
     }
 
     fn support_joint_sampling(&self) -> bool {
+        let Ok(obj) = self.obj.lock() else {
+            return false;
+        };
         Python::attach(|py| {
-            self.obj
-                .getattr(py, "support_joint_sampling")
+            obj.getattr(py, "support_joint_sampling")
                 .and_then(|x| x.extract::<bool>(py))
                 .unwrap_or(false)
         })
     }
 
     fn sample_joint(
-        &mut self,
+        &self,
         ctx: &SamplerContext,
         storage: Arc<std::sync::RwLock<dyn Storage>>,
         search_space: &HashMap<String, rustuna_core::distribution::Distribution>,
@@ -93,6 +102,12 @@ impl Sampler for ToRustSampler {
         let study_attrs = study.attrs.clone();
         drop(guard);
 
+        let obj = self.obj.lock().map_err(|e| {
+            rustuna_core::Error::with_reason(
+                rustuna_core::ErrorKind::SamplerError,
+                format!("Failed to acquire sampler object guard: {e}"),
+            )
+        })?;
         Python::attach(|py| {
             let py_ctx = PySamplerContext::from(ctx.clone());
             let py_storage = ToPythonStorage::new(storage.clone());
@@ -112,8 +127,7 @@ impl Sampler for ToRustSampler {
                     )
                 })?;
             }
-            let py_result = self
-                .obj
+            let py_result = obj
                 .call_method1(py, "sample_joint", (py_ctx, py_storage, py_search_space))
                 .map_err(|e| {
                     rustuna_core::Error::with_reason(
@@ -132,7 +146,7 @@ impl Sampler for ToRustSampler {
     }
 
     fn after_trial(
-        &mut self,
+        &self,
         ctx: &SamplerContext,
         storage: Arc<std::sync::RwLock<dyn Storage>>,
         state_values: &TrialStateValues,
@@ -143,8 +157,14 @@ impl Sampler for ToRustSampler {
             _ => None,
         };
 
+        let obj = self.obj.lock().map_err(|e| {
+            rustuna_core::Error::with_reason(
+                rustuna_core::ErrorKind::SamplerError,
+                format!("Failed to acquire sampler object guard: {e}"),
+            )
+        })?;
         Python::attach(|py| {
-            if !self.obj.bind(py).hasattr("after_trial").map_err(|e| {
+            if !obj.bind(py).hasattr("after_trial").map_err(|e| {
                 rustuna_core::Error::with_reason(
                     rustuna_core::ErrorKind::SamplerError,
                     e.to_string(),
@@ -155,8 +175,7 @@ impl Sampler for ToRustSampler {
 
             let py_ctx = PySamplerContext::from(ctx.clone());
             let py_storage = ToPythonStorage::new(storage.clone());
-            self.obj
-                .call_method1(py, "after_trial", (py_ctx, py_storage, py_state, py_values))
+            obj.call_method1(py, "after_trial", (py_ctx, py_storage, py_state, py_values))
                 .map_err(|e| {
                     rustuna_core::Error::with_reason(
                         rustuna_core::ErrorKind::SamplerError,

--- a/rustuna_pyo3/src/sampler/tpe.rs
+++ b/rustuna_pyo3/src/sampler/tpe.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
@@ -17,7 +17,7 @@ use crate::trial::PyTrialState;
 #[pyclass(name = "TPESampler")]
 #[pyo3(module = "rustuna")]
 pub struct PyTpeSampler {
-    pub sampler: Arc<Mutex<TpeSampler>>,
+    pub sampler: Arc<TpeSampler>,
 }
 #[pymethods]
 impl PyTpeSampler {
@@ -34,18 +34,13 @@ impl PyTpeSampler {
             multivariate,
         });
         Ok(PyTpeSampler {
-            sampler: Arc::new(Mutex::new(rs_sampler)),
+            sampler: Arc::new(rs_sampler),
         })
     }
 
     #[getter]
-    fn support_joint_sampling(&self, py: Python<'_>) -> PyResult<bool> {
-        py.detach(|| {
-            let guard = self.sampler.lock().map_err(|e| {
-                PyRuntimeError::new_err(format!("Failed to acquire sampler lock: {e}"))
-            })?;
-            Ok(guard.support_joint_sampling())
-        })
+    fn support_joint_sampling(&self) -> bool {
+        self.sampler.support_joint_sampling()
     }
 
     fn sample_independent(
@@ -62,10 +57,6 @@ impl PyTpeSampler {
         let distribution = distribution.distribution.clone();
         py.detach(|| {
             self.sampler
-                .lock()
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-                })?
                 .sample_independent(&context, arc_storage, &name, &distribution)
                 .map_err(|e| {
                     PyRuntimeError::new_err(format!("Failed to sample independent: {e:?}"))
@@ -88,10 +79,6 @@ impl PyTpeSampler {
             .collect();
         py.detach(|| {
             self.sampler
-                .lock()
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-                })?
                 .sample_joint(&context, arc_storage, &search_space)
                 .map_err(|e| PyRuntimeError::new_err(format!("Failed to sample joint: {e:?}")))
         })
@@ -119,10 +106,6 @@ impl PyTpeSampler {
         let context = ctx.context.clone();
         py.detach(|| {
             self.sampler
-                .lock()
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-                })?
                 .after_trial(&context, arc_storage, &state_values)
                 .map_err(|e| PyRuntimeError::new_err(format!("Failed to call after_trial: {e:?}")))
         })

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -5,7 +5,7 @@ use pyo3::{PyTypeInfo, Python};
 use pyo3::exceptions::{PyRuntimeError, PyTypeError, PyValueError};
 use rustuna_core::ErrorKind;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, RwLock};
 
 use rustuna_core::attr::AttrKey;
 use rustuna_core::sampler::Sampler;
@@ -36,7 +36,7 @@ use crate::trial_queue::sqlite3::PySQLite3TrialQueue;
 use crate::trial_queue::to_rust::ToRustTrialQueue;
 
 type SharedStorage = Arc<RwLock<dyn Storage>>;
-type SharedSampler = Arc<Mutex<dyn Sampler>>;
+type SharedSampler = Arc<dyn Sampler>;
 type SharedTrialQueue = Arc<RwLock<dyn rustuna_core::trial_queue::TrialQueue>>;
 
 mod py_exceptions {
@@ -207,7 +207,7 @@ fn resolve_sampler_pyobj(
     } else if let Ok(py_random_sampler) = sampler_ref.extract::<PyRandomSampler>() {
         Ok((py_random_sampler.sampler.clone(), sampler_pyobj))
     } else {
-        let sampler: SharedSampler = Arc::new(Mutex::new(ToRustSampler::new(sampler)));
+        let sampler: SharedSampler = Arc::new(ToRustSampler::new(sampler));
         Ok((sampler, sampler_pyobj))
     }
 }
@@ -220,7 +220,7 @@ fn into_sampler_pyobj(
     match sampler {
         Some(sampler) => resolve_sampler_pyobj(py, sampler),
         None => {
-            let sampler = Arc::new(Mutex::new(TpeSampler::new()));
+            let sampler = Arc::new(TpeSampler::new());
             let py_sampler = PyTpeSampler {
                 sampler: sampler.clone(),
             };

--- a/rustuna_sampler/src/nsgaii.rs
+++ b/rustuna_sampler/src/nsgaii.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 
 use rand::prelude::*;
 use rand::rngs::StdRng;
@@ -55,14 +55,14 @@ use rustuna_core::{Error, ErrorKind};
 /// }
 /// ```
 pub struct NSGAIISampler {
-    rng: StdRng,
+    rng: Mutex<StdRng>,
     population_size: usize,
     mutation_prob: Option<f64>,
     crossover_prob: f64,
     swapping_prob: f64,
     /// Cache mapping generation number to completed trial numbers in that generation.
     /// Updated incrementally in `after_trial` so `sample_joint` does not scan all trials every time.
-    generation_to_numbers: HashMap<u32, Vec<u32>>,
+    generation_to_numbers: Mutex<HashMap<u32, Vec<u32>>>,
 }
 impl Default for NSGAIISampler {
     fn default() -> Self {
@@ -85,12 +85,12 @@ impl NSGAIISampler {
         swapping_prob: f64,
     ) -> NSGAIISampler {
         NSGAIISampler {
-            rng: StdRng::from_seed(Default::default()),
+            rng: Mutex::new(StdRng::from_seed(Default::default())),
             population_size,
             mutation_prob,
             crossover_prob,
             swapping_prob,
-            generation_to_numbers: HashMap::new(),
+            generation_to_numbers: Mutex::new(HashMap::new()),
         }
     }
     /// Creates a reproducibly seeded NSGA-II sampler.
@@ -105,16 +105,19 @@ impl NSGAIISampler {
         swapping_prob: f64,
     ) -> NSGAIISampler {
         NSGAIISampler {
-            rng: StdRng::seed_from_u64(seed),
+            rng: Mutex::new(StdRng::seed_from_u64(seed)),
             population_size,
             mutation_prob,
             crossover_prob,
             swapping_prob,
-            generation_to_numbers: HashMap::new(),
+            generation_to_numbers: Mutex::new(HashMap::new()),
         }
     }
-    fn rebuild_generation_cache(&mut self, trials: &[Option<PersistedTrial>]) {
-        self.generation_to_numbers.clear();
+    fn rebuild_generation_cache(
+        generation_to_numbers: &mut HashMap<u32, Vec<u32>>,
+        trials: &[Option<PersistedTrial>],
+    ) {
+        generation_to_numbers.clear();
         let generation_key = AttrKey::System("generation".into());
         for trial in trials.iter().flatten() {
             if !matches!(trial.state_values, TrialStateValues::Complete(_)) {
@@ -122,7 +125,7 @@ impl NSGAIISampler {
             }
             if let Some(gen_str) = trial.attrs.get(&generation_key) {
                 if let Ok(generation) = gen_str.parse::<u32>() {
-                    self.generation_to_numbers
+                    generation_to_numbers
                         .entry(generation)
                         .or_default()
                         .push(trial.number);
@@ -131,7 +134,7 @@ impl NSGAIISampler {
         }
     }
     fn select_elite_population_numbers(
-        &mut self,
+        &self,
         ctx: &Context,
         trials: &[Option<PersistedTrial>],
         population_numbers: &[u32],
@@ -153,18 +156,19 @@ impl NSGAIISampler {
         Ok(elite_population_numbers)
     }
     fn get_parent_population_numbers(
-        &mut self,
+        &self,
+        generation_to_numbers: &mut HashMap<u32, Vec<u32>>,
         ctx: &Context,
         trials: &[Option<PersistedTrial>],
     ) -> Result<(i32, Vec<u32>)> {
-        if self.generation_to_numbers.is_empty() {
-            self.rebuild_generation_cache(trials);
+        if generation_to_numbers.is_empty() {
+            Self::rebuild_generation_cache(generation_to_numbers, trials);
         }
 
         let mut parent_generation = -1;
         let mut parent_population_numbers = Vec::with_capacity(10);
         for generation in 0..10 {
-            let population_numbers = match self.generation_to_numbers.get(&generation) {
+            let population_numbers = match generation_to_numbers.get(&generation) {
                 Some(numbers) if numbers.len() >= self.population_size => numbers.clone(),
                 _ => break,
             };
@@ -179,7 +183,8 @@ impl NSGAIISampler {
         Ok((parent_generation, parent_population_numbers))
     }
     fn crossover(
-        &mut self,
+        &self,
+        rng: &mut StdRng,
         parent0: HashMap<String, f64>,
         parent1: HashMap<String, f64>,
         search_space: &HashMap<String, Distribution>,
@@ -188,7 +193,7 @@ impl NSGAIISampler {
         for name in search_space.keys() {
             let param_value0 = *parent0.get(name).unwrap();
             let param_value1 = *parent1.get(name).unwrap();
-            let param_value = if self.rng.gen_bool(self.swapping_prob) {
+            let param_value = if rng.gen_bool(self.swapping_prob) {
                 param_value1
             } else {
                 param_value0
@@ -200,7 +205,7 @@ impl NSGAIISampler {
 }
 impl Sampler for NSGAIISampler {
     fn sample_independent(
-        &mut self,
+        &self,
         _ctx: &Context,
         _storage: Arc<RwLock<dyn Storage>>,
         _name: &str,
@@ -210,6 +215,12 @@ impl Sampler for NSGAIISampler {
             return distribution.get_single_value();
         }
 
+        let mut rng = self.rng.lock().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::SamplerError,
+                format!("Failed to acquire RNG guard: {e}"),
+            )
+        })?;
         match distribution {
             Distribution::Float {
                 low,
@@ -218,15 +229,15 @@ impl Sampler for NSGAIISampler {
                 log,
             } => {
                 let param_value = match (step, log) {
-                    (None, false) => self.rng.gen_range(*low..*high),
-                    (None, true) => self.rng.gen_range(low.ln()..high.ln()).exp(),
+                    (None, false) => rng.gen_range(*low..*high),
+                    (None, true) => rng.gen_range(low.ln()..high.ln()).exp(),
                     (Some(step), false) => {
                         let max_index = ((high - low) / step).floor().max(0.0) as i64;
-                        let index = self.rng.gen_range(0..=max_index);
+                        let index = rng.gen_range(0..=max_index);
                         low + (index as f64) * step
                     }
                     (Some(step), true) => {
-                        let value = self.rng.gen_range(low.ln()..high.ln()).exp();
+                        let value = rng.gen_range(low.ln()..high.ln()).exp();
                         let mut stepped = low + ((value - low) / step).round() * step;
                         if stepped < *low {
                             stepped = *low;
@@ -249,7 +260,7 @@ impl Sampler for NSGAIISampler {
                 let high_f = *high as f64;
                 let step_f = *step as f64;
                 let param_value = if *log {
-                    let value = self.rng.gen_range(low_f.ln()..high_f.ln()).exp();
+                    let value = rng.gen_range(low_f.ln()..high_f.ln()).exp();
                     let max_index = ((high_f - low_f) / step_f).floor().max(0.0) as i64;
                     let mut index = ((value - low_f) / step_f).round() as i64;
                     if index < 0 {
@@ -261,13 +272,13 @@ impl Sampler for NSGAIISampler {
                     low_f + (index as f64) * step_f
                 } else {
                     let max_index = ((high - low) / step).max(0);
-                    let index = self.rng.gen_range(0..=max_index);
+                    let index = rng.gen_range(0..=max_index);
                     (low + index * step) as f64
                 };
                 Ok(param_value)
             }
             Distribution::Categorical { cardinality } => {
-                let param_value = self.rng.gen_range(0..*cardinality);
+                let param_value = rng.gen_range(0..*cardinality);
                 Ok(param_value as f64)
             }
         }
@@ -278,7 +289,7 @@ impl Sampler for NSGAIISampler {
     }
 
     fn sample_joint(
-        &mut self,
+        &self,
         ctx: &Context,
         storage: Arc<RwLock<dyn Storage>>,
         search_space: &HashMap<String, Distribution>,
@@ -288,7 +299,13 @@ impl Sampler for NSGAIISampler {
             .map_err(|_e| Error::new(ErrorKind::Unexpected))?;
         let (parent_generation, parent_population_numbers) = {
             let trials = guard.get_trials(ctx.study_id)?;
-            self.get_parent_population_numbers(ctx, trials)?
+            let mut generation_to_numbers = self.generation_to_numbers.lock().map_err(|e| {
+                Error::with_reason(
+                    ErrorKind::SamplerError,
+                    format!("Failed to acquire generation cache guard: {e}"),
+                )
+            })?;
+            self.get_parent_population_numbers(&mut generation_to_numbers, ctx, trials)?
         };
         let child_generation = u32::try_from(parent_generation + 1).unwrap();
         let mut attrs = Attrs::with_capacity(1);
@@ -304,9 +321,15 @@ impl Sampler for NSGAIISampler {
             return Ok(params);
         }
 
+        let mut rng = self.rng.lock().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::SamplerError,
+                format!("Failed to acquire RNG guard: {e}"),
+            )
+        })?;
         let (parent0_number, parent1_number) = {
             let mut selected = parent_population_numbers
-                .choose_multiple(&mut self.rng, 2)
+                .choose_multiple(&mut *rng, 2)
                 .copied();
             (selected.next().unwrap(), selected.next().unwrap())
         };
@@ -328,8 +351,8 @@ impl Sampler for NSGAIISampler {
         let parent1 = build_parent_params(parent1_number)?;
         drop(guard);
 
-        let child = if self.rng.gen_bool(self.crossover_prob) {
-            self.crossover(parent0, parent1, search_space)
+        let child = if rng.gen_bool(self.crossover_prob) {
+            self.crossover(&mut rng, parent0, parent1, search_space)
         } else {
             parent0
         };
@@ -339,7 +362,7 @@ impl Sampler for NSGAIISampler {
             .unwrap_or(1.0 / 1.0_f64.max(child.len() as f64));
         let mut params = HashMap::new();
         for name in search_space.keys() {
-            if !self.rng.gen_bool(mutation_prob) {
+            if !rng.gen_bool(mutation_prob) {
                 let param_value = *child.get(name).unwrap();
                 params.insert(name.clone(), param_value);
             }
@@ -348,7 +371,7 @@ impl Sampler for NSGAIISampler {
     }
 
     fn after_trial(
-        &mut self,
+        &self,
         ctx: &Context,
         storage: Arc<RwLock<dyn Storage>>,
         state_values: &TrialStateValues,
@@ -362,6 +385,13 @@ impl Sampler for NSGAIISampler {
             if let Some(gen_str) = trial.attrs.get(&generation_key) {
                 if let Ok(generation) = gen_str.parse::<u32>() {
                     self.generation_to_numbers
+                        .lock()
+                        .map_err(|e| {
+                            Error::with_reason(
+                                ErrorKind::SamplerError,
+                                format!("Failed to acquire generation cache guard: {e}"),
+                            )
+                        })?
                         .entry(generation)
                         .or_default()
                         .push(trial.number);

--- a/rustuna_sampler/src/tpe/sampler.rs
+++ b/rustuna_sampler/src/tpe/sampler.rs
@@ -1,7 +1,7 @@
 use core::panic;
 use std::cmp::Ordering;
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -93,12 +93,12 @@ type SplitValue = (Vec<u32>, Vec<u32>);
 /// }
 /// ```
 pub struct TpeSampler {
-    rng: StdRng,
+    rng: Mutex<StdRng>,
     multivariate: Option<bool>,
     n_startup_trials: usize,
     random_sampler: RandomSampler,
     // TODO(y0z): Change to LruCache<(Vec<&PersistedTrial>, usize), (Vec<&PersistedTrial>, Vec<&PersistedTrial>)>
-    split_cache: HashMap<SplitKey, SplitValue>,
+    split_cache: RwLock<HashMap<SplitKey, SplitValue>>,
 }
 impl Default for TpeSampler {
     fn default() -> Self {
@@ -114,11 +114,11 @@ impl TpeSampler {
         };
         let seed_for_random_sampler = rng.gen();
         Self {
-            rng,
+            rng: Mutex::new(rng),
             multivariate: cfg.multivariate,
             n_startup_trials: cfg.n_startup_trials,
             random_sampler: RandomSampler::seed_from_u64(seed_for_random_sampler),
-            split_cache: HashMap::new(),
+            split_cache: RwLock::new(HashMap::new()),
         }
     }
 
@@ -144,7 +144,7 @@ impl TpeSampler {
     }
 
     fn sample(
-        &mut self,
+        &self,
         ctx: &Context,
         complete_trials: &[&rustuna_core::trial::PersistedTrial],
         search_space: &HashMap<String, Distribution>,
@@ -169,11 +169,21 @@ impl TpeSampler {
                 .map(|t| t.number)
                 .collect::<Vec<u32>>();
             let split_cache_key = (complete_trial_numbers.clone(), gamma);
+            let cached_split = self
+                .split_cache
+                .read()
+                .map_err(|e| {
+                    Error::with_reason(
+                        ErrorKind::SamplerError,
+                        format!("Failed to acquire split cache guard: {e}"),
+                    )
+                })?
+                .get(&split_cache_key)
+                .cloned();
             let (good_trials, poor_trials): (
                 Vec<&rustuna_core::trial::PersistedTrial>,
                 Vec<&rustuna_core::trial::PersistedTrial>,
-            ) = if self.split_cache.contains_key(&split_cache_key) {
-                let (good_nums, poor_nums) = self.split_cache.get(&split_cache_key).unwrap();
+            ) = if let Some((good_nums, poor_nums)) = cached_split {
                 let good_trials = complete_trials
                     .iter()
                     .copied()
@@ -193,10 +203,14 @@ impl TpeSampler {
                 );
                 let good_nums = good_trials.iter().map(|t| t.number).collect();
                 let poor_nums = poor_trials.iter().map(|t| t.number).collect();
-                // We only cache the most recent split
-                self.split_cache.clear();
-                self.split_cache
-                    .insert(split_cache_key, (good_nums, poor_nums));
+                let mut split_cache = self.split_cache.write().map_err(|e| {
+                    Error::with_reason(
+                        ErrorKind::SamplerError,
+                        format!("Failed to acquire split cache guard: {e}"),
+                    )
+                })?;
+                split_cache.clear();
+                split_cache.insert(split_cache_key, (good_nums, poor_nums));
                 (good_trials, poor_trials)
             };
             // Multi-objective: uniform weights for l(x) (below), recency ramp for g(x) (above),
@@ -208,7 +222,15 @@ impl TpeSampler {
         };
 
         let n_ei_candidates = 24;
-        let samples_good = pe_good.sample(&mut self.rng, n_ei_candidates);
+        let samples_good = {
+            let mut rng = self.rng.lock().map_err(|e| {
+                Error::with_reason(
+                    ErrorKind::SamplerError,
+                    format!("Failed to acquire RNG guard: {e}"),
+                )
+            })?;
+            pe_good.sample(&mut rng, n_ei_candidates)
+        };
         let mut best_idx = 0usize;
         let mut best_val = f64::NEG_INFINITY;
         for (i, s) in samples_good.iter().enumerate() {
@@ -401,7 +423,7 @@ impl TpeSampler {
 
 impl Sampler for TpeSampler {
     fn sample_independent(
-        &mut self,
+        &self,
         ctx: &Context,
         storage: Arc<RwLock<dyn Storage>>,
         name: &str,
@@ -440,7 +462,7 @@ impl Sampler for TpeSampler {
     }
 
     fn sample_joint(
-        &mut self,
+        &self,
         ctx: &Context,
         storage: Arc<RwLock<dyn Storage>>,
         search_space: &HashMap<String, Distribution>,
@@ -470,7 +492,7 @@ impl Sampler for TpeSampler {
     }
 
     fn after_trial(
-        &mut self,
+        &self,
         _ctx: &Context,
         _storage: Arc<RwLock<dyn Storage>>,
         _state_values: &TrialStateValues,

--- a/rustuna_sampler/src/tpe/sampler.rs
+++ b/rustuna_sampler/src/tpe/sampler.rs
@@ -1,4 +1,3 @@
-use core::panic;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
@@ -40,6 +39,13 @@ impl Default for TpeConfig {
 
 type SplitKey = (Vec<u32>, usize);
 type SplitValue = (Vec<u32>, Vec<u32>);
+
+struct TpeObservation {
+    trial_number: u32,
+    values: Vec<f64>,
+    params: Vec<Option<f64>>,
+}
+
 /// Tree-structured Parzen Estimator sampler.
 ///
 /// This sampler is the Rustuna counterpart of Optuna's `TPESampler`.
@@ -146,7 +152,7 @@ impl TpeSampler {
     fn sample(
         &self,
         ctx: &Context,
-        complete_trials: &[&rustuna_core::trial::PersistedTrial],
+        complete_trials: &[TpeObservation],
         search_space: &HashMap<String, Distribution>,
     ) -> Result<HashMap<String, f64>> {
         let is_multi_objective = ctx.directions.len() > 1;
@@ -166,7 +172,7 @@ impl TpeSampler {
             let gamma = Self::gamma_for_multi_objective(complete_trials.len());
             let complete_trial_numbers = complete_trials
                 .iter()
-                .map(|t| t.number)
+                .map(|t| t.trial_number)
                 .collect::<Vec<u32>>();
             let split_cache_key = (complete_trial_numbers.clone(), gamma);
             let cached_split = self
@@ -180,39 +186,46 @@ impl TpeSampler {
                 })?
                 .get(&split_cache_key)
                 .cloned();
-            let (good_trials, poor_trials): (
-                Vec<&rustuna_core::trial::PersistedTrial>,
-                Vec<&rustuna_core::trial::PersistedTrial>,
-            ) = if let Some((good_nums, poor_nums)) = cached_split {
-                let good_trials = complete_trials
-                    .iter()
-                    .copied()
-                    .filter(|t| good_nums.contains(&t.number))
-                    .collect::<Vec<_>>();
-                let poor_trials = complete_trials
-                    .iter()
-                    .copied()
-                    .filter(|t| poor_nums.contains(&t.number))
-                    .collect::<Vec<_>>();
-                (good_trials, poor_trials)
-            } else {
-                let (good_trials, poor_trials) = multi_objective::split_trials_for_multi_objective(
-                    complete_trials,
-                    directions,
-                    gamma,
-                );
-                let good_nums = good_trials.iter().map(|t| t.number).collect();
-                let poor_nums = poor_trials.iter().map(|t| t.number).collect();
-                let mut split_cache = self.split_cache.write().map_err(|e| {
-                    Error::with_reason(
-                        ErrorKind::SamplerError,
-                        format!("Failed to acquire split cache guard: {e}"),
-                    )
-                })?;
-                split_cache.clear();
-                split_cache.insert(split_cache_key, (good_nums, poor_nums));
-                (good_trials, poor_trials)
-            };
+            let (good_trials, poor_trials): (Vec<&TpeObservation>, Vec<&TpeObservation>) =
+                if let Some((good_nums, poor_nums)) = cached_split {
+                    let good_trials = complete_trials
+                        .iter()
+                        .filter(|t| good_nums.contains(&t.trial_number))
+                        .collect::<Vec<_>>();
+                    let poor_trials = complete_trials
+                        .iter()
+                        .filter(|t| poor_nums.contains(&t.trial_number))
+                        .collect::<Vec<_>>();
+                    (good_trials, poor_trials)
+                } else {
+                    let values = complete_trials
+                        .iter()
+                        .map(|trial| trial.values.as_slice())
+                        .collect::<Vec<_>>();
+                    let (good_indices, poor_indices) =
+                        multi_objective::split_observation_indices_for_multi_objective(
+                            &values, directions, gamma,
+                        );
+                    let good_trials = good_indices
+                        .into_iter()
+                        .map(|i| &complete_trials[i])
+                        .collect::<Vec<_>>();
+                    let poor_trials = poor_indices
+                        .into_iter()
+                        .map(|i| &complete_trials[i])
+                        .collect::<Vec<_>>();
+                    let good_nums = good_trials.iter().map(|t| t.trial_number).collect();
+                    let poor_nums = poor_trials.iter().map(|t| t.trial_number).collect();
+                    let mut split_cache = self.split_cache.write().map_err(|e| {
+                        Error::with_reason(
+                            ErrorKind::SamplerError,
+                            format!("Failed to acquire split cache guard: {e}"),
+                        )
+                    })?;
+                    split_cache.clear();
+                    split_cache.insert(split_cache_key, (good_nums, poor_nums));
+                    (good_trials, poor_trials)
+                };
             // Multi-objective: uniform weights for l(x) (below), recency ramp for g(x) (above),
             // matching Optuna's multi-objective TPE.
             (
@@ -244,13 +257,10 @@ impl TpeSampler {
     }
 
     fn split_trials_for_single_objective<'a>(
-        trials: &[&'a rustuna_core::trial::PersistedTrial],
+        trials: &'a [TpeObservation],
         direction: &Direction,
         gamma: usize,
-    ) -> (
-        Vec<&'a rustuna_core::trial::PersistedTrial>,
-        Vec<&'a rustuna_core::trial::PersistedTrial>,
-    ) {
+    ) -> (Vec<&'a TpeObservation>, Vec<&'a TpeObservation>) {
         let n = trials.len();
         assert!(
             gamma <= n,
@@ -261,14 +271,11 @@ impl TpeSampler {
             return (Vec::new(), Vec::new());
         }
         if gamma == n {
-            return (trials.to_vec(), Vec::new());
+            return (trials.iter().collect(), Vec::new());
         }
 
-        fn value_for(t: &rustuna_core::trial::PersistedTrial) -> f64 {
-            match &t.state_values {
-                TrialStateValues::Complete(v) => v[0],
-                _ => panic!("Unexpected non-complete trial found during TPE sampling"),
-            }
+        fn value_for(t: &TpeObservation) -> f64 {
+            t.values[0]
         }
 
         // NaN trials must always land in `poor_trials` regardless of `direction`:
@@ -280,8 +287,8 @@ impl TpeSampler {
         // directions.
         let mut idx: Vec<usize> = (0..n).collect();
         idx.select_nth_unstable_by(gamma, |&i, &j| {
-            let vi = value_for(trials[i]);
-            let vj = value_for(trials[j]);
+            let vi = value_for(&trials[i]);
+            let vj = value_for(&trials[j]);
             match (vi.is_nan(), vj.is_nan()) {
                 (true, true) => Ordering::Equal,
                 (true, false) => Ordering::Greater,
@@ -301,10 +308,10 @@ impl TpeSampler {
         let mut good_trials = Vec::with_capacity(gamma);
         let mut poor_trials = Vec::with_capacity(n - gamma);
         for &i in idx.iter().take(gamma) {
-            good_trials.push(trials[i]);
+            good_trials.push(&trials[i]);
         }
         for &i in idx.iter().skip(gamma) {
-            poor_trials.push(trials[i]);
+            poor_trials.push(&trials[i]);
         }
         (good_trials, poor_trials)
     }
@@ -319,20 +326,31 @@ impl TpeSampler {
         (0.1 * n as f64).ceil() as usize
     }
 
-    /// Keep only trials whose `Complete` values are fully finite-or-±inf. Trials
-    /// carrying NaN are dropped here, before the `n_startup_trials` gate, so they
-    /// neither inflate `gamma` nor leak into `good_trials`. In the all-NaN /
-    /// finite-count-below-startup case the resulting empty / short list naturally
-    /// falls through to the random sampler via the existing startup gate.
-    fn usable_complete_trials(
+    fn snapshot_usable_complete_trials(
         trials: &[Option<rustuna_core::trial::PersistedTrial>],
-    ) -> Vec<&rustuna_core::trial::PersistedTrial> {
+        search_space: &HashMap<String, Distribution>,
+    ) -> Vec<TpeObservation> {
+        let mut sorted_keys = search_space.keys().collect::<Vec<_>>();
+        sorted_keys.sort();
         trials
             .iter()
             .flatten()
-            .filter(|t| match &t.state_values {
-                TrialStateValues::Complete(v) => !v.iter().any(|x| x.is_nan()),
-                _ => false,
+            .filter_map(|trial| {
+                let TrialStateValues::Complete(values) = &trial.state_values else {
+                    return None;
+                };
+                if values.iter().any(|x| x.is_nan()) {
+                    return None;
+                }
+                let params = sorted_keys
+                    .iter()
+                    .map(|name| trial.internal_params.get(*name).copied())
+                    .collect();
+                Some(TpeObservation {
+                    trial_number: trial.number,
+                    values: values.clone(),
+                    params,
+                })
             })
             .collect()
     }
@@ -366,7 +384,7 @@ impl TpeSampler {
     }
 
     fn build_parzen_estimator(
-        trials: &[&rustuna_core::trial::PersistedTrial],
+        trials: &[&TpeObservation],
         search_space: &HashMap<String, Distribution>,
         recency_ramp: bool,
     ) -> ParzenEstimator {
@@ -381,9 +399,8 @@ impl TpeSampler {
         // Optuna's `default_weights`. (Uniform weights are order-invariant, so sorting is
         // harmless there; the split routines do not preserve chronological order.)
         let mut order: Vec<usize> = (0..n_trials).collect();
-        order.sort_by_key(|&i| trials[i].number);
-        let trials: Vec<&rustuna_core::trial::PersistedTrial> =
-            order.iter().map(|&i| trials[i]).collect();
+        order.sort_by_key(|&i| trials[i].trial_number);
+        let trials = order.iter().map(|&i| trials[i]).collect::<Vec<_>>();
 
         let mut observations_vec: Vec<Vec<f64>> = (0..n_params)
             .map(|_| Vec::with_capacity(n_trials))
@@ -391,9 +408,9 @@ impl TpeSampler {
         let mut active_counts: Vec<u32> = vec![0; n_trials];
 
         for (trial_idx, t) in trials.iter().enumerate() {
-            for (param_idx, key) in sorted_keys.iter().enumerate() {
-                if let Some(&v) = t.internal_params.get(*key) {
-                    observations_vec[param_idx].push(v);
+            for (param_idx, param) in t.params.iter().enumerate() {
+                if let Some(v) = param {
+                    observations_vec[param_idx].push(*v);
                     active_counts[trial_idx] += 1;
                 }
             }
@@ -433,7 +450,8 @@ impl Sampler for TpeSampler {
             return distribution.get_single_value();
         }
 
-        {
+        let search_space = HashMap::from([(name.to_string(), distribution.clone())]);
+        let complete_trials = {
             let mut guard = storage.write().map_err(|e| {
                 Error::with_reason(
                     ErrorKind::Unexpected,
@@ -441,13 +459,11 @@ impl Sampler for TpeSampler {
                 )
             })?;
             let trials = guard.get_trials(ctx.study_id)?;
-            let complete_trials: Vec<&rustuna_core::trial::PersistedTrial> =
-                Self::usable_complete_trials(trials);
-            if complete_trials.len() >= self.n_startup_trials {
-                let search_space = HashMap::from([(name.to_string(), distribution.clone())]);
-                let params = self.sample(ctx, &complete_trials, &search_space)?;
-                return Ok(params[name]);
-            }
+            Self::snapshot_usable_complete_trials(trials, &search_space)
+        };
+        if complete_trials.len() >= self.n_startup_trials {
+            let params = self.sample(ctx, &complete_trials, &search_space)?;
+            return Ok(params[name]);
         }
         self.random_sampler
             .sample_independent(ctx, storage, name, distribution)
@@ -475,15 +491,16 @@ impl Sampler for TpeSampler {
             return Ok(HashMap::new());
         }
 
-        let mut guard = storage.write().map_err(|e| {
-            Error::with_reason(
-                ErrorKind::Unexpected,
-                format!("Failed to acquire storage guard: {e}"),
-            )
-        })?;
-        let trials = guard.get_trials(ctx.study_id)?;
-        let complete_trials: Vec<&rustuna_core::trial::PersistedTrial> =
-            Self::usable_complete_trials(trials);
+        let complete_trials = {
+            let mut guard = storage.write().map_err(|e| {
+                Error::with_reason(
+                    ErrorKind::Unexpected,
+                    format!("Failed to acquire storage guard: {e}"),
+                )
+            })?;
+            let trials = guard.get_trials(ctx.study_id)?;
+            Self::snapshot_usable_complete_trials(trials, search_space)
+        };
         if complete_trials.len() < self.n_startup_trials {
             return Ok(HashMap::new());
         }
@@ -635,7 +652,7 @@ mod tests {
     }
 
     /// When every completed trial is NaN the sampler must not feed NaN observations
-    /// into the Parzen estimator; the entry-side `usable_complete_trials` filter
+    /// into the Parzen estimator; the entry-side snapshot filter
     /// drops NaN trials before the startup gate so the sampler falls back to random
     /// sampling cleanly.
     #[test]


### PR DESCRIPTION
## Summary

1. Make samplers internally synchronized and shareable across threads
  - Change `Sampler` to require `Send + Sync` and receive `&self`
  - Replace `Arc<Mutex<dyn Sampler>>` with `Arc<dyn Sampler>` in `Study` and `Trial`
  - Move synchronization into individual sampler implementations
  - Add a test that shares `RandomSampler` across multiple threads
2. Release storage lock before TPE model construction
  - Introduce lightweight trial snapshots for TPE sampling
  - Release the storage lock before trial splitting, Parzen estimator construction, and candidate evaluation
  - Add an index-based multi-objective observation splitting API

## Performance

```rust
// $ cargo run --release --example tpe_threaded
use std::time::{Duration, Instant};

use rustuna_core::storage::InMemoryStorage;
use rustuna_core::study::{create_study, Direction, Study};
use rustuna_core::Result;
use rustuna_sampler::tpe::TpeSampler;

const N_PARAMS: usize = 40;
const N_TRIALS: usize = 10_000;
const THREAD_COUNTS: &[usize] = &[1, 2, 4, 8];

fn optimize(study: &Study, n_trials: usize) -> Result<()> {
    study.optimize(
        |mut trial| {
            let mut value = 0.0;
            for param_index in 0..N_PARAMS {
                let name = format!("x{param_index}");
                let x = trial.suggest_float(&name, -10.0, 10.0)?;
                value += x * x;
            }
            Ok(vec![value])
        },
        n_trials,
    )
}

fn run(n_threads: usize) -> Result<Duration> {
    let study = create_study(
        "quadratic",
        InMemoryStorage::new(),
        TpeSampler::seed_from_u64(0),
        vec![Direction::Minimize],
    )?;
    let started_at = Instant::now();

    std::thread::scope(|scope| {
        let mut handles = Vec::with_capacity(n_threads);
        for worker_index in 0..n_threads {
            let study = study.clone();
            let n_trials = N_TRIALS / n_threads + usize::from(worker_index < N_TRIALS % n_threads);
            handles.push(scope.spawn(move || optimize(&study, n_trials)));
        }
        for handle in handles {
            handle.join().expect("optimization thread must not panic")?;
        }
        Ok::<(), rustuna_core::Error>(())
    })?;

    assert_eq!(study.get_trials()?.len(), N_TRIALS);
    Ok(started_at.elapsed())
}

fn main() -> Result<()> {
    println!("n_trials={N_TRIALS}, n_params={N_PARAMS}");
    for &n_threads in THREAD_COUNTS {
        let elapsed = run(n_threads)?;
        println!(
            "n_threads={n_threads}, elapsed={:.3}s, trials_per_second={:.1}",
            elapsed.as_secs_f64(),
            N_TRIALS as f64 / elapsed.as_secs_f64()
        );
    }
    Ok(())
}
```

On M4 Pro (10,000 trials, 40 params):

| n_threads | Before | Unwrap `Mutex<>` | Improve TPE Storage Guard |
| --- | ---- | --- | --- |
| 1 | 75.614s | 76.696s | 89.842s |
| 2 | 78.125s | 78.518s | 42.124s |
| 4 | 78.475s | 79.106s | 30.934s |
| 8 | 79.397s | 79.947s | 32.107s |

On Ryzen 7 5800H (5,000 trials, 40 params):

| n_threads | Before | Unwrap `Mutex<>` | Improve TPE Storage Guard |
| --- | ---- | --- | --- |
| 1 | 59.365s | 59.376s | 60.500s |
| 2 | 62.041s | 62.135s | 33.039s |
| 4 | 60.375s | 62.401s | 28.940s |
| 8 | 59.566s | 59.623s | 29.305s |

The previous implementation did not scale beyond one thread. After releasing the storage lock, performance scales up to four threads in this environment.