### PR TITLE
Add constraints handling to TPE-sampler

### DIFF
--- a/rustuna_core/src/multi_objective/split.rs
+++ b/rustuna_core/src/multi_objective/split.rs
@@ -39,17 +39,17 @@ pub fn split_trials_for_multi_objective<'a>(
     }
 
     let feasible_gamma = gamma.min(feasible_trials.len());
-    let (mut feasible_good_trials, mut feasible_poor_trials) =
+    let (mut good_trials, mut poor_trials) =
         split_feasible_trials_for_multi_objective(&feasible_trials, directions, feasible_gamma);
-    let infeasible_gamma = gamma.saturating_sub(feasible_good_trials.len());
+    let infeasible_gamma = gamma.saturating_sub(good_trials.len());
     let (infeasible_good_trials, infeasible_poor_trials) =
         split_infeasible_trials_for_multi_objective(
             &mut infeasible_trial_with_violations,
             infeasible_gamma,
         );
-    feasible_good_trials.extend(infeasible_good_trials);
-    feasible_poor_trials.extend(infeasible_poor_trials);
-    Ok((feasible_good_trials, feasible_poor_trials))
+    good_trials.extend(infeasible_good_trials);
+    poor_trials.extend(infeasible_poor_trials);
+    Ok((good_trials, poor_trials))
 }
 
 fn split_feasible_trials_for_multi_objective<'a>(

--- a/rustuna_core/src/multi_objective/split.rs
+++ b/rustuna_core/src/multi_objective/split.rs
@@ -38,11 +38,15 @@ pub fn split_trials_for_multi_objective<'a>(
         }
     }
 
+    let feasible_gamma = gamma.min(feasible_trials.len());
     let (mut feasible_good_trials, mut feasible_poor_trials) =
-        split_feasible_trials_for_multi_objective(&feasible_trials, directions, gamma);
-    let gamma = gamma.saturating_sub(feasible_good_trials.len());
+        split_feasible_trials_for_multi_objective(&feasible_trials, directions, feasible_gamma);
+    let infeasible_gamma = gamma.saturating_sub(feasible_good_trials.len());
     let (infeasible_good_trials, infeasible_poor_trials) =
-        split_infeasible_trials_for_multi_objective(&mut infeasible_trial_with_violations, gamma);
+        split_infeasible_trials_for_multi_objective(
+            &mut infeasible_trial_with_violations,
+            infeasible_gamma,
+        );
     feasible_good_trials.extend(infeasible_good_trials);
     feasible_poor_trials.extend(infeasible_poor_trials);
     Ok((feasible_good_trials, feasible_poor_trials))
