### PR TITLE
Make samplers internally synchronized and shareable across threads

### DIFF
--- a/rustuna_core/src/sampler.rs
+++ b/rustuna_core/src/sampler.rs
@@ -34,14 +34,17 @@ pub struct Context {
 /// at the beginning of a trial with the inferred joint search space. Parameters not returned from
 /// that method, or all parameters when joint sampling is disabled, fall back to
 /// [`Sampler::sample_independent`].
-pub trait Sampler: Send {
+///
+/// A sampler can be shared by multiple optimization threads. Implementations must synchronize
+/// mutable state internally and keep immutable sampling work outside critical sections.
+pub trait Sampler: Send + Sync {
     /// Samples a single parameter independently.
     ///
     /// This method is used for parameters that are not covered by joint sampling. It is suitable
     /// for samplers such as random search or univariate TPE that decide each parameter
     /// separately.
     fn sample_independent(
-        &mut self,
+        &self,
         ctx: &Context,
         storage: Arc<RwLock<dyn Storage>>,
         name: &str,
@@ -57,7 +60,7 @@ pub trait Sampler: Send {
     /// This is the Rustuna counterpart of Optuna's `sample_relative`. The input search space is
     /// inferred from previously observed compatible parameters in the study.
     fn sample_joint(
-        &mut self,
+        &self,
         ctx: &Context,
         storage: Arc<RwLock<dyn Storage>>,
         search_space: &HashMap<String, Distribution>,
@@ -67,7 +70,7 @@ pub trait Sampler: Send {
     /// This corresponds to Optuna's `after_trial` hook. Rustuna calls it after the objective
     /// function returns and before the finalized state is written to storage.
     fn after_trial(
-        &mut self,
+        &self,
         _ctx: &Context,
         _storage: Arc<RwLock<dyn Storage>>,
         _state_values: &TrialStateValues,
@@ -161,7 +164,7 @@ fn sample_int_with_step(rng: &mut StdRng, low: i64, high: i64, step: i64, log: b
 
 impl Sampler for RandomSampler {
     fn sample_independent(
-        &mut self,
+        &self,
         _ctx: &Context,
         _storage: Arc<RwLock<dyn Storage>>,
         _name: &str,
@@ -178,7 +181,6 @@ impl Sampler for RandomSampler {
                 format!("Failed to acquire RNG guard: {e}"),
             )
         })?;
-
         match distribution {
             Distribution::Float {
                 low,
@@ -210,7 +212,7 @@ impl Sampler for RandomSampler {
     }
 
     fn sample_joint(
-        &mut self,
+        &self,
         _ctx: &Context,
         _storage: Arc<RwLock<dyn Storage>>,
         _search_space: &HashMap<String, Distribution>,
@@ -219,7 +221,7 @@ impl Sampler for RandomSampler {
     }
 
     fn after_trial(
-        &mut self,
+        &self,
         _ctx: &Context,
         _storage: Arc<RwLock<dyn Storage>>,
         _state_values: &TrialStateValues,
@@ -231,6 +233,7 @@ impl Sampler for RandomSampler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::thread;
 
     use crate::storage::InMemoryStorage;
     use crate::study::create_study;
@@ -241,7 +244,7 @@ mod tests {
     }
     impl Sampler for DummyJointSampler {
         fn sample_independent(
-            &mut self,
+            &self,
             _ctx: &Context,
             _storage: Arc<RwLock<dyn Storage>>,
             _name: &str,
@@ -255,7 +258,7 @@ mod tests {
         }
 
         fn sample_joint(
-            &mut self,
+            &self,
             _ctx: &Context,
             _storage: Arc<RwLock<dyn Storage>>,
             _search_space: &HashMap<String, Distribution>,
@@ -264,7 +267,7 @@ mod tests {
         }
 
         fn after_trial(
-            &mut self,
+            &self,
             _ctx: &Context,
             _storage: Arc<RwLock<dyn Storage>>,
             _state_values: &TrialStateValues,
@@ -277,6 +280,43 @@ mod tests {
         let x = t.suggest_float("x", -10.0, 10.0)?;
         let y = t.suggest_float("y", -10.0, 10.0)?;
         Ok(vec![x * x + y * y])
+    }
+
+    #[test]
+    fn random_sampler_can_be_shared_between_threads() -> Result<()> {
+        let sampler: Arc<dyn Sampler> = Arc::new(RandomSampler::seed_from_u64(0));
+        let storage: Arc<RwLock<dyn Storage>> = Arc::new(RwLock::new(InMemoryStorage::new()));
+        let distribution = Distribution::new_float(-1.0, 1.0, None, false);
+        let mut handles = Vec::new();
+
+        for thread_id in 0..4 {
+            let sampler = Arc::clone(&sampler);
+            let storage = Arc::clone(&storage);
+            let distribution = distribution.clone();
+            handles.push(thread::spawn(move || -> Result<()> {
+                for trial_number in 0..100 {
+                    let ctx = Context {
+                        study_id: 0,
+                        directions: vec![Direction::Minimize],
+                        trial_number,
+                        trial_id: thread_id * 100 + trial_number,
+                    };
+                    let value = sampler.sample_independent(
+                        &ctx,
+                        Arc::clone(&storage),
+                        "x",
+                        &distribution,
+                    )?;
+                    assert!((-1.0..1.0).contains(&value));
+                }
+                Ok(())
+            }));
+        }
+
+        for handle in handles {
+            handle.join().expect("sampling thread must not panic")?;
+        }
+        Ok(())
     }
 
     #[test]

--- a/rustuna_core/src/study.rs
+++ b/rustuna_core/src/study.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, RwLock};
 
 use crate::attr::{extract_fixed_params, fixed_params_to_attrs, AttrKey, Attrs, CategoryLabel};
 use crate::distribution::Distribution;
@@ -10,7 +10,7 @@ use crate::trial_queue::{InMemoryTrialQueue, TrialQueue};
 use crate::{Error, ErrorKind, Result};
 
 /// Creates a study backed by the given storage and sampler.
-pub fn create_study<S: Storage + Send + Sync + 'static, T: Sampler + Send + 'static>(
+pub fn create_study<S: Storage + Send + Sync + 'static, T: Sampler + 'static>(
     study_name: &str,
     mut storage: S,
     sampler: T,
@@ -18,7 +18,7 @@ pub fn create_study<S: Storage + Send + Sync + 'static, T: Sampler + Send + 'sta
 ) -> Result<Study> {
     let study_id = storage.create_new_study(study_name, directions.clone())?.id;
     let storage = Arc::new(RwLock::new(storage));
-    let sampler: Arc<Mutex<dyn Sampler>> = Arc::new(Mutex::new(sampler));
+    let sampler: Arc<dyn Sampler> = Arc::new(sampler);
     let queue = Arc::new(RwLock::new(InMemoryTrialQueue::new()));
     Ok(Study::new(
         study_id,
@@ -34,7 +34,7 @@ pub fn create_study<S: Storage + Send + Sync + 'static, T: Sampler + Send + 'sta
 pub fn create_study_with_arc(
     study_name: &str,
     storage: Arc<RwLock<dyn Storage>>,
-    sampler: Arc<Mutex<dyn Sampler>>,
+    sampler: Arc<dyn Sampler>,
     directions: Vec<Direction>,
 ) -> Result<Study> {
     let mut guard = storage.write().map_err(|e| {
@@ -69,7 +69,7 @@ pub struct Study {
     pub name: String,
     pub directions: Vec<Direction>,
     pub storage: Arc<RwLock<dyn Storage>>,
-    pub sampler: Arc<Mutex<dyn Sampler>>,
+    pub sampler: Arc<dyn Sampler>,
     pub queue: Arc<RwLock<dyn TrialQueue>>,
 }
 impl Study {
@@ -79,7 +79,7 @@ impl Study {
         name: String,
         directions: Vec<Direction>,
         storage: Arc<RwLock<dyn Storage>>,
-        sampler: Arc<Mutex<dyn Sampler>>,
+        sampler: Arc<dyn Sampler>,
         queue: Arc<RwLock<dyn TrialQueue>>,
     ) -> Self {
         Study {
@@ -96,7 +96,7 @@ impl Study {
     pub fn from_id(
         id: u32,
         storage: Arc<RwLock<dyn Storage>>,
-        sampler: Arc<Mutex<dyn Sampler>>,
+        sampler: Arc<dyn Sampler>,
     ) -> Result<Self> {
         let mut guard = storage.write().map_err(|e| {
             Error::with_reason(
@@ -116,7 +116,7 @@ impl Study {
     pub fn from_name(
         name: String,
         storage: Arc<RwLock<dyn Storage>>,
-        sampler: Arc<Mutex<dyn Sampler>>,
+        sampler: Arc<dyn Sampler>,
     ) -> Result<Self> {
         let mut guard = storage.write().map_err(|e| {
             Error::with_reason(
@@ -221,46 +221,40 @@ impl Study {
                 )
             };
 
-        let sampler = Arc::clone(&self.sampler);
-        let mut guard = sampler.lock().map_err(|e| {
-            Error::with_reason(
-                ErrorKind::Unexpected,
-                format!("Failed to acquire a sampler guard: {e}"),
-            )
-        })?;
-        let joint_params: HashMap<String, (Distribution, f64)> = if guard.support_joint_sampling() {
-            let joint_search_space = self
-                .storage
-                .write()
-                .map_err(|e| {
-                    Error::with_reason(
-                        ErrorKind::Unexpected,
-                        format!("Failed to acquire a storage guard: {e}"),
-                    )
-                })?
-                .get_joint_search_space(self.id)?;
+        let joint_params: HashMap<String, (Distribution, f64)> =
+            if self.sampler.support_joint_sampling() {
+                let joint_search_space = self
+                    .storage
+                    .write()
+                    .map_err(|e| {
+                        Error::with_reason(
+                            ErrorKind::Unexpected,
+                            format!("Failed to acquire a storage guard: {e}"),
+                        )
+                    })?
+                    .get_joint_search_space(self.id)?;
 
-            let ctx = SamplerContext {
-                study_id: self.id,
-                trial_number,
-                trial_id,
-                directions: self.directions.clone(),
-            };
-            let params = guard.sample_joint(&ctx, self.storage.clone(), &joint_search_space)?;
-            let mut joint_params = HashMap::new();
-            for (name, param_value) in params {
-                if !joint_search_space.contains_key(&name) {
-                    continue;
+                let ctx = SamplerContext {
+                    study_id: self.id,
+                    trial_number,
+                    trial_id,
+                    directions: self.directions.clone(),
+                };
+                let params =
+                    self.sampler
+                        .sample_joint(&ctx, self.storage.clone(), &joint_search_space)?;
+                let mut joint_params = HashMap::new();
+                for (name, param_value) in params {
+                    if !joint_search_space.contains_key(&name) {
+                        continue;
+                    }
+                    let distribution = joint_search_space[&name].clone();
+                    joint_params.insert(name, (distribution, param_value));
                 }
-                let distribution = joint_search_space[&name].clone();
-                joint_params.insert(name, (distribution, param_value));
-            }
-            joint_params
-        } else {
-            HashMap::new()
-        };
-
-        drop(guard);
+                joint_params
+            } else {
+                HashMap::new()
+            };
 
         let trial = Trial::new(
             trial_id,
@@ -295,15 +289,9 @@ impl Study {
             trial_number,
             trial_id,
         };
-        let after_trial_result = {
-            let mut sampler_guard = self.sampler.lock().map_err(|e| {
-                Error::with_reason(
-                    ErrorKind::Unexpected,
-                    format!("Failed to acquire a sampler guard: {e}"),
-                )
-            })?;
-            sampler_guard.after_trial(&ctx, self.storage.clone(), &state_values)
-        };
+        let after_trial_result =
+            self.sampler
+                .after_trial(&ctx, self.storage.clone(), &state_values);
 
         let mut storage_guard = self.storage.write().map_err(|e| {
             Error::with_reason(
@@ -618,6 +606,7 @@ mod tests {
     use crate::attr::AttrKey;
     use crate::distribution::Distribution;
     use crate::sampler::{Context as SamplerContext, Sampler};
+    use std::sync::Mutex;
     use std::thread;
 
     use crate::sampler::RandomSampler;
@@ -633,7 +622,7 @@ mod tests {
 
     impl Sampler for RecordingSampler {
         fn sample_independent(
-            &mut self,
+            &self,
             _ctx: &SamplerContext,
             _storage: Arc<RwLock<dyn Storage>>,
             _name: &str,
@@ -647,7 +636,7 @@ mod tests {
         }
 
         fn sample_joint(
-            &mut self,
+            &self,
             _ctx: &SamplerContext,
             _storage: Arc<RwLock<dyn Storage>>,
             _search_space: &HashMap<String, Distribution>,
@@ -656,7 +645,7 @@ mod tests {
         }
 
         fn after_trial(
-            &mut self,
+            &self,
             ctx: &SamplerContext,
             storage: Arc<RwLock<dyn Storage>>,
             state_values: &TrialStateValues,
@@ -992,10 +981,10 @@ mod tests {
     fn test_tell_calls_after_trial_before_storage_update() -> Result<()> {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
         let calls = Arc::new(Mutex::new(Vec::new()));
-        let sampler = Arc::new(Mutex::new(RecordingSampler {
+        let sampler = Arc::new(RecordingSampler {
             calls: calls.clone(),
             fail_after_trial: false,
-        }));
+        });
         let study = create_study_with_arc(
             "dummy-after-trial",
             storage.clone(),
@@ -1038,10 +1027,10 @@ mod tests {
     fn test_tell_persists_trial_even_if_after_trial_fails() -> Result<()> {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
         let calls = Arc::new(Mutex::new(Vec::new()));
-        let sampler = Arc::new(Mutex::new(RecordingSampler {
+        let sampler = Arc::new(RecordingSampler {
             calls,
             fail_after_trial: true,
-        }));
+        });
         let study = create_study_with_arc(
             "dummy-after-trial-failure",
             storage.clone(),

--- a/rustuna_core/src/trial.rs
+++ b/rustuna_core/src/trial.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, RwLock};
 
 use crate::attr::{category_labels_to_attrs, AttrKey, Attrs, CategoryLabel};
 use crate::distribution::Distribution;
@@ -23,7 +23,7 @@ pub struct Trial {
     pub datetime_complete: Option<String>,
     directions: Vec<Direction>,
     storage: Arc<RwLock<dyn Storage>>,
-    sampler: Arc<Mutex<dyn Sampler>>,
+    sampler: Arc<dyn Sampler>,
     joint_params: HashMap<String, (Distribution, f64)>,
     fixed_params: HashMap<String, CategoryLabel>,
     cached_user_attrs: HashMap<String, String>,
@@ -39,7 +39,7 @@ impl Trial {
         datetime_complete: Option<String>,
         directions: Vec<Direction>,
         storage: Arc<RwLock<dyn Storage>>,
-        sampler: Arc<Mutex<dyn Sampler>>,
+        sampler: Arc<dyn Sampler>,
         joint_params: HashMap<String, (Distribution, f64)>,
         fixed_params: HashMap<String, CategoryLabel>,
     ) -> Self {
@@ -131,15 +131,9 @@ impl Trial {
             trial_id: self.id,
             directions: self.directions.clone(),
         };
-        let mut sampler_guard = self.sampler.lock().map_err(|e| {
-            Error::with_reason(
-                ErrorKind::SamplerError,
-                format!("Failed to acquire sampler guard: {e}"),
-            )
-        })?;
         let param_value =
-            sampler_guard.sample_independent(&context, self.storage.clone(), name, distribution)?;
-        drop(sampler_guard);
+            self.sampler
+                .sample_independent(&context, self.storage.clone(), name, distribution)?;
 
         let mut storage_guard = self.storage.write().map_err(|e| {
             Error::with_reason(
@@ -490,7 +484,7 @@ mod tests {
     #[test]
     fn test_enqueue_and_suggest_float() -> Result<()> {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
-        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
+        let sampler = Arc::new(RandomSampler::new());
         let directions = vec![Direction::Minimize];
         let study = create_study_with_arc("dummy", storage.clone(), sampler, directions)?;
 
@@ -507,7 +501,7 @@ mod tests {
     #[test]
     fn test_enqueue_and_suggest_int() -> Result<()> {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
-        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
+        let sampler = Arc::new(RandomSampler::new());
         let directions = vec![Direction::Minimize];
         let study = create_study_with_arc("dummy", storage.clone(), sampler, directions)?;
 
@@ -524,7 +518,7 @@ mod tests {
     #[test]
     fn test_enqueue_fallback_on_out_of_range() -> Result<()> {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
-        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
+        let sampler = Arc::new(RandomSampler::new());
         let directions = vec![Direction::Minimize];
         let study = create_study_with_arc("dummy", storage.clone(), sampler, directions)?;
 
@@ -541,7 +535,7 @@ mod tests {
     #[test]
     fn test_enqueue_mixed_with_normal_ask() -> Result<()> {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
-        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
+        let sampler = Arc::new(RandomSampler::new());
         let directions = vec![Direction::Minimize];
         let study = create_study_with_arc("dummy", storage.clone(), sampler, directions)?;
 
@@ -564,7 +558,7 @@ mod tests {
     #[test]
     fn test_enqueue_unspecified_param_sampled() -> Result<()> {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
-        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
+        let sampler = Arc::new(RandomSampler::new());
         let directions = vec![Direction::Minimize];
         let study = create_study_with_arc("dummy", storage.clone(), sampler, directions)?;
 
@@ -584,7 +578,7 @@ mod tests {
     #[test]
     fn test_trial_user_attr() -> Result<()> {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
-        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
+        let sampler = Arc::new(RandomSampler::new());
         let directions = vec![Direction::Minimize];
         let study = create_study_with_arc("dummy", storage.clone(), sampler, directions)?;
 
@@ -623,7 +617,7 @@ mod tests {
     #[test]
     fn test_set_constraints() -> Result<()> {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
-        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
+        let sampler = Arc::new(RandomSampler::new());
         let directions = vec![Direction::Minimize];
         let study = create_study_with_arc("dummy", storage.clone(), sampler, directions)?;
 
@@ -643,7 +637,7 @@ mod tests {
     #[test]
     fn test_set_constraints_with_nan() -> Result<()> {
         let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
-        let sampler = Arc::new(Mutex::new(RandomSampler::new()));
+        let sampler = Arc::new(RandomSampler::new());
         let directions = vec![Direction::Minimize];
         let study = create_study_with_arc("dummy", storage.clone(), sampler, directions)?;
 

--- a/rustuna_pyo3/src/sampler/cmaes.rs
+++ b/rustuna_pyo3/src/sampler/cmaes.rs
@@ -235,7 +235,7 @@ impl CmaEsSampler {
 
 impl Sampler for CmaEsSampler {
     fn sample_independent(
-        &mut self,
+        &self,
         ctx: &Context,
         storage: Arc<RwLock<dyn Storage>>,
         name: &str,
@@ -257,7 +257,7 @@ impl Sampler for CmaEsSampler {
     }
 
     fn sample_joint(
-        &mut self,
+        &self,
         ctx: &Context,
         storage: Arc<RwLock<dyn Storage>>,
         search_space: &HashMap<String, Distribution>,
@@ -289,10 +289,10 @@ impl Sampler for CmaEsSampler {
 #[pyclass(name = "CmaEsSampler", from_py_object)]
 #[pyo3(module = "rustuna")]
 pub struct PyCmaEsSampler {
-    pub sampler: Arc<Mutex<dyn Sampler>>,
+    pub sampler: Arc<CmaEsSampler>,
 }
 
-// These methods release the GIL before acquiring the sampler mutex because
+// These methods release the GIL before acquiring the sampler's internal mutex because
 // `CmaEsSampler` re-attaches to Python internally. Acquiring the mutex while holding the GIL
 // could deadlock with another thread that holds the mutex and waits for the GIL.
 #[pymethods]
@@ -301,7 +301,7 @@ impl PyCmaEsSampler {
     #[pyo3(signature = (*, seed = None, popsize = None))]
     fn py_new(seed: Option<u64>, popsize: Option<usize>) -> Self {
         PyCmaEsSampler {
-            sampler: Arc::new(Mutex::new(CmaEsSampler::new(seed, popsize))),
+            sampler: Arc::new(CmaEsSampler::new(seed, popsize)),
         }
     }
 
@@ -324,10 +324,6 @@ impl PyCmaEsSampler {
         let distribution = distribution.distribution.clone();
         py.detach(|| {
             self.sampler
-                .lock()
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-                })?
                 .sample_independent(&context, arc_storage, &name, &distribution)
                 .map_err(|e| {
                     PyRuntimeError::new_err(format!("Failed to sample independent: {e:?}"))
@@ -350,10 +346,6 @@ impl PyCmaEsSampler {
             .collect();
         py.detach(|| {
             self.sampler
-                .lock()
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-                })?
                 .sample_joint(&context, arc_storage, &search_space)
                 .map_err(err_to_exceptions)
         })
@@ -381,10 +373,6 @@ impl PyCmaEsSampler {
         let context = ctx.context.clone();
         py.detach(|| {
             self.sampler
-                .lock()
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-                })?
                 .after_trial(&context, arc_storage, &state_values)
                 .map_err(|e| PyRuntimeError::new_err(format!("Failed to call after_trial: {e:?}")))
         })

--- a/rustuna_pyo3/src/sampler/cmaes.rs
+++ b/rustuna_pyo3/src/sampler/cmaes.rs
@@ -26,8 +26,7 @@ use crate::trial::PyTrialState;
 /// configuration is asked, so no bookkeeping is required when a trial finishes.
 pub struct CmaEsSampler {
     state: Mutex<CmaEsSamplerState>,
-    // TODO(c-bata): Remove this mutex after RandomSampler becomes internally synchronized.
-    random_sampler: Mutex<RandomSampler>,
+    random_sampler: RandomSampler,
 }
 
 struct CmaEsSamplerState {
@@ -228,7 +227,7 @@ impl CmaEsSampler {
         };
         Self {
             state: Mutex::new(CmaEsSamplerState::new(seed, popsize)),
-            random_sampler: Mutex::new(random_sampler),
+            random_sampler,
         }
     }
 }
@@ -242,13 +241,6 @@ impl Sampler for CmaEsSampler {
         distribution: &Distribution,
     ) -> Result<f64> {
         self.random_sampler
-            .lock()
-            .map_err(|e| {
-                Error::with_reason(
-                    ErrorKind::SamplerError,
-                    format!("Failed to acquire random sampler guard: {e}"),
-                )
-            })?
             .sample_independent(ctx, storage, name, distribution)
     }
 

--- a/rustuna_pyo3/src/sampler/nsgaii.rs
+++ b/rustuna_pyo3/src/sampler/nsgaii.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::Mutex;
 
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
@@ -18,7 +17,7 @@ use crate::trial::PyTrialState;
 #[pyclass(name = "NSGAIISampler", from_py_object)]
 #[pyo3(module = "rustuna")]
 pub struct PyNSGAIISampler {
-    pub sampler: Arc<Mutex<NSGAIISampler>>,
+    pub sampler: Arc<NSGAIISampler>,
 }
 #[pymethods]
 impl PyNSGAIISampler {
@@ -47,18 +46,13 @@ impl PyNSGAIISampler {
             ),
         };
         Ok(PyNSGAIISampler {
-            sampler: Arc::new(Mutex::new(rs_sampler)),
+            sampler: Arc::new(rs_sampler),
         })
     }
 
     #[getter]
-    fn support_joint_sampling(&self, py: Python<'_>) -> PyResult<bool> {
-        py.detach(|| {
-            let guard = self.sampler.lock().map_err(|e| {
-                PyRuntimeError::new_err(format!("Failed to acquire sampler lock: {e}"))
-            })?;
-            Ok(guard.support_joint_sampling())
-        })
+    fn support_joint_sampling(&self) -> bool {
+        self.sampler.support_joint_sampling()
     }
 
     fn sample_independent(
@@ -75,10 +69,6 @@ impl PyNSGAIISampler {
         let distribution = distribution.distribution.clone();
         py.detach(|| {
             self.sampler
-                .lock()
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-                })?
                 .sample_independent(&context, arc_storage, &name, &distribution)
                 .map_err(|e| {
                     PyRuntimeError::new_err(format!("Failed to sample independent: {e:?}"))
@@ -101,10 +91,6 @@ impl PyNSGAIISampler {
             .collect();
         py.detach(|| {
             self.sampler
-                .lock()
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-                })?
                 .sample_joint(&context, arc_storage, &search_space)
                 .map_err(|e| PyRuntimeError::new_err(format!("Failed to sample joint: {e:?}")))
         })
@@ -132,10 +118,6 @@ impl PyNSGAIISampler {
         let context = ctx.context.clone();
         py.detach(|| {
             self.sampler
-                .lock()
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-                })?
                 .after_trial(&context, arc_storage, &state_values)
                 .map_err(|e| PyRuntimeError::new_err(format!("Failed to call after_trial: {e:?}")))
         })

--- a/rustuna_pyo3/src/sampler/random.rs
+++ b/rustuna_pyo3/src/sampler/random.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
@@ -14,7 +14,7 @@ use crate::trial::PyTrialState;
 #[pyclass(name = "RandomSampler", from_py_object)]
 #[pyo3(module = "rustuna")]
 pub struct PyRandomSampler {
-    pub sampler: Arc<Mutex<RandomSampler>>,
+    pub sampler: Arc<RandomSampler>,
 }
 #[pymethods]
 impl PyRandomSampler {
@@ -26,7 +26,7 @@ impl PyRandomSampler {
             None => RandomSampler::new(),
         };
         Self {
-            sampler: Arc::new(Mutex::new(random_sampler)),
+            sampler: Arc::new(random_sampler),
         }
     }
 
@@ -49,10 +49,6 @@ impl PyRandomSampler {
         let distribution = distribution.distribution.clone();
         py.detach(|| {
             self.sampler
-                .lock()
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-                })?
                 .sample_independent(&context, arc_storage, &name, &distribution)
                 .map_err(|e| {
                     PyRuntimeError::new_err(format!("Failed to sample independent: {e:?}"))

--- a/rustuna_pyo3/src/sampler/to_rust.rs
+++ b/rustuna_pyo3/src/sampler/to_rust.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
@@ -18,16 +18,18 @@ use crate::trial::PyTrialState;
 // rustuna_core::sampler::Sampler. Rustuna can therefore use Python samplers through the same
 // interface as native Rust samplers.
 pub struct ToRustSampler {
-    obj: Py<PyAny>,
+    obj: Mutex<Py<PyAny>>,
 }
 impl ToRustSampler {
     pub fn new(obj: Py<PyAny>) -> Self {
-        ToRustSampler { obj }
+        ToRustSampler {
+            obj: Mutex::new(obj),
+        }
     }
 }
 impl Sampler for ToRustSampler {
     fn sample_independent(
-        &mut self,
+        &self,
         ctx: &SamplerContext,
         storage: Arc<std::sync::RwLock<dyn rustuna_core::storage::Storage>>,
         name: &str,
@@ -43,12 +45,17 @@ impl Sampler for ToRustSampler {
         let study_attrs = study.attrs.clone();
         drop(guard);
 
+        let obj = self.obj.lock().map_err(|e| {
+            rustuna_core::Error::with_reason(
+                rustuna_core::ErrorKind::SamplerError,
+                format!("Failed to acquire sampler object guard: {e}"),
+            )
+        })?;
         Python::attach(|py| {
             let py_ctx = PySamplerContext::from(ctx.clone());
             let py_storage = ToPythonStorage::new(storage.clone());
             let py_distribution = PyDistribution::new(distribution.clone(), name, &study_attrs);
-            let py_result = self
-                .obj
+            let py_result = obj
                 .call_method1(
                     py,
                     "sample_independent",
@@ -72,16 +79,18 @@ impl Sampler for ToRustSampler {
     }
 
     fn support_joint_sampling(&self) -> bool {
+        let Ok(obj) = self.obj.lock() else {
+            return false;
+        };
         Python::attach(|py| {
-            self.obj
-                .getattr(py, "support_joint_sampling")
+            obj.getattr(py, "support_joint_sampling")
                 .and_then(|x| x.extract::<bool>(py))
                 .unwrap_or(false)
         })
     }
 
     fn sample_joint(
-        &mut self,
+        &self,
         ctx: &SamplerContext,
         storage: Arc<std::sync::RwLock<dyn Storage>>,
         search_space: &HashMap<String, rustuna_core::distribution::Distribution>,
@@ -93,6 +102,12 @@ impl Sampler for ToRustSampler {
         let study_attrs = study.attrs.clone();
         drop(guard);
 
+        let obj = self.obj.lock().map_err(|e| {
+            rustuna_core::Error::with_reason(
+                rustuna_core::ErrorKind::SamplerError,
+                format!("Failed to acquire sampler object guard: {e}"),
+            )
+        })?;
         Python::attach(|py| {
             let py_ctx = PySamplerContext::from(ctx.clone());
             let py_storage = ToPythonStorage::new(storage.clone());
@@ -112,8 +127,7 @@ impl Sampler for ToRustSampler {
                     )
                 })?;
             }
-            let py_result = self
-                .obj
+            let py_result = obj
                 .call_method1(py, "sample_joint", (py_ctx, py_storage, py_search_space))
                 .map_err(|e| {
                     rustuna_core::Error::with_reason(
@@ -132,7 +146,7 @@ impl Sampler for ToRustSampler {
     }
 
     fn after_trial(
-        &mut self,
+        &self,
         ctx: &SamplerContext,
         storage: Arc<std::sync::RwLock<dyn Storage>>,
         state_values: &TrialStateValues,
@@ -143,8 +157,14 @@ impl Sampler for ToRustSampler {
             _ => None,
         };
 
+        let obj = self.obj.lock().map_err(|e| {
+            rustuna_core::Error::with_reason(
+                rustuna_core::ErrorKind::SamplerError,
+                format!("Failed to acquire sampler object guard: {e}"),
+            )
+        })?;
         Python::attach(|py| {
-            if !self.obj.bind(py).hasattr("after_trial").map_err(|e| {
+            if !obj.bind(py).hasattr("after_trial").map_err(|e| {
                 rustuna_core::Error::with_reason(
                     rustuna_core::ErrorKind::SamplerError,
                     e.to_string(),
@@ -155,8 +175,7 @@ impl Sampler for ToRustSampler {
 
             let py_ctx = PySamplerContext::from(ctx.clone());
             let py_storage = ToPythonStorage::new(storage.clone());
-            self.obj
-                .call_method1(py, "after_trial", (py_ctx, py_storage, py_state, py_values))
+            obj.call_method1(py, "after_trial", (py_ctx, py_storage, py_state, py_values))
                 .map_err(|e| {
                     rustuna_core::Error::with_reason(
                         rustuna_core::ErrorKind::SamplerError,

--- a/rustuna_pyo3/src/sampler/tpe.rs
+++ b/rustuna_pyo3/src/sampler/tpe.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
@@ -17,7 +17,7 @@ use crate::trial::PyTrialState;
 #[pyclass(name = "TPESampler", from_py_object)]
 #[pyo3(module = "rustuna")]
 pub struct PyTpeSampler {
-    pub sampler: Arc<Mutex<TpeSampler>>,
+    pub sampler: Arc<TpeSampler>,
 }
 #[pymethods]
 impl PyTpeSampler {
@@ -34,18 +34,13 @@ impl PyTpeSampler {
             multivariate,
         });
         Ok(PyTpeSampler {
-            sampler: Arc::new(Mutex::new(rs_sampler)),
+            sampler: Arc::new(rs_sampler),
         })
     }
 
     #[getter]
-    fn support_joint_sampling(&self, py: Python<'_>) -> PyResult<bool> {
-        py.detach(|| {
-            let guard = self.sampler.lock().map_err(|e| {
-                PyRuntimeError::new_err(format!("Failed to acquire sampler lock: {e}"))
-            })?;
-            Ok(guard.support_joint_sampling())
-        })
+    fn support_joint_sampling(&self) -> bool {
+        self.sampler.support_joint_sampling()
     }
 
     fn sample_independent(
@@ -62,10 +57,6 @@ impl PyTpeSampler {
         let distribution = distribution.distribution.clone();
         py.detach(|| {
             self.sampler
-                .lock()
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-                })?
                 .sample_independent(&context, arc_storage, &name, &distribution)
                 .map_err(|e| {
                     PyRuntimeError::new_err(format!("Failed to sample independent: {e:?}"))
@@ -88,10 +79,6 @@ impl PyTpeSampler {
             .collect();
         py.detach(|| {
             self.sampler
-                .lock()
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-                })?
                 .sample_joint(&context, arc_storage, &search_space)
                 .map_err(|e| PyRuntimeError::new_err(format!("Failed to sample joint: {e:?}")))
         })
@@ -119,10 +106,6 @@ impl PyTpeSampler {
         let context = ctx.context.clone();
         py.detach(|| {
             self.sampler
-                .lock()
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to acquire the sampler guard: {e}"))
-                })?
                 .after_trial(&context, arc_storage, &state_values)
                 .map_err(|e| PyRuntimeError::new_err(format!("Failed to call after_trial: {e:?}")))
         })

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -5,7 +5,7 @@ use pyo3::{PyTypeInfo, Python};
 use pyo3::exceptions::{PyRuntimeError, PyTypeError, PyValueError};
 use rustuna_core::ErrorKind;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, RwLock};
 
 use rustuna_core::attr::AttrKey;
 use rustuna_core::sampler::Sampler;
@@ -36,7 +36,7 @@ use crate::trial_queue::sqlite3::PySQLite3TrialQueue;
 use crate::trial_queue::to_rust::ToRustTrialQueue;
 
 type SharedStorage = Arc<RwLock<dyn Storage>>;
-type SharedSampler = Arc<Mutex<dyn Sampler>>;
+type SharedSampler = Arc<dyn Sampler>;
 type SharedTrialQueue = Arc<RwLock<dyn rustuna_core::trial_queue::TrialQueue>>;
 
 mod py_exceptions {
@@ -207,7 +207,7 @@ fn resolve_sampler_pyobj(
     } else if let Ok(py_random_sampler) = sampler_ref.extract::<PyRandomSampler>() {
         Ok((py_random_sampler.sampler.clone(), sampler_pyobj))
     } else {
-        let sampler: SharedSampler = Arc::new(Mutex::new(ToRustSampler::new(sampler)));
+        let sampler: SharedSampler = Arc::new(ToRustSampler::new(sampler));
         Ok((sampler, sampler_pyobj))
     }
 }
@@ -220,7 +220,7 @@ fn into_sampler_pyobj(
     match sampler {
         Some(sampler) => resolve_sampler_pyobj(py, sampler),
         None => {
-            let sampler = Arc::new(Mutex::new(TpeSampler::new()));
+            let sampler = Arc::new(TpeSampler::new());
             let py_sampler = PyTpeSampler {
                 sampler: sampler.clone(),
             };

--- a/rustuna_sampler/src/nsgaii.rs
+++ b/rustuna_sampler/src/nsgaii.rs
@@ -133,7 +133,7 @@ impl NSGAIISampler {
         })
     }
     fn get_generation_to_numbers_write_lock(
-        &mut self,
+        &self,
     ) -> Result<RwLockWriteGuard<'_, HashMap<u32, Vec<u32>>>> {
         self.generation_to_numbers.write().map_err(|e| {
             Error::with_reason(
@@ -142,7 +142,7 @@ impl NSGAIISampler {
             )
         })
     }
-    fn rebuild_generation_cache(&mut self, trials: &[Option<PersistedTrial>]) -> Result<()> {
+    fn rebuild_generation_cache(&self, trials: &[Option<PersistedTrial>]) -> Result<()> {
         let mut generation_to_numbers = self.get_generation_to_numbers_write_lock()?;
         generation_to_numbers.clear();
         let generation_key = AttrKey::System("generation".into());
@@ -162,7 +162,7 @@ impl NSGAIISampler {
         Ok(())
     }
     fn select_elite_population_numbers(
-        &mut self,
+        &self,
         ctx: &Context,
         trials: &[Option<PersistedTrial>],
         population_numbers: &[u32],
@@ -184,7 +184,7 @@ impl NSGAIISampler {
         Ok(elite_population_numbers)
     }
     fn get_parent_population_numbers(
-        &mut self,
+        &self,
         ctx: &Context,
         trials: &[Option<PersistedTrial>],
     ) -> Result<(i32, Vec<u32>)> {
@@ -211,7 +211,7 @@ impl NSGAIISampler {
         Ok((parent_generation, parent_population_numbers))
     }
     fn crossover(
-        &mut self,
+        &self,
         parent0: &HashMap<String, f64>,
         parent1: &HashMap<String, f64>,
         sorted_names: &[&str],
@@ -232,7 +232,7 @@ impl NSGAIISampler {
 }
 impl Sampler for NSGAIISampler {
     fn sample_independent(
-        &mut self,
+        &self,
         _ctx: &Context,
         _storage: Arc<RwLock<dyn Storage>>,
         _name: &str,
@@ -311,7 +311,7 @@ impl Sampler for NSGAIISampler {
     }
 
     fn sample_joint(
-        &mut self,
+        &self,
         ctx: &Context,
         storage: Arc<RwLock<dyn Storage>>,
         search_space: &HashMap<String, Distribution>,
@@ -383,7 +383,7 @@ impl Sampler for NSGAIISampler {
     }
 
     fn after_trial(
-        &mut self,
+        &self,
         ctx: &Context,
         storage: Arc<RwLock<dyn Storage>>,
         state_values: &TrialStateValues,

--- a/rustuna_sampler/src/tpe/sampler.rs
+++ b/rustuna_sampler/src/tpe/sampler.rs
@@ -1,7 +1,7 @@
 use core::panic;
 use std::cmp::Ordering;
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -93,12 +93,12 @@ type SplitValue = (Vec<u32>, Vec<u32>);
 /// }
 /// ```
 pub struct TpeSampler {
-    rng: StdRng,
+    rng: Mutex<StdRng>,
     multivariate: Option<bool>,
     n_startup_trials: usize,
     random_sampler: RandomSampler,
     // TODO(y0z): Change to LruCache<(Vec<&PersistedTrial>, usize), (Vec<&PersistedTrial>, Vec<&PersistedTrial>)>
-    split_cache: HashMap<SplitKey, SplitValue>,
+    split_cache: RwLock<HashMap<SplitKey, SplitValue>>,
 }
 impl Default for TpeSampler {
     fn default() -> Self {
@@ -114,11 +114,11 @@ impl TpeSampler {
         };
         let seed_for_random_sampler = rng.gen();
         Self {
-            rng,
+            rng: Mutex::new(rng),
             multivariate: cfg.multivariate,
             n_startup_trials: cfg.n_startup_trials,
             random_sampler: RandomSampler::seed_from_u64(seed_for_random_sampler),
-            split_cache: HashMap::new(),
+            split_cache: RwLock::new(HashMap::new()),
         }
     }
 
@@ -144,7 +144,7 @@ impl TpeSampler {
     }
 
     fn sample(
-        &mut self,
+        &self,
         ctx: &Context,
         complete_trials: &[&rustuna_core::trial::PersistedTrial],
         search_space: &HashMap<String, Distribution>,
@@ -169,11 +169,21 @@ impl TpeSampler {
                 .map(|t| t.number)
                 .collect::<Vec<u32>>();
             let split_cache_key = (complete_trial_numbers.clone(), gamma);
+            let cached_split = self
+                .split_cache
+                .read()
+                .map_err(|e| {
+                    Error::with_reason(
+                        ErrorKind::SamplerError,
+                        format!("Failed to acquire split cache guard: {e}"),
+                    )
+                })?
+                .get(&split_cache_key)
+                .cloned();
             let (good_trials, poor_trials): (
                 Vec<&rustuna_core::trial::PersistedTrial>,
                 Vec<&rustuna_core::trial::PersistedTrial>,
-            ) = if self.split_cache.contains_key(&split_cache_key) {
-                let (good_nums, poor_nums) = self.split_cache.get(&split_cache_key).unwrap();
+            ) = if let Some((good_nums, poor_nums)) = cached_split {
                 let good_trials = complete_trials
                     .iter()
                     .copied()
@@ -193,10 +203,14 @@ impl TpeSampler {
                 )?;
                 let good_nums = good_trials.iter().map(|t| t.number).collect();
                 let poor_nums = poor_trials.iter().map(|t| t.number).collect();
-                // We only cache the most recent split
-                self.split_cache.clear();
-                self.split_cache
-                    .insert(split_cache_key, (good_nums, poor_nums));
+                let mut split_cache = self.split_cache.write().map_err(|e| {
+                    Error::with_reason(
+                        ErrorKind::SamplerError,
+                        format!("Failed to acquire split cache guard: {e}"),
+                    )
+                })?;
+                split_cache.clear();
+                split_cache.insert(split_cache_key, (good_nums, poor_nums));
                 (good_trials, poor_trials)
             };
             // Multi-objective: uniform weights for l(x) (below), recency ramp for g(x) (above),
@@ -208,7 +222,15 @@ impl TpeSampler {
         };
 
         let n_ei_candidates = 24;
-        let samples_good = pe_good.sample(&mut self.rng, n_ei_candidates);
+        let samples_good = {
+            let mut rng = self.rng.lock().map_err(|e| {
+                Error::with_reason(
+                    ErrorKind::SamplerError,
+                    format!("Failed to acquire RNG guard: {e}"),
+                )
+            })?;
+            pe_good.sample(&mut rng, n_ei_candidates)
+        };
         let mut best_idx = 0usize;
         let mut best_val = f64::NEG_INFINITY;
         for (i, s) in samples_good.iter().enumerate() {
@@ -425,7 +447,7 @@ impl TpeSampler {
 
 impl Sampler for TpeSampler {
     fn sample_independent(
-        &mut self,
+        &self,
         ctx: &Context,
         storage: Arc<RwLock<dyn Storage>>,
         name: &str,
@@ -464,7 +486,7 @@ impl Sampler for TpeSampler {
     }
 
     fn sample_joint(
-        &mut self,
+        &self,
         ctx: &Context,
         storage: Arc<RwLock<dyn Storage>>,
         search_space: &HashMap<String, Distribution>,
@@ -500,7 +522,7 @@ impl Sampler for TpeSampler {
     }
 
     fn after_trial(
-        &mut self,
+        &self,
         _ctx: &Context,
         _storage: Arc<RwLock<dyn Storage>>,
         _state_values: &TrialStateValues,


### PR DESCRIPTION
## Summary

refs #200 

- Change `Sampler` to require `Send + Sync` and receive `&self`
- Replace `Arc<Mutex<dyn Sampler>>` with `Arc<dyn Sampler>` in `Study` and `Trial`
- Move synchronization into individual sampler implementations
- Add a test that shares `RandomSampler` across multiple threads