### PR TITLE
Make `CmaEsSampler` internally synchronized

### DIFF
--- a/rustuna_pyo3/src/sampler/cmaes.rs
+++ b/rustuna_pyo3/src/sampler/cmaes.rs
@@ -25,9 +25,14 @@ use crate::trial::PyTrialState;
 /// generation are reconstructed from completed trials in the storage when the next parameter
 /// configuration is asked, so no bookkeeping is required when a trial finishes.
 pub struct CmaEsSampler {
+    state: Mutex<CmaEsSamplerState>,
+    // TODO(c-bata): Remove this mutex after RandomSampler becomes internally synchronized.
+    random_sampler: Mutex<RandomSampler>,
+}
+
+struct CmaEsSamplerState {
     seed: Option<u64>,
     popsize: Option<usize>,
-    random_sampler: RandomSampler,
     optimizer: Option<Py<PyAny>>,
     population_size: Option<usize>,
     search_space: Option<HashMap<String, Distribution>>,
@@ -35,16 +40,11 @@ pub struct CmaEsSampler {
     solution_trial_ids: Vec<u32>,
 }
 
-impl CmaEsSampler {
-    pub fn new(seed: Option<u64>, popsize: Option<usize>) -> Self {
-        let random_sampler = match seed {
-            Some(seed) => RandomSampler::seed_from_u64(seed),
-            None => RandomSampler::new(),
-        };
+impl CmaEsSamplerState {
+    fn new(seed: Option<u64>, popsize: Option<usize>) -> Self {
         Self {
             seed,
             popsize,
-            random_sampler,
             optimizer: None,
             population_size: None,
             search_space: None,
@@ -126,25 +126,8 @@ impl CmaEsSampler {
             Ok(())
         })
     }
-}
 
-impl Sampler for CmaEsSampler {
-    fn sample_independent(
-        &mut self,
-        ctx: &Context,
-        storage: Arc<RwLock<dyn Storage>>,
-        name: &str,
-        distribution: &Distribution,
-    ) -> Result<f64> {
-        self.random_sampler
-            .sample_independent(ctx, storage, name, distribution)
-    }
-
-    fn support_joint_sampling(&self) -> bool {
-        true
-    }
-
-    fn sample_joint(
+    fn sample(
         &mut self,
         ctx: &Context,
         storage: Arc<RwLock<dyn Storage>>,
@@ -234,6 +217,60 @@ impl Sampler for CmaEsSampler {
             .as_ref()
             .ok_or_else(|| Error::new(ErrorKind::Unexpected))?
             .untransform(&x)
+    }
+}
+
+impl CmaEsSampler {
+    pub fn new(seed: Option<u64>, popsize: Option<usize>) -> Self {
+        let random_sampler = match seed {
+            Some(seed) => RandomSampler::seed_from_u64(seed),
+            None => RandomSampler::new(),
+        };
+        Self {
+            state: Mutex::new(CmaEsSamplerState::new(seed, popsize)),
+            random_sampler: Mutex::new(random_sampler),
+        }
+    }
+}
+
+impl Sampler for CmaEsSampler {
+    fn sample_independent(
+        &mut self,
+        ctx: &Context,
+        storage: Arc<RwLock<dyn Storage>>,
+        name: &str,
+        distribution: &Distribution,
+    ) -> Result<f64> {
+        self.random_sampler
+            .lock()
+            .map_err(|e| {
+                Error::with_reason(
+                    ErrorKind::SamplerError,
+                    format!("Failed to acquire random sampler guard: {e}"),
+                )
+            })?
+            .sample_independent(ctx, storage, name, distribution)
+    }
+
+    fn support_joint_sampling(&self) -> bool {
+        true
+    }
+
+    fn sample_joint(
+        &mut self,
+        ctx: &Context,
+        storage: Arc<RwLock<dyn Storage>>,
+        search_space: &HashMap<String, Distribution>,
+    ) -> Result<HashMap<String, f64>> {
+        self.state
+            .lock()
+            .map_err(|e| {
+                Error::with_reason(
+                    ErrorKind::SamplerError,
+                    format!("Failed to acquire sampler state guard: {e}"),
+                )
+            })?
+            .sample(ctx, storage, search_space)
     }
 }
 

--- a/rustuna_pyo3/tests/sampler_tests/test_cmaes.py
+++ b/rustuna_pyo3/tests/sampler_tests/test_cmaes.py
@@ -1,4 +1,5 @@
 import sys
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -20,6 +21,27 @@ def test_cmaes_sampler() -> None:
     assert all(
         trial.state == rustuna.trial.TrialState.COMPLETE for trial in study.trials
     )
+
+
+def test_cmaes_sampler_samples_independently_from_multiple_threads() -> None:
+    sampler = rustuna.samplers.CmaEsSampler(seed=1)
+    storage = rustuna.storages.InMemoryStorage()
+    study = rustuna.create_study(sampler=sampler, storage=storage)
+    ctx = rustuna.samplers.SamplerContext(
+        study_id=study._study_id,
+        trial_number=0,
+        trial_id=0,
+        directions=study.directions,
+    )
+    distribution = rustuna.distributions.FloatDistribution(-1, 1)
+
+    def sample(_: int) -> float:
+        return sampler.sample_independent(ctx, storage, "x", distribution)
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        values = list(executor.map(sample, range(100)))
+
+    assert all(-1 <= value <= 1 for value in values)
 
 
 def test_cmaes_sampler_with_failed_trials() -> None:


### PR DESCRIPTION
## Summary

Make `CmaEsSampler` internally synchronized
This is a preparatory change for allowing samplers to be shared across threads without wrapping the entire sampler in a mutex (refs #200).

## Changes

- Like #201, this PR wrap all states in CmaEsSampler by `Mutex`.
