### PR TITLE
Update PyO3 version to 0.29 and enable `bundled` feature on `rusqlite`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 
 [[package]]
+name = "cc"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +62,12 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "foldhash"
@@ -97,15 +113,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,6 +146,7 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -158,15 +166,6 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "nalgebra"
@@ -278,35 +277,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.27.2"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
+checksum = "4688ddedf473e32662b9b067670129a8afb8c18e351482c70d62ba4a88171e8b"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.27.2"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
+checksum = "f41027e41b4bd03f6e60f9f417fe24a6341a6bb744edd62b6f709f2a52ea30e9"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.27.2"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
+checksum = "e591a95526fead067432c3b3a33fc74770b87b1e04e73671090d9c2055a2b327"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -314,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.27.2"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
+checksum = "73225868fc1cd84eef2c3c230ddb91273bf1de46aeb8a4248da76d32a0924a1c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -326,13 +322,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.27.2"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
+checksum = "571575aa3749fa6216757dd47d2a3e7ef360f329a40f0666a9fbd14889024952"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -541,6 +536,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "simba"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,12 +600,6 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "vcpkg"

--- a/rustuna_pyo3/Cargo.toml
+++ b/rustuna_pyo3/Cargo.toml
@@ -13,7 +13,7 @@ name = "rustuna"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.27", features = ["extension-module"] }
+pyo3 = { version = "0.29", features = ["extension-module"] }
 rustuna_core = { workspace = true }
 rustuna_sampler = { workspace = true }
 rustuna_storage = { workspace = true }

--- a/rustuna_pyo3/pyproject.toml
+++ b/rustuna_pyo3/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=1.3,<2.0"]
+requires = ["maturin>=1.14,<2.0"]
 build-backend = "maturin"
 
 [project]

--- a/rustuna_pyo3/src/distribution.rs
+++ b/rustuna_pyo3/src/distribution.rs
@@ -9,7 +9,7 @@ use rustuna_core::attr::{get_category_labels, Attrs, CategoryLabel};
 use rustuna_core::distribution::Distribution;
 
 #[derive(Clone, Debug)]
