### PR TITLE
remove cached_trials, instead add cached_user_attrs

### DIFF
--- a/rustuna_core/src/trial.rs
+++ b/rustuna_core/src/trial.rs
@@ -26,7 +26,7 @@ pub struct Trial {
     sampler: Arc<Mutex<dyn Sampler>>,
     joint_params: HashMap<String, (Distribution, f64)>,
     fixed_params: HashMap<String, CategoryLabel>,
-    cached_trial: PersistedTrial,
+    cached_user_attrs: HashMap<String, String>,
 }
 impl Trial {
     /// Constructs a trial from storage and sampler state.
@@ -43,9 +43,7 @@ impl Trial {
         joint_params: HashMap<String, (Distribution, f64)>,
         fixed_params: HashMap<String, CategoryLabel>,
     ) -> Self {
-        let mut cached_trial = PersistedTrial::new(trial_id, study_id, number);
-        cached_trial.datetime_start = datetime_start.clone();
-        cached_trial.datetime_complete = datetime_complete.clone();
+        let cached_user_attrs = HashMap::new();
         Trial {
             id: trial_id,
             study_id,
@@ -57,7 +55,7 @@ impl Trial {
             sampler,
             joint_params,
             fixed_params,
-            cached_trial,
+            cached_user_attrs,
         }
     }
 
@@ -108,14 +106,6 @@ impl Trial {
                 })?;
                 storage_guard.set_trial_param(self.id, name, distribution, internal_value)?;
                 drop(storage_guard);
-
-                self.cached_trial
-                    .internal_params
-                    .insert(name.to_string(), internal_value);
-                self.cached_trial
-                    .distributions
-                    .insert(name.to_string(), distribution.clone());
-
                 return Ok(internal_value);
             }
         }
@@ -159,14 +149,6 @@ impl Trial {
         })?;
         storage_guard.set_trial_param(self.id, name, distribution, param_value)?;
         drop(storage_guard);
-
-        self.cached_trial
-            .internal_params
-            .insert(name.to_string(), param_value);
-        self.cached_trial
-            .distributions
-            .insert(name.to_string(), distribution.clone());
-
         Ok(param_value)
     }
 
@@ -229,18 +211,11 @@ impl Trial {
     // making it difficult to cache the value.
     /// Returns a user attribute stored on the trial.
     pub fn get_user_attr(&mut self, key: &str) -> Option<&String> {
-        let key = AttrKey::User(key.into());
-        self.cached_trial.attrs.get(&key)
+        self.cached_user_attrs.get(key)
     }
     /// Returns user attributes stored on the trial.
     pub fn get_user_attrs(&self) -> HashMap<String, String> {
-        let mut user_attrs = HashMap::with_capacity(self.cached_trial.attrs.len());
-        for (key, value) in &self.cached_trial.attrs {
-            if let AttrKey::User(key) = key {
-                user_attrs.insert(key.to_string(), value.clone());
-            }
-        }
-        user_attrs
+        self.cached_user_attrs.clone()
     }
 
     /// Sets a single user attribute on the trial.
@@ -253,10 +228,10 @@ impl Trial {
         })?;
         let mut attrs = Attrs::new();
 
-        let key = AttrKey::User(key.into());
-        attrs.insert(key.clone(), value.clone());
+        let attr_key = AttrKey::User(key.into());
+        attrs.insert(attr_key.clone(), value.clone());
         guard.set_trial_attrs(self.id, attrs, false)?;
-        self.cached_trial.attrs.insert(key, value);
+        self.cached_user_attrs.insert(key.to_string(), value);
         Ok(())
     }
 
@@ -275,11 +250,7 @@ impl Trial {
         guard.set_trial_attrs(self.id, attrs, false)?;
         drop(guard);
 
-        for (key, value) in user_attrs {
-            self.cached_trial
-                .attrs
-                .insert(AttrKey::User(key.into()), value);
-        }
+        self.cached_user_attrs.extend(user_attrs);
         Ok(())
     }
 
@@ -290,10 +261,6 @@ impl Trial {
             let key_with_constraint_prefix = format!("{}:{}", CONSTRAINTS_KEY, key);
             attrs.insert(
                 AttrKey::System(key_with_constraint_prefix.as_str().into()),
-                value.to_string(),
-            );
-            self.cached_trial.attrs.insert(
-                AttrKey::System(key_with_constraint_prefix.into()),
                 value.to_string(),
             );
         }


### PR DESCRIPTION
I removed `cached_trials` property in `Trial` class.
Instead, I added `cached_user_attrs` (because `cached_trials` is used only for getting user attrs.)