### PR TITLE
Preserve trial datetimes when syncing ToRustStorage cache

### DIFF
--- a/rustuna_core/src/storage.rs
+++ b/rustuna_core/src/storage.rs
@@ -267,6 +267,25 @@ impl InMemoryStorage {
         }
         discarded_if_none(trials[number as usize].as_ref())
     }
+
+    /// Updates trial timestamps when synchronizing an external storage into the cache.
+    pub fn set_trial_datetimes(
+        &mut self,
+        trial_id: u32,
+        datetime_start: Option<String>,
+        datetime_complete: Option<String>,
+    ) -> Result<()> {
+        let (study_id, trial_number) =
+            get_study_id_trial_number_by_trial_id(&self.trial_id_number_map, trial_id)?;
+        let trial = discarded_if_none(
+            get_mut_trials_by_study_id(&mut self.trials, study_id)?
+                .get_mut(trial_number as usize)
+                .and_then(Option::as_mut),
+        )?;
+        trial.datetime_start = datetime_start;
+        trial.datetime_complete = datetime_complete;
+        Ok(())
+    }
 }
 fn get_trials_by_study_id(
     all_trials: &HashMap<u32, Vec<Option<PersistedTrial>>>,

--- a/rustuna_pyo3/src/storage/to_rust.rs
+++ b/rustuna_pyo3/src/storage/to_rust.rs
@@ -365,6 +365,11 @@ impl ToRustStorage {
 
         let cache_trial = self.cache.get_trial(src_trial.id)?.clone();
         if cache_trial.is_finished() {
+            self.cache.set_trial_datetimes(
+                src_trial.id,
+                src_trial.datetime_start.clone(),
+                src_trial.datetime_complete.clone(),
+            )?;
             return Ok(());
         }
         self.cache
@@ -389,6 +394,11 @@ impl ToRustStorage {
             self.cache
                 .set_trial_state_values(src_trial.id, src_trial.state_values.clone())?;
         }
+        self.cache.set_trial_datetimes(
+            src_trial.id,
+            src_trial.datetime_start,
+            src_trial.datetime_complete,
+        )?;
         Ok(())
     }
 

--- a/rustuna_pyo3/tests/storage_tests/test_to_rustuna_storage.py
+++ b/rustuna_pyo3/tests/storage_tests/test_to_rustuna_storage.py
@@ -59,6 +59,22 @@ def test_resume_optimization():
     assert len(optuna_study.trials) == 30
 
 
+def test_trial_datetimes_are_preserved_in_rustuna_storage_cache():
+    optuna_storage = optuna.storages.InMemoryStorage()
+    optuna_study = optuna.create_study(storage=optuna_storage)
+    optuna_study.optimize(lambda _: 1.0, n_trials=1)
+
+    rustuna_study = rustuna.load_study(
+        study_name=optuna_study.study_name,
+        storage=ToRustunaStorage(optuna_storage),
+    )
+
+    optuna_trial = optuna_study.trials[0]
+    rustuna_trial = rustuna_study.trials[0]
+    assert rustuna_trial.datetime_start == optuna_trial.datetime_start
+    assert rustuna_trial.datetime_complete == optuna_trial.datetime_complete
+
+
 def _run_optimize(sqlite3_filepath: str) -> None:
     optuna_storage = optuna.storages.RDBStorage(f"sqlite:///{sqlite3_filepath}")
     storage = ToRustunaStorage(optuna_storage)


### PR DESCRIPTION
## Motivation

`ToRustStorage` maintains an `InMemoryStorage` cache because Rustuna's `Storage` trait returns references to Rust-owned trial data.

However, the external Python storage can be updated without going through `ToRustStorage`. For example:

- Optuna APIs update the storage directly when using `ToOptunaSampler`.
- Another process or worker completes a trial in the shared storage.
- An existing Optuna study is loaded through `ToRustunaStorage`.
- Rustuna's importance APIs read trials from an Optuna-backed storage.

In these cases, `ToRustStorage` synchronizes the external trial into its cache.

Before this change, the synchronization did not preserve trial timestamps:

- Newly inserted cached trials started with `datetime_start = None`.
- `set_trial_state_values` generated `datetime_complete` using the current time instead of the source value.
- Already-finished cached trials returned early and skipped timestamp synchronization.

As a result, code using historical trial durations could either fail or produce incorrect values. For example:

```python
target=lambda trial: trial.duration.total_seconds()
```

in the importance API could raise an error because trial.duration was None, or could use the synchronization time instead of the actual completion time. This PR fixes these issues.

  ## Changes

  - Add InMemoryStorage::set_trial_datetimes for synchronizing timestamps into an existing cached trial.
  - Preserve source timestamps in both the finished-trial and unfinished-trial synchronization paths.
  - Add a regression test covering datetime preservation in ToRustStorage.