### PR TITLE
Update minimum supported Python version to 3.11

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rustuna-docs"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 version = "0.1.0"
 
 [dependency-groups]

--- a/rustuna_pyo3/pyproject.toml
+++ b/rustuna_pyo3/pyproject.toml
@@ -6,11 +6,10 @@ build-backend = "maturin"
 name = "rustuna"
 description = "A faster Optuna implementation in Rust"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Summary

* This PR updates the supported minimum Python version to 3.11. See https://devguide.python.org/versions/ for details.
* Remove `PyPy` classifier.