### PR TITLE
Release the GIL around Rust sampling/storage work

### DIFF
--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -389,42 +389,54 @@ impl PyStudy {
         })
     }
 
+    /// The optimize loop. ask/tell take the storage write lock and sampler
+    /// mutex inside rustuna_core: they run detached (see the comment on
+    /// `PyTrial::suggest_float`), which also lets other Python threads —
+    /// including concurrent optimize calls on this study — make progress
+    /// while a trial is being sampled or stored. Only the objective call,
+    /// its result conversion, and the exception classification run attached.
     #[pyo3(signature = (objective, n_trials, catch = None))]
     pub fn optimize(
         &self,
+        py: Python<'_>,
         objective: Py<PyAny>,
         n_trials: usize,
         catch: Option<Py<PyAny>>,
     ) -> PyResult<()> {
-        let catch = Python::attach(|py| normalize_catch(py, catch.as_ref().map(|c| c.bind(py))))?;
+        let catch = normalize_catch(py, catch.as_ref().map(|c| c.bind(py)))?;
         for _ in 0..n_trials {
-            let rs_trial = self.study.ask().map_err(err_to_exceptions)?;
+            let rs_trial = py.detach(|| self.study.ask()).map_err(err_to_exceptions)?;
             let trial_number = rs_trial.number;
 
-            let result: PyResult<Vec<f64>> = Python::attach(|py| {
+            let result: PyResult<Vec<f64>> = {
                 let trial = PyTrial::new(rs_trial, self.storage_pyobj.clone_ref(py));
-                let val = objective.call1(py, (trial,))?;
-                objective_result_to_values(val.bind(py).clone())
-            });
+                objective
+                    .call1(py, (trial,))
+                    .and_then(|val| objective_result_to_values(val.bind(py).clone()))
+            };
 
             match result {
                 Ok(val) => {
-                    self.study
-                        .tell(trial_number, TrialStateValues::Complete(val))
-                        .map_err(|e| PyRuntimeError::new_err(format!("Failed to tell: {e:?}")))?;
+                    py.detach(|| {
+                        self.study
+                            .tell(trial_number, TrialStateValues::Complete(val))
+                    })
+                    .map_err(|e| PyRuntimeError::new_err(format!("Failed to tell: {e:?}")))?;
                 }
                 Err(e) => {
-                    let (state, should_reraise) = Python::attach(|py| -> PyResult<_> {
+                    let (state, should_reraise) =
                         if e.matches(py, py_exceptions::TrialPruned::type_object(py))? {
-                            Ok((TrialStateValues::Pruned, false))
+                            (TrialStateValues::Pruned, false)
                         } else {
-                            let should_reraise = !matches_any_exception(py, &e, &catch)?;
-                            Ok((TrialStateValues::Fail, should_reraise))
-                        }
-                    })?;
-                    self.study.tell(trial_number, state).map_err(|err| {
-                        PyRuntimeError::new_err(format!("Failed to tell: {err:?}"))
-                    })?;
+                            (
+                                TrialStateValues::Fail,
+                                !matches_any_exception(py, &e, &catch)?,
+                            )
+                        };
+                    py.detach(|| self.study.tell(trial_number, state))
+                        .map_err(|err| {
+                            PyRuntimeError::new_err(format!("Failed to tell: {err:?}"))
+                        })?;
                     if should_reraise {
                         return Err(e);
                     }
@@ -434,15 +446,17 @@ impl PyStudy {
         Ok(())
     }
 
-    pub fn ask(&self) -> PyResult<PyTrial> {
-        let trial = self.study.ask().map_err(err_to_exceptions)?;
-        let trial = Python::attach(|py| PyTrial::new(trial, self.storage_pyobj.clone_ref(py)));
-        Ok(trial)
+    pub fn ask(&self, py: Python<'_>) -> PyResult<PyTrial> {
+        // ask takes the storage/sampler locks inside rustuna_core: run it
+        // detached (see the comment on `PyTrial::suggest_float`).
+        let trial = py.detach(|| self.study.ask()).map_err(err_to_exceptions)?;
+        Ok(PyTrial::new(trial, self.storage_pyobj.clone_ref(py)))
     }
 
     #[pyo3(signature = (number, values = None, state = None))]
     pub fn tell(
         &self,
+        py: Python<'_>,
         number: u32,
         values: Option<Py<PyAny>>,
         state: Option<PyTrialState>,
@@ -462,32 +476,37 @@ impl PyStudy {
             (Some(PyTrialState::COMPLETE), None) => Err(PyValueError::new_err(
                 "values must be specified when state is COMPLETE",
             )),
-            (Some(PyTrialState::COMPLETE), Some(values)) => Python::attach(|py| {
+            (Some(PyTrialState::COMPLETE), Some(values)) => {
                 objective_result_to_values(values.bind(py).clone()).map(TrialStateValues::Complete)
-            }),
-            (None, Some(values)) => Python::attach(|py| {
+            }
+            (None, Some(values)) => {
                 objective_result_to_values(values.bind(py).clone()).map(TrialStateValues::Complete)
-            }),
+            }
         };
-        self.study
-            .tell(number, state_values?)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to tell: {e:?}")))?;
+        let state_values = state_values?;
+        // tell and the trial fetch below take the storage lock: run them
+        // detached (see the comment on `PyTrial::suggest_float`).
+        py.detach(|| {
+            self.study
+                .tell(number, state_values)
+                .map_err(|e| PyRuntimeError::new_err(format!("Failed to tell: {e:?}")))?;
 
-        let mut guard = self.study.storage.write().map_err(|e| {
-            PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
-        })?;
-        let trial_id = guard
-            .get_trial_id_from_study_id_trial_number(self.study.id, number)
-            .map_err(|e| {
-                PyRuntimeError::new_err(format!("Failed to get trial id: {:?}", e.kind))
+            let mut guard = self.study.storage.write().map_err(|e| {
+                PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
             })?;
-        let trial = guard
-            .get_trial(trial_id)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get trial: {:?}", e.kind)))?;
-        Ok(PyPersistedTrial::from_storage(
-            self.study.storage.clone(),
-            trial,
-        ))
+            let trial_id = guard
+                .get_trial_id_from_study_id_trial_number(self.study.id, number)
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to get trial id: {:?}", e.kind))
+                })?;
+            let trial = guard.get_trial(trial_id).map_err(|e| {
+                PyRuntimeError::new_err(format!("Failed to get trial: {:?}", e.kind))
+            })?;
+            Ok(PyPersistedTrial::from_storage(
+                self.study.storage.clone(),
+                trial,
+            ))
+        })
     }
 
     #[pyo3(signature = (params, user_attrs = None))]

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -389,12 +389,6 @@ impl PyStudy {
         })
     }
 
-    /// The optimize loop. ask/tell take the storage write lock and sampler
-    /// mutex inside rustuna_core: they run detached (see the comment on
-    /// `PyTrial::suggest_float`), which also lets other Python threads —
-    /// including concurrent optimize calls on this study — make progress
-    /// while a trial is being sampled or stored. Only the objective call,
-    /// its result conversion, and the exception classification run attached.
     #[pyo3(signature = (objective, n_trials, catch = None))]
     pub fn optimize(
         &self,

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -441,8 +441,7 @@ impl PyStudy {
     }
 
     pub fn ask(&self, py: Python<'_>) -> PyResult<PyTrial> {
-        // ask takes the storage/sampler locks inside rustuna_core: run it
-        // detached (see the comment on `PyTrial::suggest_float`).
+        // ask takes the storage/sampler locks inside rustuna_core: run it detached.
         let trial = py.detach(|| self.study.ask()).map_err(err_to_exceptions)?;
         Ok(PyTrial::new(trial, self.storage_pyobj.clone_ref(py)))
     }
@@ -478,8 +477,7 @@ impl PyStudy {
             }
         };
         let state_values = state_values?;
-        // tell and the trial fetch below take the storage lock: run them
-        // detached (see the comment on `PyTrial::suggest_float`).
+        // tell and the trial fetch below take the storage lock: run them detached.
         py.detach(|| {
             self.study
                 .tell(number, state_values)

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -282,16 +282,8 @@ impl PyTrial {
     pub fn storage<'py>(&self, py: Python<'py>) -> Py<PyAny> {
         self.storage_pyobj.clone_ref(py)
     }
-    // suggest_* runs its Rust work detached (GIL released), which upholds the
-    // rule shared with ask/tell/optimize in study.rs: never wait for the
-    // sampler mutex / storage rwlock while holding the GIL. The rule is
-    // needed because the ToRust* adapters for Python-backed samplers/storages
-    // hold these locks while (re)attaching — one half of a GIL <-> lock
-    // deadlock cycle. The cycle closes only if another thread holds the GIL
-    // while waiting for the same lock, and that is the half this rule
-    // eliminates. Detaching also lets other Python threads run while the
-    // sampler computes. Keep this unconditional: an attached fast path for
-    // Python-backed components reintroduces the deadlock.
+    // TODO(porink0424): Handle the potential GIL/lock deadlock in the ToRust*
+    // adapters for Python-backed components.
     #[pyo3(signature = (name, low, high, step=None, log=false))]
     pub fn suggest_float(
         &mut self,

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -282,9 +282,20 @@ impl PyTrial {
     pub fn storage<'py>(&self, py: Python<'py>) -> Py<PyAny> {
         self.storage_pyobj.clone_ref(py)
     }
+    // suggest_* runs its Rust work detached (GIL released), which upholds the
+    // rule shared with ask/tell/optimize in study.rs: never wait for the
+    // sampler mutex / storage rwlock while holding the GIL. The rule is
+    // needed because the ToRust* adapters for Python-backed samplers/storages
+    // hold these locks while (re)attaching — one half of a GIL <-> lock
+    // deadlock cycle. The cycle closes only if another thread holds the GIL
+    // while waiting for the same lock, and that is the half this rule
+    // eliminates. Detaching also lets other Python threads run while the
+    // sampler computes. Keep this unconditional: an attached fast path for
+    // Python-backed components reintroduces the deadlock.
     #[pyo3(signature = (name, low, high, step=None, log=false))]
     pub fn suggest_float(
         &mut self,
+        py: Python<'_>,
         name: &str,
         low: f64,
         high: f64,
@@ -292,17 +303,20 @@ impl PyTrial {
         log: bool,
     ) -> PyResult<f64> {
         let dist = Distribution::new_float(low, high, step, log);
-        let value = self.trial.suggest(name, &dist).map_err(|e| match e.kind {
-            rustuna_core::ErrorKind::UnsupportedMultiObjective => PyRuntimeError::new_err(
-                "The TPE sampler of rustuna currently only supports single objective study.",
-            ),
-            _ => PyRuntimeError::new_err(format!("Failed to suggest float: {e:?}")),
-        })?;
+        let value = py
+            .detach(|| self.trial.suggest(name, &dist))
+            .map_err(|e| match e.kind {
+                rustuna_core::ErrorKind::UnsupportedMultiObjective => PyRuntimeError::new_err(
+                    "The TPE sampler of rustuna currently only supports single objective study.",
+                ),
+                _ => PyRuntimeError::new_err(format!("Failed to suggest float: {e:?}")),
+            })?;
         Ok(value)
     }
     #[pyo3(signature = (name, low, high, step=1, log=false))]
     pub fn suggest_int(
         &mut self,
+        py: Python<'_>,
         name: &str,
         low: i64,
         high: i64,
@@ -310,33 +324,40 @@ impl PyTrial {
         log: bool,
     ) -> PyResult<i64> {
         let dist = Distribution::new_int(low, high, step, log);
-        let value = self.trial.suggest(name, &dist).map_err(|e| match e.kind {
-            rustuna_core::ErrorKind::UnsupportedMultiObjective => PyRuntimeError::new_err(
-                "The TPE sampler of rustuna currently only supports single objective study.",
-            ),
-            _ => PyRuntimeError::new_err(format!("Failed to suggest int: {e:?}")),
-        })?;
+        let value = py
+            .detach(|| self.trial.suggest(name, &dist))
+            .map_err(|e| match e.kind {
+                rustuna_core::ErrorKind::UnsupportedMultiObjective => PyRuntimeError::new_err(
+                    "The TPE sampler of rustuna currently only supports single objective study.",
+                ),
+                _ => PyRuntimeError::new_err(format!("Failed to suggest int: {e:?}")),
+            })?;
         Ok(value as i64)
     }
     #[pyo3(signature = (name, choices))]
     pub fn suggest_categorical(
         &mut self,
+        py: Python<'_>,
         name: &str,
         choices: Vec<Py<PyAny>>,
     ) -> PyResult<Py<PyAny>> {
+        // Only the Python choice <-> Rust label conversions run attached;
+        // the sampling itself runs detached (see suggest_float above).
         let mut category_labels: Vec<CategoryLabel> = Vec::with_capacity(choices.len());
-        let category_labels = Python::attach(|py| {
-            for choice in choices {
-                match pyobject_to_category_label(choice.bind(py)) {
-                    Ok(label) => category_labels.push(label),
-                    Err(e) => return Err(e),
-                }
+        for choice in choices {
+            match pyobject_to_category_label(choice.bind(py)) {
+                Ok(label) => category_labels.push(label),
+                Err(e) => return Err(e),
             }
-            Ok(category_labels)
-        })?;
-        let label = self
-            .trial
-            .suggest_categorical_enum(name, &category_labels)
+        }
+        let label = py
+            .detach(|| {
+                // Return an owned label: no borrow of `self` escapes the
+                // detach closure.
+                self.trial
+                    .suggest_categorical_enum(name, &category_labels)
+                    .cloned()
+            })
             .map_err(|e| match e.kind {
                 rustuna_core::ErrorKind::UnsupportedMultiObjective => PyRuntimeError::new_err(
                     "The TPE sampler of rustuna currently only supports single objective study.",
@@ -344,7 +365,7 @@ impl PyTrial {
                 _ => PyRuntimeError::new_err(format!("Failed to suggest categorical: {e:?}")),
             })?;
 
-        Python::attach(|py| category_label_to_pyobject(py, label).map(|b| b.unbind()))
+        category_label_to_pyobject(py, &label).map(|b| b.unbind())
     }
     #[pyo3(signature = (key, value))]
     pub fn set_user_attr(&mut self, key: &str, value: String) -> PyResult<()> {

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -345,10 +345,7 @@ impl PyTrial {
         // the sampling itself runs detached (see suggest_float above).
         let mut category_labels: Vec<CategoryLabel> = Vec::with_capacity(choices.len());
         for choice in choices {
-            match pyobject_to_category_label(choice.bind(py)) {
-                Ok(label) => category_labels.push(label),
-                Err(e) => return Err(e),
-            }
+            category_labels.push(pyobject_to_category_label(choice.bind(py))?);
         }
         let label = py
             .detach(|| {

--- a/rustuna_pyo3/tests/test_gil_release.py
+++ b/rustuna_pyo3/tests/test_gil_release.py
@@ -1,0 +1,86 @@
+"""Progress tests: the GIL must be released during Rust sampling/storage work.
+
+Mechanism shared by both tests: a worker thread runs a busy loop of
+suggest/ask/tell while the main thread tries to set a flag the worker
+watches. If the worker held the GIL throughout the run (which takes well
+under the 5s forced-switch interval), the main thread could not set the
+flag until the worker finished, so the worker would never observe it. The
+worker observing the flag mid-run therefore proves the main thread got the
+GIL while the worker was inside the detached Rust work.
+"""
+
+import sys
+import threading
+
+import rustuna
+
+
+def test_optimize_releases_gil() -> None:
+    # The worker runs a busy optimize; its detach points (the internal
+    # ask/tell and the suggest_* calls inside the objective) are what let
+    # the main thread run mid-optimize.
+    old_interval = sys.getswitchinterval()
+    sys.setswitchinterval(5.0)
+    try:
+        study = rustuna.create_study(
+            sampler=rustuna.samplers.TPESampler(seed=3, n_startup_trials=10)
+        )
+        first_trial_started = threading.Event()
+        progress: dict[str, int | bool | None] = {"flag": False, "seen_at": None}
+
+        def objective(trial: rustuna.Trial) -> float:
+            x = trial.suggest_float("x", -5.0, 5.0)
+            y = trial.suggest_float("y", -5.0, 5.0)
+            z = trial.suggest_int("z", 0, 100)
+            first_trial_started.set()
+            if progress["flag"] and progress["seen_at"] is None:
+                progress["seen_at"] = trial.number
+            return x * x + y * y + z
+
+        # daemon: if a deadlock regression keeps the worker alive past the
+        # join timeout below, the test fails but pytest can still exit.
+        worker = threading.Thread(
+            target=lambda: study.optimize(objective, n_trials=2000), daemon=True
+        )
+        worker.start()
+        assert first_trial_started.wait(timeout=60)
+        progress["flag"] = True  # only reachable mid-run if the GIL was released
+        worker.join(timeout=120)
+        assert not worker.is_alive()
+        assert progress["seen_at"] is not None
+    finally:
+        sys.setswitchinterval(old_interval)
+
+
+def test_ask_tell_release_gil() -> None:
+    # Same mechanism, but driving the ask/tell pymethods directly — a
+    # separate code path from the detach boundaries inside optimize.
+    old_interval = sys.getswitchinterval()
+    sys.setswitchinterval(5.0)
+    try:
+        study = rustuna.create_study(
+            sampler=rustuna.samplers.TPESampler(seed=3, n_startup_trials=10)
+        )
+        first_iteration_started = threading.Event()
+        progress: dict[str, int | bool | None] = {"flag": False, "seen_at": None}
+
+        def ask_tell_loop() -> None:
+            for i in range(2000):
+                trial = study.ask()
+                x = trial.suggest_float("x", -5.0, 5.0)
+                y = trial.suggest_float("y", -5.0, 5.0)
+                study.tell(trial.number, x * x + y * y)
+                first_iteration_started.set()
+                if progress["flag"] and progress["seen_at"] is None:
+                    progress["seen_at"] = i
+
+        # daemon: see test_optimize_releases_gil.
+        worker = threading.Thread(target=ask_tell_loop, daemon=True)
+        worker.start()
+        assert first_iteration_started.wait(timeout=60)
+        progress["flag"] = True  # only reachable mid-run if the GIL was released
+        worker.join(timeout=120)
+        assert not worker.is_alive()
+        assert progress["seen_at"] is not None
+    finally:
+        sys.setswitchinterval(old_interval)


### PR DESCRIPTION
## Summary

`Trial.suggest_*` and `Study.ask` / `tell` / `optimize` now run their Rust core work (sampler mutex / storage rwlock) under `py.detach`, so other Python threads can make progress while rustuna samples/stores. The detach is unconditional — a conditional attached path for Python-backed components (an object implemented in Python, driven through the `ToRust*` adapter) can deadlock (see the comment on `PyTrial::suggest_float`).

Behavior is unchanged: fixed-seed runs are bit-identical before/after. `tests/test_gil_release.py` proves the GIL is actually released.

### How to verify behavior is unchanged

Run the [verification script in the comment below](https://github.com/optuna/rustuna/pull/220#issuecomment-5340110703) on both builds (same machine) and compare the printed digests:

```bash
# on main, then on this branch:
cd rustuna_pyo3 && uv sync --group dev --reinstall-package rustuna
uv run --no-sync python verify_bitexact.py
```

### Known limitation

Other `Study` / trial methods (`best_trial`, `trials`, ...) still take the storage lock while attached. With a Python-backed storage, concurrent calls involving these methods can deadlock (this is pre-existing on main, not introduced here). This PR removes the hazard only for the four paths it touches. Native storages are unaffected. A follow-up PR will cover the rest.