@@ -217,6 +221,10 @@ fn split_infeasible_trials_for_multi_objective<'a>(
     gamma: usize,
 ) -> (Vec<&'a PersistedTrial>, Vec<&'a PersistedTrial>) {
     let n = trial_with_violations.len();
+    assert!(
+        gamma <= n,
+        "gamma must be less than or equal to the number of trials"
+    );
     if n == 0 {
         return (Vec::new(), Vec::new());
     }

--- a/rustuna_core/src/multi_objective/split.rs
+++ b/rustuna_core/src/multi_objective/split.rs
@@ -3,10 +3,52 @@ use std::collections::{HashMap, HashSet};
 use crate::multi_objective::{hssp, nds};
 use crate::study::Direction;
 use crate::trial::{PersistedTrial, TrialStateValues};
+use crate::Result;
 
 const EPS: f64 = 1e-12;
 
 pub fn split_trials_for_multi_objective<'a>(
+    trials: &[&'a PersistedTrial],
+    directions: &[Direction],
+    gamma: usize,
+) -> Result<(Vec<&'a PersistedTrial>, Vec<&'a PersistedTrial>)> {
+    let n = trials.len();
+    assert!(
+        gamma <= n,
+        "gamma must be less than or equal to the number of trials"
+    );
+
+    if n == 0 {
+        return Ok((Vec::new(), Vec::new()));
+    }
+    if gamma == n {
+        return Ok((trials.to_vec(), Vec::new()));
+    }
+
+    let mut feasible_trials = Vec::new();
+    let mut infeasible_trial_with_violations = Vec::new();
+    for &trial in trials {
+        let constraints = trial.constraints()?;
+        let feasible = constraints.values().all(|x| *x <= 0.0);
+        if feasible {
+            feasible_trials.push(trial);
+        } else {
+            let violation = constraints.values().filter(|&x| *x > 0.0).sum::<f64>();
+            infeasible_trial_with_violations.push((trial, violation));
+        }
+    }
+
+    let (mut feasible_good_trials, mut feasible_poor_trials) =
+        split_feasible_trials_for_multi_objective(&feasible_trials, directions, gamma);
+    let gamma = gamma.saturating_sub(feasible_good_trials.len());
+    let (infeasible_good_trials, infeasible_poor_trials) =
+        split_infeasible_trials_for_multi_objective(&mut infeasible_trial_with_violations, gamma);
+    feasible_good_trials.extend(infeasible_good_trials);
+    feasible_poor_trials.extend(infeasible_poor_trials);
+    Ok((feasible_good_trials, feasible_poor_trials))
+}
+
+fn split_feasible_trials_for_multi_objective<'a>(
     trials: &[&'a PersistedTrial],
     directions: &[Direction],
     gamma: usize,
@@ -19,6 +61,9 @@ pub fn split_trials_for_multi_objective<'a>(
 
     if n == 0 {
         return (Vec::new(), Vec::new());
+    }
+    if gamma == 0 {
+        return (Vec::new(), trials.to_vec());
     }
     if gamma == n {
         return (trials.to_vec(), Vec::new());
@@ -165,4 +210,37 @@ pub fn split_trials_for_multi_objective<'a>(
     }
 
     (good_trials, poor_trials)
+}
+
+fn split_infeasible_trials_for_multi_objective<'a>(
+    trial_with_violations: &mut [(&'a PersistedTrial, f64)],
+    gamma: usize,
+) -> (Vec<&'a PersistedTrial>, Vec<&'a PersistedTrial>) {
+    let n = trial_with_violations.len();
+    if n == 0 {
+        return (Vec::new(), Vec::new());
+    }
+    if gamma == 0 {
+        return (
+            Vec::new(),
+            trial_with_violations.iter().map(|&(t, _)| t).collect(),
+        );
+    }
+    if gamma == n {
+        return (
+            trial_with_violations.iter().map(|&(t, _)| t).collect(),
+            Vec::new(),
+        );
+    }
+
+    trial_with_violations.select_nth_unstable_by(gamma, |(_, violation_i), (_, violation_j)| {
+        violation_i
+            .partial_cmp(violation_j)
+            .expect("constraint is non-Nan value")
+    });
+    let (good_trials, poor_trials) = trial_with_violations.split_at(gamma);
+    (
+        good_trials.iter().map(|&(t, _)| t).collect(),
+        poor_trials.iter().map(|&(t, _)| t).collect(),
+    )
 }

--- a/rustuna_core/src/multi_objective/split.rs
+++ b/rustuna_core/src/multi_objective/split.rs
@@ -66,9 +66,6 @@ fn split_feasible_trials_for_multi_objective<'a>(
     if n == 0 {
         return (Vec::new(), Vec::new());
     }
-    if gamma == 0 {
-        return (Vec::new(), trials.to_vec());
-    }
     if gamma == n {
         return (trials.to_vec(), Vec::new());
     }

--- a/rustuna_core/src/trial.rs
+++ b/rustuna_core/src/trial.rs
@@ -287,6 +287,12 @@ impl Trial {
     pub fn set_constraints(&mut self, constraints: HashMap<String, f64>) -> Result<()> {
         let mut attrs = Attrs::with_capacity(constraints.len());
         for (key, value) in constraints {
+            if value.is_nan() {
+                return Err(Error::with_reason(
+                    ErrorKind::Unexpected,
+                    format!("The constraint value of '{key}' should not be NaN."),
+                ));
+            }
             let key_with_constraint_prefix = format!("{}:{}", CONSTRAINTS_KEY, key);
             attrs.insert(
                 AttrKey::System(key_with_constraint_prefix.as_str().into()),
@@ -664,6 +670,25 @@ mod tests {
 
         let constraints = trials[0].constraints()?;
         assert_eq!(constraints, HashMap::from([(String::from("c0"), 10.0)]));
+        Ok(())
+    }
+
+    #[test]
+    fn test_set_constraints_with_nan() -> Result<()> {
+        let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
+        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
+        let directions = vec![Direction::Minimize];
+        let study = create_study_with_arc("dummy", storage.clone(), sampler, directions)?;
+
+        let mut trial = study.ask()?;
+        let _ = trial.suggest_float("x", -10.0, 10.0)?;
+        let constraints = HashMap::from([(String::from("c0"), f64::NAN)]);
+        let err = trial.set_constraints(constraints).unwrap_err();
+        assert!(matches!(err.kind, ErrorKind::Unexpected));
+
+        let _ = study.tell(trial.number, TrialStateValues::Complete(vec![0.0]));
+        let trials = study.get_trials()?;
+        assert!(trials[0].constraints()?.is_empty());
         Ok(())
     }
 }

--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -169,8 +169,22 @@ class Trial:
     def set_constraints(self, constraints: dict[str, float]) -> None:
         """Set constraints to the trial.
 
+        A trial is feasible when every one of its constraint values is zero or less, and
+        infeasible when any of them is positive. How the infeasible trials are compared
+        with each other is up to the sampler; see the documentation of each sampler that
+        supports constraints, such as [TPESampler][rustuna.samplers.TPESampler] and
+        [NSGAIISampler][rustuna.samplers.NSGAIISampler].
+
+        Calling this method again overwrites the values of the constraint names given in
+        `constraints`, and leaves the other names untouched.
+
         Args:
-            constraints: A dictionary object.
+            constraints: A dictionary object mapping each constraint name to its value.
+
+        Raises:
+            RuntimeError: If any of the values is NaN. The constraints are validated
+                before anything is stored, so none of the values in `constraints` is
+                recorded in that case.
         """
 
 class AttrsDictView(Mapping[str, str]):
@@ -1259,6 +1273,20 @@ class TPESampler:
         jointly, which is reported to outperform independent sampling. See
         [BOHB: Robust and Efficient Hyperparameter Optimization at Scale](http://proceedings.mlr.press/v80/falkner18a.html)
         for more details.
+
+    Note:
+        Constraints set via [Trial.set_constraints][rustuna.trial.Trial.set_constraints] are
+        taken into account when the observations are split into the good half, which `l(x)`
+        is fitted to, and the poor half, which `g(x)` is fitted to. Feasible trials, whose
+        constraint values are all zero or less, are always preferred over infeasible ones,
+        so the good half is filled with the best feasible trials first, and only the
+        remaining slots, if any, are filled with infeasible trials. The infeasible trials
+        are ordered by their total violation, i.e. the sum of their positive constraint
+        values, and the ones violating the constraints the least come first.
+
+        Which feasible trials are the best is decided exactly as in the unconstrained case:
+        by the objective value for single-objective studies, and by the non-domination rank
+        and the hypervolume contribution for multi-objective ones.
     """
     def __init__(
         self,
@@ -1324,6 +1352,21 @@ class NSGAIISampler:
         crossover_prob: Probability of performing crossover between two parents. Defaults to `0.9`.
         swapping_prob: Probability of swapping each parameter value during crossover.
             Defaults to `0.5`.
+
+    Note:
+        Constraints set via [Trial.set_constraints][rustuna.trial.Trial.set_constraints] are
+        taken into account by replacing the dominance relation of the non-dominated sort with
+        constrained domination. A trial is feasible when its constraint values are all zero
+        or less, and its total violation is the sum of its positive constraint values. A
+        trial `a` constrained-dominates a trial `b` when
+
+        * both are feasible and `a` dominates `b` in the usual Pareto sense,
+        * `a` is feasible and `b` is not, or
+        * both are infeasible and the total violation of `a` is smaller than that of `b`.
+
+        Feasible trials therefore always form the earlier fronts, and the infeasible ones
+        are ranked by how much they violate the constraints. The crowding distance used
+        within a front is unchanged.
     """
     def __init__(
         self,

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -367,9 +367,9 @@ impl PyTrial {
         let constraints: HashMap<String, f64> =
             Python::attach(|py| constraints.bind(py).extract())?;
 
-        self.trial.set_constraints(constraints).map_err(|e| {
-            PyRuntimeError::new_err(format!("Fialed to set constraints: {:?}", e.kind))
-        })?;
+        self.trial
+            .set_constraints(constraints)
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to set constraints: {e}")))?;
 
         Ok(())
     }

--- a/rustuna_sampler/src/tpe/sampler.rs
+++ b/rustuna_sampler/src/tpe/sampler.rs
@@ -876,4 +876,34 @@ mod tests {
             "Optimization should complete without panicking."
         );
     }
+
+    #[test]
+    fn test_multi_objective_constraint_with_few_feasible_trials() {
+        // Only a tiny slice of the search space is feasible, so the number of feasible
+        // trials stays below gamma. The good half then has to be padded with the least
+        // violating infeasible trials.
+        let storage = InMemoryStorage::new();
+        let directions = vec![Direction::Minimize, Direction::Minimize];
+        let study = create_study(
+            "multi-objective-constraint",
+            storage,
+            TpeSampler::seed_from_u64(0),
+            directions,
+        )
+        .unwrap();
+        let result = study.optimize(
+            |mut t| {
+                let x = t.suggest_float("x", 0.0, 1.0)?;
+                let y = t.suggest_float("y", 0.0, 1.0)?;
+                let c0 = if x < 0.02 { -1.0 } else { 1.0 };
+                t.set_constraints(HashMap::from([(String::from("c0"), c0)]))?;
+                Ok(vec![x, y])
+            },
+            200,
+        );
+        assert!(
+            result.is_ok(),
+            "Optimization should complete without panicking."
+        );
+    }
 }

--- a/rustuna_sampler/src/tpe/sampler.rs
+++ b/rustuna_sampler/src/tpe/sampler.rs
@@ -155,7 +155,7 @@ impl TpeSampler {
             let gamma = Self::gamma_for_single_objective(complete_trials.len());
             let direction: &Direction = &ctx.directions[0];
             let (good_trials, poor_trials) =
-                Self::split_trials_for_single_objective(complete_trials, direction, gamma);
+                Self::split_trials_for_single_objective(complete_trials, direction, gamma)?;
             // Single-objective: recency ramp for both l(x) and g(x) (Optuna default_weights).
             (
                 Self::build_parzen_estimator(&good_trials, search_space, true),
@@ -225,10 +225,10 @@ impl TpeSampler {
         trials: &[&'a rustuna_core::trial::PersistedTrial],
         direction: &Direction,
         gamma: usize,
-    ) -> (
+    ) -> Result<(
         Vec<&'a rustuna_core::trial::PersistedTrial>,
         Vec<&'a rustuna_core::trial::PersistedTrial>,
-    ) {
+    )> {
         let n = trials.len();
         assert!(
             gamma <= n,
@@ -236,10 +236,10 @@ impl TpeSampler {
         );
 
         if n == 0 {
-            return (Vec::new(), Vec::new());
+            return Ok((Vec::new(), Vec::new()));
         }
         if gamma == n {
-            return (trials.to_vec(), Vec::new());
+            return Ok((trials.to_vec(), Vec::new()));
         }
 
         fn value_for(t: &rustuna_core::trial::PersistedTrial) -> f64 {
@@ -249,6 +249,21 @@ impl TpeSampler {
             }
         }
 
+        // Since `usable_complete_trials` already filtered non-completed trials,
+        // we only check feasiblity of `trial`.
+        let feasibles_violations = trials
+            .iter()
+            .map(|trial| {
+                let constraints = trial.constraints()?;
+                let feasible = constraints.values().all(|x| !x.is_nan() && *x <= 0.0);
+                let violation = constraints
+                    .values()
+                    .filter(|&x| !x.is_nan() && *x > 0.0)
+                    .sum::<f64>();
+                Ok((feasible, violation))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
         // NaN trials must always land in `poor_trials` regardless of `direction`:
         // a NaN observation is a failed evaluation, and feeding it into the Parzen
         // estimator would corrupt the `good_trials` model. Using
@@ -257,7 +272,7 @@ impl TpeSampler {
         // good half. Treat NaN as strictly worse than any finite value, in both
         // directions.
         let mut idx: Vec<usize> = (0..n).collect();
-        idx.select_nth_unstable_by(gamma, |&i, &j| {
+        let compare_feasibles = |i, j| {
             let vi = value_for(trials[i]);
             let vj = value_for(trials[j]);
             match (vi.is_nan(), vj.is_nan()) {
@@ -274,6 +289,18 @@ impl TpeSampler {
                     }
                 }
             }
+        };
+        idx.select_nth_unstable_by(gamma, |&i, &j| {
+            let (feasible_i, violation_i) = feasibles_violations[i];
+            let (feasible_j, violation_j) = feasibles_violations[j];
+            match (feasible_i, feasible_j) {
+                (true, true) => compare_feasibles(i, j),
+                (true, false) => Ordering::Less,
+                (false, true) => Ordering::Greater,
+                (false, false) => violation_i
+                    .partial_cmp(&violation_j)
+                    .expect("NaN is already filtered."),
+            }
         });
 
         let mut good_trials = Vec::with_capacity(gamma);
@@ -284,7 +311,7 @@ impl TpeSampler {
         for &i in idx.iter().skip(gamma) {
             poor_trials.push(trials[i]);
         }
-        (good_trials, poor_trials)
+        Ok((good_trials, poor_trials))
     }
 
     fn gamma_for_single_objective(n: usize) -> usize {
@@ -825,5 +852,31 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_single_objective_constraint() {
+        let storage = InMemoryStorage::new();
+        let directions = vec![Direction::Minimize];
+        let study = create_study(
+            "single-objective-constraint",
+            storage,
+            TpeSampler::seed_from_u64(0),
+            directions,
+        )
+        .unwrap();
+        let result = study.optimize(
+            |mut t| {
+                let x = t.suggest_float("x", -15.0, 15.0)?;
+                let c0 = x.powi(2) - 8.0;
+                t.set_constraints(HashMap::from([(String::from("c0"), c0)]))?;
+                Ok(vec![x.powi(2)])
+            },
+            100,
+        );
+        assert!(
+            result.is_ok(),
+            "Optimization should complete without panicking."
+        );
     }
 }

--- a/rustuna_sampler/src/tpe/sampler.rs
+++ b/rustuna_sampler/src/tpe/sampler.rs
@@ -190,7 +190,7 @@ impl TpeSampler {
                     complete_trials,
                     directions,
                     gamma,
-                );
+                )?;
                 let good_nums = good_trials.iter().map(|t| t.number).collect();
                 let poor_nums = poor_trials.iter().map(|t| t.number).collect();
                 // We only cache the most recent split
@@ -255,11 +255,8 @@ impl TpeSampler {
             .iter()
             .map(|trial| {
                 let constraints = trial.constraints()?;
-                let feasible = constraints.values().all(|x| !x.is_nan() && *x <= 0.0);
-                let violation = constraints
-                    .values()
-                    .filter(|&x| !x.is_nan() && *x > 0.0)
-                    .sum::<f64>();
+                let feasible = constraints.values().all(|x| *x <= 0.0);
+                let violation = constraints.values().filter(|&x| *x > 0.0).sum::<f64>();
                 Ok((feasible, violation))
             })
             .collect::<Result<Vec<_>>>()?;


### PR DESCRIPTION
I added constraints handling to TPE-sampler for single objective and multi objectives.
To handle constraints, I change the algorithm to make good, poor trial sets, according to Optuna.
We compare trials as follows:
+ feasible trial is always better than infeasible trial.
+ Two infeasible trials are compared by total sum of violations (smaller is better.).
+ Two feasible trials are compared same as before.

Moreover,
+ I added docs about it (and `NSGA-II sampler, set_constraints`).
+ I changed to raise an error when some constraint value inputted to `set_constraints` are f64::NAN.

I checked the performance by C2-DTLZ2 problem

<details>
<summary>
benchmark code (C2-DTLZ2)
</summary>

```python
"""Benchmark the Rustuna TPE sampler on the constrained DTLZ (C2-DTLZ2) problem.

The script runs the Rustuna TPE sampler with and without constraints on the
`benchmarks/dtlz_constrained` problem from OptunaHub, and reports

* the Pareto front of every run,
* the hypervolume history averaged over the repeats, and
* the ratio of feasible trials.

Usage:
    python benchmark_cdtlz_tpe.py --n-trials 10000 --n-repeat 2

Pass `--include-optuna` to add Optuna's own `TPESampler(constraints_func=...)`
as a reference baseline.
"""

from __future__ import annotations

import argparse
import os
import time
from typing import Any, Callable, Sequence

import matplotlib

matplotlib.use("Agg")

import matplotlib.pyplot as plt
import numpy as np
import optuna
import optuna.visualization.matplotlib
import optunahub
from matplotlib.figure import Figure
from optuna.trial import FrozenTrial
from optuna.visualization._hypervolume_history import (
    _get_hypervolume_history_info,
    _HypervolumeHistoryInfo,
)
from optuna.visualization._pareto_front import _ParetoFrontInfo
from optuna.visualization.matplotlib import plot_pareto_front

import rustuna
from rustuna.converter import ToOptunaStudy

WITH_CONSTRAINTS = "Rustuna TPE with Constraints"
WITHOUT_CONSTRAINTS = "Rustuna TPE without Constraints"
OPTUNA_BASELINE = "Optuna TPE with Constraints"

COLORS = {
    WITH_CONSTRAINTS: "#0072B2",
    WITHOUT_CONSTRAINTS: "#CC79A7",
    OPTUNA_BASELINE: "#E69F00",
}


def _get_pareto_front_2d_patched(
    info: _ParetoFrontInfo,
    xlim: tuple[float | None, float | None] | None = None,
    ylim: tuple[float | None, float | None] | None = None,
) -> Figure:
    fig, ax = plt.subplots()

    ax.set_xlabel(info.target_names[info.axis_order[0]], fontsize=13, fontproperties=None)
    ax.set_ylabel(info.target_names[info.axis_order[1]], fontsize=13, fontproperties=None)

    if len(info.infeasible_trials_with_values) > 0:
        ax.scatter(
            x=[values[info.axis_order[0]] for _, values in info.infeasible_trials_with_values],
            y=[values[info.axis_order[1]] for _, values in info.infeasible_trials_with_values],
            color="#2B2B2B",
            facecolors="#6E6E6E",
            alpha=0.7,
            label="Infeasible Trial",
            s=1,
        )
    if len(info.non_best_trials_with_values) > 0:
        ax.scatter(
            x=[values[info.axis_order[0]] for _, values in info.non_best_trials_with_values],
            y=[values[info.axis_order[1]] for _, values in info.non_best_trials_with_values],
            color="#963269",
            facecolors="#CC79A7",
            alpha=0.7,
            label="Feasible Trial",
            s=1,
        )
    if len(info.best_trials_with_values) > 0:
        ax.scatter(
            x=[values[info.axis_order[0]] for _, values in info.best_trials_with_values],
            y=[values[info.axis_order[1]] for _, values in info.best_trials_with_values],
            color="#1348AC",
            facecolors="#0072B2",
            alpha=0.7,
            label="Best Trial",
            s=1,
        )

    if info.non_best_trials_with_values is not None and ax.has_data():
        ax.legend(handlelength=0.8, handletextpad=0.4)

    ax.grid(which="major", color="gray", linestyle="--", linewidth=0.5)
    ax.tick_params(labelsize=12)

    if xlim is not None:
        ax.set_xlim(*xlim)
    if ylim is not None:
        ax.set_ylim(*ylim)

    return fig


def plot_results(
    data: dict[str, list[np.ndarray]],
    trial_numbers: np.ndarray,
    ylabel: str,
    trial_min: int | None = None,
    xlim: tuple[float, float] | None = None,
    ylim: tuple[float, float] | None = None,
    figsize: tuple[float, float] | None = None,
    legend_loc: str = "lower right",
) -> Figure:
    """Plot the mean +- standard error over the repeats of every sampler."""

    fig, ax = plt.subplots(figsize=figsize)
    for name, runs in data.items():
        values = np.asarray(runs, dtype=float)
        mean = np.mean(values, axis=0)
        # Standard error of the mean over the repeats.
        std = np.std(values, axis=0) / np.sqrt(values.shape[0])
        ax.plot(
            trial_numbers[trial_min:],
            mean[trial_min:],
            COLORS[name],
            label=name,
            linewidth=1.0,
            markevery=8,
        )
        ax.fill_between(
            trial_numbers[trial_min:],
            (mean - std)[trial_min:],
            (mean + std)[trial_min:],
            alpha=0.2,
            color=COLORS[name],
        )

    ax.legend(loc=legend_loc, fontsize=12, prop=None)
    ax.set_xlabel("Number of Trials", fontsize=13, fontproperties=None)
    ax.set_ylabel(ylabel, fontsize=13, fontproperties=None)
    ax.grid(which="major", color="gray", linestyle="--", linewidth=0.5)
    ax.tick_params(labelsize=12)

    if xlim is not None:
        ax.set_xlim(*xlim)
    if ylim is not None:
        ax.set_ylim(*ylim)
    return fig


def cumulative_feasible_ratio(study: optuna.Study) -> np.ndarray:
    """Return the ratio of feasible trials among the first `i + 1` trials."""

    trials = study.get_trials(deepcopy=False)
    ratios = np.empty(len(trials), dtype=float)
    count = 0
    for i, trial in enumerate(trials):
        constraints = trial.constraints
        assert len(constraints) > 0, "The trial has no constraint value."
        if all(value <= 0.0 for value in constraints.values()):
            count += 1
        ratios[i] = count / (i + 1)
    return ratios


def plot_single_feasible_ratio(ratios: np.ndarray, path: str) -> None:
    fig, ax = plt.subplots()
    ax.plot(ratios, color="#0072B2", linewidth=1.0)
    ax.set_xlabel("Number of Trials", fontsize=13)
    ax.set_ylabel("Ratio of Feasible Trials", fontsize=13)
    ax.set_ylim(0.0, 1.0)
    ax.grid(which="major", color="gray", linestyle="--", linewidth=0.5)
    ax.tick_params(labelsize=12)
    fig.savefig(path, bbox_inches="tight", dpi=300)
    plt.close(fig)


def make_objective(
    problem: Any, set_constraints: bool
) -> Callable[[rustuna.Trial], list[float]]:
    def objective(trial: rustuna.Trial) -> list[float]:
        params = {
            name: trial.suggest_float(
                name,
                distribution.low,
                distribution.high,
                step=distribution.step,
                log=distribution.log,
            )
            for name, distribution in problem.search_space.items()
        }

        if set_constraints:
            # C2-DTLZ2 has a single constraint, so this stores c1. The same mapping
            # also handles benchmark variants returning c2, c3, ... values.
            trial.set_constraints(
                {
                    f"c{i}": float(value)
                    for i, value in enumerate(problem.evaluate_constraints(params), start=1)
                }
            )

        return [float(value) for value in problem.evaluate(params)]

    return objective


def run_rustuna_with_constraints(
    problem: Any, directions: list[str], seed: int, n_trials: int
) -> optuna.Study:
    sampler = rustuna.samplers.TPESampler(seed=seed)
    study = rustuna.create_study(
        sampler=sampler,
        study_name=f"Rustuna-TPE-with-Constraints-with-seed={seed}",
        directions=directions,
    )
    study.optimize(make_objective(problem, set_constraints=True), n_trials=n_trials)
    return ToOptunaStudy(study)


def run_rustuna_without_constraints(
    problem: Any, directions: list[str], seed: int, n_trials: int
) -> optuna.Study:
    sampler = rustuna.samplers.TPESampler(seed=seed)
    rustuna_study = rustuna.create_study(
        sampler=sampler,
        study_name=f"Rustuna-TPE-without-Constraints-with-seed={seed}",
        directions=directions,
    )
    rustuna_study.optimize(make_objective(problem, set_constraints=False), n_trials=n_trials)

    # The sampler ignored the constraints, but the Pareto front, the hypervolume and
    # the feasible ratio are all defined in terms of them, so attach them afterwards.
    study = optuna.create_study(
        study_name=f"Rustuna-TPE-without-Constraints-with-seed={seed}",
        directions=directions,
    )
    for trial in ToOptunaStudy(rustuna_study).get_trials(deepcopy=True):
        assert len(trial.constraints) == 0
        constraints = problem.evaluate_constraints(trial.params)
        assert len(constraints) != 0
        for j, value in enumerate(constraints, start=1):
            trial.set_constraint(f"c{j}", float(value))
        study.add_trial(trial)
    return study


def run_optuna_baseline(
    problem: Any, directions: list[str], seed: int, n_trials: int
) -> optuna.Study:
    def constraints_func(trial: FrozenTrial) -> Sequence[float]:
        return [float(value) for value in problem.evaluate_constraints(trial.params)]

    def objective(trial: optuna.Trial) -> list[float]:
        params = {
            name: trial.suggest_float(
                name,
                distribution.low,
                distribution.high,
                step=distribution.step,
                log=distribution.log,
            )
            for name, distribution in problem.search_space.items()
        }
        return [float(value) for value in problem.evaluate(params)]

    sampler = optuna.samplers.TPESampler(seed=seed, constraints_func=constraints_func)
    study = optuna.create_study(
        sampler=sampler,
        study_name=f"Optuna-TPE-with-Constraints-with-seed={seed}",
        directions=directions,
    )
    study.optimize(objective, n_trials=n_trials)
    return study


def parse_args() -> argparse.Namespace:
    parser = argparse.ArgumentParser(description=__doc__)
    parser.add_argument("--n-trials", type=int, default=10000)
    parser.add_argument("--n-repeat", type=int, default=2)
    parser.add_argument("--n-objectives", type=int, default=2)
    parser.add_argument("--dimension", type=int, default=3)
    parser.add_argument("--function-id", type=int, default=2)
    parser.add_argument("--constraint-type", type=int, default=2)
    parser.add_argument("--reference-point", type=float, default=2.0)
    parser.add_argument("--outdir", type=str, default="benchmark_cdtlz_tpe_results")
    parser.add_argument(
        "--include-optuna",
        action="store_true",
        help="Also run Optuna's own TPESampler with constraints_func as a baseline.",
    )
    return parser.parse_args()


def main() -> None:
    args = parse_args()
    os.makedirs(args.outdir, exist_ok=True)
    optuna.logging.set_verbosity(optuna.logging.WARNING)

    optuna.visualization.matplotlib._pareto_front._get_pareto_front_2d = (
        lambda info: _get_pareto_front_2d_patched(info, xlim=(None, 2.0), ylim=(None, 2.0))
    )

    # https://hub.optuna.org/benchmarks/dtlz_constrained/
    cdtlz = optunahub.load_module("benchmarks/dtlz_constrained")
    problem = cdtlz.Problem(
        n_objectives=args.n_objectives,
        dimension=args.dimension,
        function_id=args.function_id,
        constraint_type=args.constraint_type,
    )

    # Problem.directions contains Optuna's StudyDirection values. Rustuna accepts
    # direction strings (or Rustuna's own StudyDirection values), so convert them.
    directions = [
        "maximize" if direction == optuna.study.StudyDirection.MAXIMIZE else "minimize"
        for direction in problem.directions
    ]

    runners: dict[str, Callable[[int], optuna.Study]] = {
        WITH_CONSTRAINTS: lambda seed: run_rustuna_with_constraints(
            problem, directions, seed, args.n_trials
        ),
        WITHOUT_CONSTRAINTS: lambda seed: run_rustuna_without_constraints(
            problem, directions, seed, args.n_trials
        ),
    }
    if args.include_optuna:
        runners[OPTUNA_BASELINE] = lambda seed: run_optuna_baseline(
            problem, directions, seed, args.n_trials
        )

    reference_point = np.array([args.reference_point] * args.n_objectives, dtype=float)
    hypervolumes: dict[str, list[np.ndarray]] = {name: [] for name in runners}
    feasible_ratios: dict[str, list[np.ndarray]] = {name: [] for name in runners}
    trial_numbers: np.ndarray | None = None

    for name, runner in runners.items():
        for seed in range(args.n_repeat):
            start = time.time()
            study = runner(seed)
            elapsed = time.time() - start

            slug = f"{name.replace(' ', '-')}-with-seed={seed}"
            fig = plot_pareto_front(study)
            fig.savefig(
                os.path.join(args.outdir, f"{slug}_pareto_front.png"),
                bbox_inches="tight",
                dpi=300,
            )
            plt.close(fig)

            ratios = cumulative_feasible_ratio(study)
            plot_single_feasible_ratio(
                ratios, os.path.join(args.outdir, f"{slug}_feasible_ratio.png")
            )
            feasible_ratios[name].append(ratios)

            info: _HypervolumeHistoryInfo = _get_hypervolume_history_info(study, reference_point)
            hypervolumes[name].append(np.asarray(info.values, dtype=float))
            if trial_numbers is None:
                trial_numbers = np.asarray(info.trial_numbers, dtype=float)

            print(
                f"{name} (seed={seed}): {elapsed:.1f}s, "
                f"final hypervolume={info.values[-1]:.4f}, "
                f"feasible ratio={ratios[-1]:.4f}",
                flush=True,
            )

    assert trial_numbers is not None
    fig = plot_results(
        hypervolumes,
        trial_numbers,
        ylabel="Hypervolume",
        xlim=(6, args.n_trials + 4),
        trial_min=10,
        figsize=(7.5, 4),
    )
    fig.savefig(os.path.join(args.outdir, "hypervolume.png"), bbox_inches="tight", dpi=300)
    plt.close(fig)

    fig = plot_results(
        feasible_ratios,
        trial_numbers,
        ylabel="Ratio of Feasible Trials",
        xlim=(6, args.n_trials + 4),
        ylim=(0.0, 1.05),
        trial_min=10,
        figsize=(7.5, 4),
        legend_loc="lower right",
    )
    fig.savefig(os.path.join(args.outdir, "feasible_ratio.png"), bbox_inches="tight", dpi=300)
    plt.close(fig)

    print(f"Saved the figures to {os.path.abspath(args.outdir)}")


if __name__ == "__main__":
    main()

```

</details>

+ feasible ratio
<img width="2040" height="1134" alt="feasible_ratio" src="https://github.com/user-attachments/assets/01d46ea1-1630-4e67-af50-00a75b4efb9b" />
+ hyper volume history
<img width="2040" height="1134" alt="hypervolume" src="https://github.com/user-attachments/assets/1d4123cc-bc3b-4e76-b171-b284bd8f9a50" />
+ Parate front *With* constraints
<img width="1816" height="1337" alt="Rustuna-TPE-with-Constraints-with-seed=0_pareto_front" src="https://github.com/user-attachments/assets/61f6b49a-268e-43fc-87eb-0a5c0f8189f5" />
+ Parate front *Without* constraints
<img width="1816" height="1337" alt="Rustuna-TPE-without-Constraints-with-seed=0_pareto_front" src="https://github.com/user-attachments/assets/a69c64f5-c408-44b1-9d9b-5e0ff032fd48" />

I compared 
<details>
<summary>
benchmark code (speed)
</summary>

```python

import time

import rustuna

N_TRIALS = 1000


def objective(trial: rustuna.Trial) -> float:
    x = trial.suggest_float("x", -5, 5)
    y = trial.suggest_float("y", -5, 5)
    return x**2 + y**2


def objective_with_constraints(trial: rustuna.Trial) -> float:
    x = trial.suggest_float("x", -5, 5)
    y = trial.suggest_float("y", -5, 5)
    trial.set_constraints({"c0": x + y})
    return x**2 + y**2


def measure(name, objective_func):
    study = rustuna.create_study(
        sampler=rustuna.samplers.TPESampler(seed=0),
        study_name=name,
        directions=["minimize"],
    )
    start = time.perf_counter()
    study.optimize(objective_func, n_trials=N_TRIALS)
    elapsed = time.perf_counter() - start
    print(f"{name}: {elapsed:.3f} s ({1e3 * elapsed / N_TRIALS:.3f} ms/trial)")


def main():
    print(f"rustuna: {rustuna._rustuna.__file__}")
    print(f"n_trials={N_TRIALS}")
    for _ in range(3):
        measure("without constraints", objective)
    for _ in range(3):
        measure("with constraints", objective_with_constraints)


if __name__ == "__main__":
    main()
```

</details>

main
```
n_trials=1000
without constraints: 0.102 s (0.102 ms/trial)
without constraints: 0.100 s (0.100 ms/trial)
without constraints: 0.100 s (0.100 ms/trial)
with constraints: 0.101 s (0.101 ms/trial)
with constraints: 0.102 s (0.102 ms/trial)
with constraints: 0.101 s (0.101 ms/trial)
```

This PR
```
n_trials=1000
without constraints: 0.108 s (0.108 ms/trial)
without constraints: 0.105 s (0.105 ms/trial)
without constraints: 0.106 s (0.106 ms/trial)
with constraints: 0.135 s (0.135 ms/trial)
with constraints: 0.135 s (0.135 ms/trial)
with constraints: 0.135 s (0.135 ms/trial)
```

The performance decrease with constrains (0.135 compared to 0.105) is almost due to the `constraints` method.