-#[pyclass(name = "Distribution")]
+#[pyclass(name = "Distribution", from_py_object)]
 #[pyo3(module = "rustuna")]
 pub struct PyDistribution {
     pub distribution: Distribution,

--- a/rustuna_pyo3/src/sampler/cmaes.rs
+++ b/rustuna_pyo3/src/sampler/cmaes.rs
@@ -286,7 +286,7 @@ impl Sampler for CmaEsSampler {
 ///     seed: Random seed for CMA-ES. If `None`, the backend chooses a random seed.
 ///     popsize: CMA-ES population size. If `None`, the backend default is used.
 #[derive(Clone)]
-#[pyclass(name = "CmaEsSampler")]
+#[pyclass(name = "CmaEsSampler", from_py_object)]
 #[pyo3(module = "rustuna")]
 pub struct PyCmaEsSampler {
     pub sampler: Arc<Mutex<dyn Sampler>>,

--- a/rustuna_pyo3/src/sampler/context.rs
+++ b/rustuna_pyo3/src/sampler/context.rs
@@ -5,7 +5,7 @@ use rustuna_core::sampler::Context as SamplerContext;
 use crate::study::PyDirection;
 
 #[derive(Clone)]
-#[pyclass(name = "SamplerContext")]
+#[pyclass(name = "SamplerContext", skip_from_py_object)]
 #[pyo3(module = "rustuna")]
 pub struct PySamplerContext {
     pub(crate) context: SamplerContext,

--- a/rustuna_pyo3/src/sampler/nsgaii.rs
+++ b/rustuna_pyo3/src/sampler/nsgaii.rs
@@ -15,7 +15,7 @@ use crate::sampler::{extract_storage, PySamplerContext};
 use crate::trial::PyTrialState;
 
 #[derive(Clone)]
-#[pyclass(name = "NSGAIISampler")]
+#[pyclass(name = "NSGAIISampler", from_py_object)]
 #[pyo3(module = "rustuna")]
 pub struct PyNSGAIISampler {
     pub sampler: Arc<Mutex<NSGAIISampler>>,

--- a/rustuna_pyo3/src/sampler/random.rs
+++ b/rustuna_pyo3/src/sampler/random.rs
@@ -11,7 +11,7 @@ use crate::sampler::{extract_storage, PySamplerContext};
 use crate::trial::PyTrialState;
 
 #[derive(Clone)]
-#[pyclass(name = "RandomSampler")]
+#[pyclass(name = "RandomSampler", from_py_object)]
 #[pyo3(module = "rustuna")]
 pub struct PyRandomSampler {
     pub sampler: Arc<Mutex<RandomSampler>>,

--- a/rustuna_pyo3/src/sampler/tpe.rs
+++ b/rustuna_pyo3/src/sampler/tpe.rs
@@ -14,7 +14,7 @@ use crate::sampler::{extract_storage, PySamplerContext};
 use crate::trial::PyTrialState;
 
 #[derive(Clone)]
-#[pyclass(name = "TPESampler")]
+#[pyclass(name = "TPESampler", from_py_object)]
 #[pyo3(module = "rustuna")]
 pub struct PyTpeSampler {
     pub sampler: Arc<Mutex<TpeSampler>>,

--- a/rustuna_pyo3/src/storage/cached.rs
+++ b/rustuna_pyo3/src/storage/cached.rs
@@ -404,7 +404,7 @@ impl CachedStorageBackend for PyCachedStorageBackend {
 }
 
 #[derive(Clone)]
-#[pyclass(name = "CachedStorage")]
+#[pyclass(name = "CachedStorage", from_py_object)]
 #[pyo3(module = "rustuna")]
 pub struct PyCachedStorage {
     pub(crate) binding: StorageBinding,

--- a/rustuna_pyo3/src/storage/in_memory.rs
+++ b/rustuna_pyo3/src/storage/in_memory.rs
@@ -10,7 +10,7 @@ use crate::study::{PyDirection, PyPersistedStudy};
 use crate::trial::{PyPersistedTrial, PyTrialState};
 
 #[derive(Clone)]
-#[pyclass(name = "InMemoryStorage")]
+#[pyclass(name = "InMemoryStorage", from_py_object)]
 #[pyo3(module = "rustuna")]
 pub struct PyInMemoryStorage {
     pub(crate) binding: StorageBinding,

--- a/rustuna_pyo3/src/storage/journal.rs
+++ b/rustuna_pyo3/src/storage/journal.rs
@@ -13,7 +13,7 @@ use crate::study::{PyDirection, PyPersistedStudy};
 use crate::trial::{PyPersistedTrial, PyTrialState};
 
 #[derive(Clone)]
-#[pyclass(name = "JournalFileStorage")]
+#[pyclass(name = "JournalFileStorage", from_py_object)]
 #[pyo3(module = "rustuna")]
 pub struct PyJournalFileStorage {
     pub(crate) binding: StorageBinding,

--- a/rustuna_pyo3/src/storage/sqlite3.rs
+++ b/rustuna_pyo3/src/storage/sqlite3.rs
@@ -13,7 +13,7 @@ use crate::study::{PyDirection, PyPersistedStudy};
 use crate::trial::{PyPersistedTrial, PyTrialState};
 
 #[derive(Clone)]
-#[pyclass(name = "SQLite3Storage")]
+#[pyclass(name = "SQLite3Storage", from_py_object)]
 #[pyo3(module = "rustuna")]
 pub struct PySQLite3Storage {
     pub(crate) binding: StorageBinding,

--- a/rustuna_pyo3/src/storage/to_python.rs
+++ b/rustuna_pyo3/src/storage/to_python.rs
@@ -10,7 +10,7 @@ use crate::study::{PyDirection, PyPersistedStudy};
 use crate::trial::{PyPersistedTrial, PyTrialState};
 
 #[derive(Clone)]
-#[pyclass(name = "ToPythonStorage")]
+#[pyclass(name = "ToPythonStorage", skip_from_py_object)]
 #[pyo3(module = "rustuna")]
 pub struct ToPythonStorage {
     pub(crate) binding: StorageBinding,

--- a/rustuna_pyo3/src/storage/to_rust.rs
+++ b/rustuna_pyo3/src/storage/to_rust.rs
@@ -788,7 +788,7 @@ impl Storage for ToRustStorage {
 }
 
 #[derive(Clone)]
-#[pyclass(name = "ToRustStorage")]
+#[pyclass(name = "ToRustStorage", from_py_object)]
 #[pyo3(module = "rustuna")]
 pub struct PyToRustStorage {
     pub storage: Arc<RwLock<ToRustStorage>>,

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -741,7 +741,7 @@ impl PyStudy {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-#[pyclass(name = "StudyDirection", eq, eq_int)]
+#[pyclass(name = "StudyDirection", eq, eq_int, from_py_object)]
 #[pyo3(module = "rustuna")]
 pub enum PyDirection {
     #[pyo3(name = "MINIMIZE")]
@@ -866,7 +866,7 @@ pub fn py_copy_study(
 }
 
 #[derive(Debug, Clone)]
-#[pyclass(name = "PersistedStudy")]
+#[pyclass(name = "PersistedStudy", skip_from_py_object)]
 #[pyo3(module = "rustuna", get_all, set_all)]
 pub struct PyPersistedStudy {
     pub id: u32,

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -174,7 +174,7 @@ pub fn py_create_trial(
 }
 
 #[derive(Clone, Debug, PartialEq)]
-#[pyclass(name = "TrialState", eq, eq_int)]
+#[pyclass(name = "TrialState", eq, eq_int, from_py_object)]
 #[pyo3(module = "rustuna")]
 #[allow(clippy::upper_case_acronyms)]
 pub enum PyTrialState {

--- a/rustuna_pyo3/src/trial_queue/directory.rs
+++ b/rustuna_pyo3/src/trial_queue/directory.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, RwLock};
 use crate::exception::err_to_exceptions;
 
 #[derive(Clone)]
-#[pyclass(name = "DirectoryTrialQueue")]
+#[pyclass(name = "DirectoryTrialQueue", from_py_object)]
 #[pyo3(module = "rustuna")]
 pub struct PyDirectoryTrialQueue {
     pub queue: Arc<RwLock<DirectoryTrialQueue>>,

--- a/rustuna_pyo3/src/trial_queue/inmemory.rs
+++ b/rustuna_pyo3/src/trial_queue/inmemory.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, RwLock};
 use crate::exception::err_to_exceptions;
 
 #[derive(Clone)]
-#[pyclass(name = "InMemoryTrialQueue")]
+#[pyclass(name = "InMemoryTrialQueue", from_py_object)]
 #[pyo3(module = "rustuna")]
 pub struct PyInMemoryTrialQueue {
     pub queue: Arc<RwLock<InMemoryTrialQueue>>,

--- a/rustuna_pyo3/src/trial_queue/sqlite3.rs
+++ b/rustuna_pyo3/src/trial_queue/sqlite3.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, RwLock};
 use crate::exception::err_to_exceptions;
 
 #[derive(Clone)]
-#[pyclass(name = "SQLite3TrialQueue")]
+#[pyclass(name = "SQLite3TrialQueue", from_py_object)]
 #[pyo3(module = "rustuna")]
 pub struct PySQLite3TrialQueue {
     pub queue: Arc<RwLock<SQLite3TrialQueue>>,

--- a/rustuna_storage/Cargo.toml
+++ b/rustuna_storage/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 
 [dependencies]
 rustuna_core = { workspace = true }
-rusqlite = "0.37.0"
+rusqlite = { version = "0.37.0", features = ["bundled"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
 libc = "0.2"


### PR DESCRIPTION
## Summary

I applied following changes to prepare the release workflow:

- [Bump the PyO3 version up to 0.29](https://github.com/optuna/rustuna/commit/64c35367e5413f84855d6c55c3fb537e6bdb8442) to enable `abi3t-py315`.
- [Enable bundled feature on rusqlite](https://github.com/optuna/rustuna/commit/d84df800a48b8da639da63b753e06b634e5d083a) for the static link to the `libsqlite3`.