### PR TITLE
improve performance of NSGA-II sampler

### DIFF
--- a/rustuna_core/src/study.rs
+++ b/rustuna_core/src/study.rs
@@ -599,12 +599,10 @@ pub fn dominates(values0: &[f64], values1: &[f64], directions: &[Direction]) -> 
 
     let mut equal = true;
     for ((v0, v1), d) in values0.iter().zip(values1).zip(directions) {
-        if *v0 != *v1 {
-            equal = false;
-        }
+        equal &= v0 == v1;
         let v1_dominate_v0 = match d {
-            Direction::Minimize => *v0 > *v1,
-            Direction::Maximize => *v0 < *v1,
+            Direction::Minimize => v0 > v1,
+            Direction::Maximize => v0 < v1,
         };
         if v1_dominate_v0 {
             return false; // Early return

--- a/rustuna_core/src/study.rs
+++ b/rustuna_core/src/study.rs
@@ -591,6 +591,7 @@ pub fn get_pareto_front(study: &Study) -> Result<Vec<u32>> {
 /// Returns whether `values0` dominates `values1` under the given directions.
 /// Validate `values0` and `values1` have the same length and neither of them contains f64::NAN
 /// by `rustuna_core::trial::validate_trials` before calling this function.
+#[inline]
 pub fn dominates(values0: &[f64], values1: &[f64], directions: &[Direction]) -> bool {
     debug_assert_eq!(values0.len(), values1.len());
     debug_assert_eq!(values0.len(), directions.len());

--- a/rustuna_sampler/src/nsgaii.rs
+++ b/rustuna_sampler/src/nsgaii.rs
@@ -439,11 +439,8 @@ fn fast_non_dominated_sort(
     let mut dominated_count = vec![0u32; n];
     let mut dominates_list: Vec<Vec<usize>> = vec![vec![]; n];
 
-    for (i, _) in population_numbers.iter().enumerate() {
-        for (j, _) in population_numbers.iter().enumerate() {
-            if i >= j {
-                continue;
-            }
+    for i in 0..n {
+        for j in (i + 1)..n {
             if constrained_dominates(&population_infos[i], &population_infos[j], &ctx.directions) {
                 dominates_list[i].push(j);
                 dominated_count[j] += 1;


### PR DESCRIPTION
I improved the performance of NSGA-II sampler by enabling cross-crate inlining `dominates` function, which is often called inside `fast_non_dominated_sort`, and removing unnecessary loops inside `fast_non_dominated_sort`.
I checked the performance.

current main
```
Rustuna elapsed=4.224
Rustuna elapsed=4.136
Rustuna elapsed=4.136
```

this PR
```
Rustuna elapsed=3.709
Rustuna elapsed=3.526
Rustuna elapsed=3.588
```

<details>

<summary>
benchmark code
</summary>

```python
import time
import rustuna

n_trials = 10000


def run_optimize():
    def objective(trial: rustuna.Trial) -> tuple[float, float]:
        x = trial.suggest_float("x", -15, 30)
        y = trial.suggest_float("y", -15, 30)

        v0 = 4 * x**2 + 4 * y**2
        v1 = (x - 5) ** 2 + (y - 5) ** 2
        trial.set_constraints({"c0": 1000 - v0})
        return v0, v1

    directions = ["minimize", "minimize"]
    sampler = rustuna.samplers.NSGAIISampler(seed=1)
    study = rustuna.create_study(sampler=sampler, directions=directions)
    study.optimize(objective, n_trials=n_trials)
    return study


def main():
    for _ in range(3):
        start = time.time()
        study = run_optimize()
        elapsed_rustuna = time.time() - start
        assert len(study.get_trials(states=[rustuna.trial.TrialState.COMPLETE])) == n_trials
        print(f"Rustuna\telapsed={elapsed_rustuna:.3f}")

if __name__ == "__main__":
    main()
```

</details>