### PR TITLE
fix: fall back from empty joint search space

### DIFF
--- a/rustuna_sampler/src/tpe/sampler.rs
+++ b/rustuna_sampler/src/tpe/sampler.rs
@@ -452,6 +452,12 @@ impl Sampler for TpeSampler {
         if !multivariate {
             return Ok(HashMap::new());
         }
+        // A dynamic search space may have no parameters in common across completed
+        // trials. In that case, let each parameter fall back to independent sampling
+        // instead of trying to build a Parzen estimator with no observations.
+        if search_space.is_empty() {
+            return Ok(HashMap::new());
+        }
 
         let mut guard = storage.write().map_err(|e| {
             Error::with_reason(
@@ -541,6 +547,36 @@ mod tests {
             .unwrap();
         let best_trial_number = get_best_trial(&study);
         assert!(best_trial_number.is_ok());
+    }
+
+    #[test]
+    fn test_dynamic_float_range_falls_back_to_independent_sampling() {
+        let storage = InMemoryStorage::new();
+        let directions = vec![Direction::Minimize];
+        let sampler = TpeSampler::from_config(TpeConfig {
+            multivariate: None,
+            n_startup_trials: 2,
+            seed: Some(42),
+        });
+        let study = create_study("dynamic-float-range", storage, sampler, directions).unwrap();
+
+        study
+            .optimize(
+                |mut t| {
+                    let x = if t.number % 2 == 0 {
+                        t.suggest_float("x", 0.0, 1.0)?
+                    } else {
+                        t.suggest_float("x", 0.5, 1.0)?
+                    };
+                    assert!((0.0..=1.0).contains(&x));
+                    if t.number % 2 == 1 {
+                        assert!(x >= 0.5);
+                    }
+                    Ok(vec![(x - 0.75).powi(2)])
+                },
+                6,
+            )
+            .unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Motivation & Changes

Fix a panic that occurs when TPE encounters a dynamic search space.

When the same parameter is suggested with different ranges across trials, for example:

```python
if trial.number % 2 == 0:
    trial.suggest_float("x", 0, 1)
else:
    trial.suggest_float("x", 0.5, 1)
```

`x` is removed from Rustuna's joint search space because the distributions are not identical. However, TPE still attempted to build a Parzen estimator with an empty search space, causing an assertion failure due to mismatched observation and weight counts.

- Return an empty result from `sample_joint` when the joint search space is empty.
- Let the corresponding parameters fall back to independent sampling.

This matches Optuna's handling of dynamic search spaces.