### PR TITLE
Fix JournalFileStorage compilation on Windows

### DIFF
--- a/rustuna_pyo3/src/storage/journal.rs
+++ b/rustuna_pyo3/src/storage/journal.rs
@@ -4,7 +4,7 @@ use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 
 use rustuna_core::storage::Storage;
-use rustuna_storage::journal::file::{JournalFileBackend, JournalFileSymlinkLock};
+use rustuna_storage::journal::file::JournalFileBackend;
 use rustuna_storage::journal::storage::{JournalStorage, JournalStorageOptions};
 
 use crate::distribution::PyDistribution;
@@ -30,9 +30,7 @@ impl PyJournalFileStorage {
     #[new]
     #[pyo3(signature = (file_path, *, apply_discard = false))]
     fn py_new(file_path: &str, apply_discard: bool) -> PyResult<Self> {
-        // TODO(c-bata): Add lock_obj argument to use JournalFileOpenLock.
-        let lock_obj = Box::new(JournalFileSymlinkLock::new(file_path));
-        let backend = JournalFileBackend::new(file_path, Some(lock_obj)).map_err(|e| {
+        let backend = JournalFileBackend::new(file_path, None).map_err(|e| {
             PyRuntimeError::new_err(format!("Failed to create journal file: {e:?}"))
         })?;
         let storage = JournalStorage::new_with_options(

--- a/rustuna_storage/src/journal/file.rs
+++ b/rustuna_storage/src/journal/file.rs
@@ -48,6 +48,16 @@ pub trait JournalFileLock: Send + Sync {
     fn release(&self) -> Result<()>;
 }
 
+#[cfg(unix)]
+fn default_journal_file_lock(file_path: &Path) -> Box<dyn JournalFileLock> {
+    Box::new(JournalFileSymlinkLock::new(file_path))
+}
+
+#[cfg(not(unix))]
+fn default_journal_file_lock(file_path: &Path) -> Box<dyn JournalFileLock> {
+    Box::new(JournalFileOpenLock::new(file_path))
+}
+
 /// File-based backend for [`super::storage::JournalStorage`].
 ///
 /// Logs are appended as newline-delimited JSON records. A pluggable lock implementation is used
@@ -71,7 +81,7 @@ impl JournalFileBackend {
             File::create(&file_path)
                 .map_err(|e| Error::with_reason(ErrorKind::StorageError, e.to_string()))?;
         }
-        let lock = lock.unwrap_or_else(|| Box::new(JournalFileSymlinkLock::new(&file_path)));
+        let lock = lock.unwrap_or_else(|| default_journal_file_lock(&file_path));
         Ok(JournalFileBackend {
             file_path,
             lock,
@@ -222,11 +232,13 @@ impl JournalBackend for JournalFileBackend {
 /// Similar to Optuna's symlink-based journal lock, this variant is intended for environments
 /// where symlink creation provides a more portable inter-process exclusion mechanism than
 /// exclusive file creation.
+#[cfg(unix)]
 pub struct JournalFileSymlinkLock {
     lock_target_file: PathBuf,
     lock_file: PathBuf,
 }
 
+#[cfg(unix)]
 impl JournalFileSymlinkLock {
     /// Creates a symlink-based lock next to the journal file.
     pub fn new(filepath: impl AsRef<Path>) -> Self {
@@ -238,6 +250,7 @@ impl JournalFileSymlinkLock {
     }
 }
 
+#[cfg(unix)]
 impl JournalFileLock for JournalFileSymlinkLock {
     /// Acquires the lock by creating a symlink in a blocking retry loop.
     fn acquire(&self) -> Result<()> {


### PR DESCRIPTION
## Summary

refs #211

This PR fixes Windows builds, where `JournalFileSymlinkLock` referenced `std::os::unix::fs::symlink`.

## Description of the changes

- Use `JournalFileSymlinkLock` as the default lock on Unix.
- Use `JournalFileOpenLock` as the default lock on non-Unix platforms.
- Let the Python binding use the platform-specific default lock.
- Compile the symlink-based implementation only on Unix.

