### PR TITLE
emit warning when the key of some constraints is already set

### DIFF
--- a/rustuna_core/src/trial.rs
+++ b/rustuna_core/src/trial.rs
@@ -270,6 +270,16 @@ impl Trial {
                 format!("Failed to acquire storage guard: {e}"),
             )
         })?;
+        let persisted = guard.get_trial(self.id)?;
+        if let Some(AttrKey::System(key)) = attrs.keys().find(|k| persisted.attrs.contains_key(k)) {
+            // TODO(inoue): Replace eprintln! with warning once rustuna has a logging mechanism.
+            eprintln!(
+                "Warning: The constraint '{}' is already set. No constraint was updated.",
+                key.as_str().trim_start_matches(CONSTRAINTS_PREFIX)
+            );
+            return Ok(());
+        }
+
         guard.set_trial_attrs(self.id, attrs, false)?;
         drop(guard);
         Ok(())
@@ -631,6 +641,30 @@ mod tests {
 
         let constraints = trials[0].constraints()?;
         assert_eq!(constraints, HashMap::from([(String::from("c0"), 10.0)]));
+        Ok(())
+    }
+
+    #[test]
+    fn test_set_constraints_with_duplicated_key() -> Result<()> {
+        let storage = Arc::new(RwLock::new(InMemoryStorage::new()));
+        let sampler = Arc::new(RandomSampler::new());
+        let directions = vec![Direction::Minimize];
+        let study = create_study_with_arc("dummy", storage.clone(), sampler, directions)?;
+
+        let mut trial = study.ask()?;
+        let _ = trial.suggest_float("x", -10.0, 10.0)?;
+        trial.set_constraints(HashMap::from([(String::from("c0"), 10.0)]))?;
+
+        // "c0" is already set, so nothing is updated including the new "c1".
+        let constraints = HashMap::from([(String::from("c0"), 20.0), (String::from("c1"), 1.0)]);
+        trial.set_constraints(constraints)?;
+
+        let _ = study.tell(trial.number, TrialStateValues::Complete(vec![0.0]));
+        let trials = study.get_trials()?;
+        assert_eq!(
+            trials[0].constraints()?,
+            HashMap::from([(String::from("c0"), 10.0)])
+        );
         Ok(())
     }
 

--- a/rustuna_core/src/trial.rs
+++ b/rustuna_core/src/trial.rs
@@ -275,7 +275,9 @@ impl Trial {
             // TODO(inoue): Replace eprintln! with warning once rustuna has a logging mechanism.
             eprintln!(
                 "Warning: The constraint '{}' is already set. No constraint was updated.",
-                key.as_str().trim_start_matches(CONSTRAINTS_PREFIX)
+                key.as_str()
+                    .strip_prefix(CONSTRAINTS_PREFIX)
+                    .unwrap_or(key.as_str())
             );
             return Ok(());
         }

--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -175,8 +175,9 @@ class Trial:
         supports constraints, such as [TPESampler][rustuna.samplers.TPESampler] and
         [NSGAIISampler][rustuna.samplers.NSGAIISampler].
 
-        Calling this method again overwrites the values of the constraint names given in
-        `constraints`, and leaves the other names untouched.
+        A constraint name that is already set on the trial cannot be overwritten. If any of
+        the names in `constraints` is already set, a warning is emitted and none of the
+        values is recorded, not even the ones whose names are not set yet.
 
         Args:
             constraints: A dictionary object mapping each constraint name to its value.

--- a/rustuna_pyo3/tests/test_trial.py
+++ b/rustuna_pyo3/tests/test_trial.py
@@ -117,3 +117,19 @@ def test_constraints() -> None:
     study.optimize(objective, n_trials=1)
     assert study.trials[0].constraints["c0"] == 5.0
     assert study.trials[0].constraints["c1"] == 10.0
+
+
+def test_constraints_with_duplicated_key(capfd: pytest.CaptureFixture[str]) -> None:
+    study = rustuna.create_study()
+
+    trial = study.ask()
+    trial.set_constraints({"c0": 5.0})
+
+    # "c0" is already set, so nothing is updated including the new "c1".
+    trial.set_constraints({"c0": 10.0, "c1": 1.0})
+    # The warning is written to the stderr file descriptor by Rust, so it is only visible
+    # through capfd, not through capsys.
+    assert "The constraint 'c0' is already set." in capfd.readouterr().err
+
+    study.tell(trial.number, values=0.0)
+    assert study.trials[0].constraints == {"c0": 5.0}


### PR DESCRIPTION
I fixed the behavior when the key of some constraints is already set.
Specifically, emit warning and update nothing when it occurs.
This behavior is the same as that of Optuna (https://github.com/optuna/optuna/blob/1d8ce7bb6f3c7274a7a31a0a007991995085baa7/optuna/trial/_trial.py#L803-L809).