### PR TITLE
Rename GitHub workflows

### DIFF
--- a/.github/workflows/checks_js.yml
+++ b/.github/workflows/checks_js.yml
@@ -1,4 +1,4 @@
-name: tests
+name: Tests and checks (JavaScript)
 on:
   pull_request:
     branches:

--- a/.github/workflows/checks_python.yml
+++ b/.github/workflows/checks_python.yml
@@ -1,4 +1,4 @@
-name: tests
+name: Checks and tests (Python)
 on:
   pull_request:
     branches:

--- a/.github/workflows/checks_rust.yml
+++ b/.github/workflows/checks_rust.yml
@@ -1,4 +1,4 @@
-name: tests
+name: Checks and tests (Rust)
 on:
   pull_request:
     branches:


### PR DESCRIPTION
## Motivation

Currently, there are three workflows named `tests`, making it difficult to check the CI status on https://github.com/optuna/rustuna/actions.

<img width="628" height="350" alt="Screenshot 2026-08-19 14 28 01" src="https://github.com/user-attachments/assets/7b136305-da63-41de-b130-62a511192612" />

## Description of the changes

* Rename GitHub workflows.