### PR TITLE
Release storage lock before TPE model construction

### DIFF
--- a/rustuna_core/src/multi_objective/mod.rs
+++ b/rustuna_core/src/multi_objective/mod.rs
@@ -40,4 +40,4 @@ mod split;
 
 pub use hssp::hypervolume_subset_selection;
 pub use nds::fast_non_dominated_sort_partial;
-pub use split::split_trials_for_multi_objective;
+pub use split::{split_observation_indices_for_multi_objective, split_trials_for_multi_objective};

--- a/rustuna_core/src/multi_objective/split.rs
+++ b/rustuna_core/src/multi_objective/split.rs
@@ -25,39 +25,54 @@ pub fn split_trials_for_multi_objective<'a>(
         return Ok((trials.to_vec(), Vec::new()));
     }
 
-    let mut feasible_trials = Vec::new();
-    let mut infeasible_trial_with_violations = Vec::new();
-    for &trial in trials {
-        let constraints = trial.constraints()?;
-        let feasible = constraints.values().all(|x| *x <= 0.0);
-        if feasible {
-            feasible_trials.push(trial);
-        } else {
+    let values = trials
+        .iter()
+        .map(|trial| match &trial.state_values {
+            TrialStateValues::Complete(values) => values.as_slice(),
+            _ => panic!("Unexpected non-complete trial found during multi-objective split"),
+        })
+        .collect::<Vec<_>>();
+    let feasibles_violations = trials
+        .iter()
+        .map(|trial| {
+            let constraints = trial.constraints()?;
+            let feasible = constraints.values().all(|x| *x <= 0.0);
             let violation = constraints.values().filter(|&x| *x > 0.0).sum::<f64>();
-            infeasible_trial_with_violations.push((trial, violation));
-        }
-    }
-
-    let feasible_gamma = gamma.min(feasible_trials.len());
-    let (mut good_trials, mut poor_trials) =
-        split_feasible_trials_for_multi_objective(&feasible_trials, directions, feasible_gamma);
-    let infeasible_gamma = gamma.saturating_sub(good_trials.len());
-    let (infeasible_good_trials, infeasible_poor_trials) =
-        split_infeasible_trials_for_multi_objective(
-            &mut infeasible_trial_with_violations,
-            infeasible_gamma,
-        );
-    good_trials.extend(infeasible_good_trials);
-    poor_trials.extend(infeasible_poor_trials);
+            Ok((feasible, violation))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let (good_indices, poor_indices) = split_observation_indices_for_multi_objective(
+        &values,
+        &feasibles_violations,
+        directions,
+        gamma,
+    );
+    let good_trials = good_indices.into_iter().map(|i| trials[i]).collect();
+    let poor_trials = poor_indices.into_iter().map(|i| trials[i]).collect();
     Ok((good_trials, poor_trials))
 }
 
-fn split_feasible_trials_for_multi_objective<'a>(
-    trials: &[&'a PersistedTrial],
+/// Splits objective observations into promising and non-promising index sets.
+///
+/// `values[i]` holds the observed objective values (before direction
+/// normalization) and `feasibles_violations[i]` the constraint feasibility and
+/// total violation of the same observation. Both returned vectors contain
+/// indices into the input slices: feasible observations are ranked by
+/// non-dominated sorting and hypervolume subset selection, and when fewer than
+/// `gamma` observations are feasible the promising set is padded with the
+/// least-violating infeasible ones.
+pub fn split_observation_indices_for_multi_objective<T: AsRef<[f64]>>(
+    values: &[T],
+    feasibles_violations: &[(bool, f64)],
     directions: &[Direction],
     gamma: usize,
-) -> (Vec<&'a PersistedTrial>, Vec<&'a PersistedTrial>) {
-    let n = trials.len();
+) -> (Vec<usize>, Vec<usize>) {
+    let n = values.len();
+    assert_eq!(
+        n,
+        feasibles_violations.len(),
+        "values and feasibles_violations must have the same length"
+    );
     assert!(
         gamma <= n,
         "gamma must be less than or equal to the number of trials"
@@ -67,18 +82,56 @@ fn split_feasible_trials_for_multi_objective<'a>(
         return (Vec::new(), Vec::new());
     }
     if gamma == n {
-        return (trials.to_vec(), Vec::new());
+        return ((0..n).collect(), Vec::new());
+    }
+
+    let mut feasible_indices = Vec::new();
+    let mut infeasible_index_violations = Vec::new();
+    for (index, &(feasible, violation)) in feasibles_violations.iter().enumerate() {
+        if feasible {
+            feasible_indices.push(index);
+        } else {
+            infeasible_index_violations.push((index, violation));
+        }
+    }
+
+    let feasible_gamma = gamma.min(feasible_indices.len());
+    let (mut good_indices, mut poor_indices) =
+        split_feasible_observation_indices(values, &feasible_indices, directions, feasible_gamma);
+    let infeasible_gamma = gamma.saturating_sub(good_indices.len());
+    let (infeasible_good_indices, infeasible_poor_indices) =
+        split_infeasible_observation_indices(&mut infeasible_index_violations, infeasible_gamma);
+    good_indices.extend(infeasible_good_indices);
+    poor_indices.extend(infeasible_poor_indices);
+    (good_indices, poor_indices)
+}
+
+fn split_feasible_observation_indices<T: AsRef<[f64]>>(
+    values: &[T],
+    feasible_indices: &[usize],
+    directions: &[Direction],
+    gamma: usize,
+) -> (Vec<usize>, Vec<usize>) {
+    let n = feasible_indices.len();
+    assert!(
+        gamma <= n,
+        "gamma must be less than or equal to the number of trials"
+    );
+
+    if n == 0 {
+        return (Vec::new(), Vec::new());
+    }
+    if gamma == n {
+        return (feasible_indices.to_vec(), Vec::new());
     }
 
     // Assume minimization (negate value if maximization)
-    let loss_values: Vec<Vec<f64>> = trials
+    let loss_values: Vec<Vec<f64>> = feasible_indices
         .iter()
-        .map(|t| {
-            let vals = match &t.state_values {
-                TrialStateValues::Complete(v) => v.as_slice(),
-                _ => panic!("Unexpected non-complete trial found during multi-objective split"),
-            };
-            vals.iter()
+        .map(|&index| {
+            values[index]
+                .as_ref()
+                .iter()
                 .zip(directions.iter())
                 .map(|(&val, dir)| match dir {
                     Direction::Minimize => val,
@@ -93,19 +146,19 @@ fn split_feasible_trials_for_multi_objective<'a>(
         rank_to_indices.entry(rank).or_default().push(i);
     }
 
-    let mut good_trials = Vec::with_capacity(gamma);
-    let mut poor_trials = Vec::with_capacity(n - gamma);
+    let mut good_local = Vec::with_capacity(gamma);
+    let mut poor_local = Vec::with_capacity(n - gamma);
 
     let mut current_rank = 0usize;
-    while good_trials.len() + rank_to_indices.get(&current_rank).map_or(0, |v| v.len()) <= gamma {
+    while good_local.len() + rank_to_indices.get(&current_rank).map_or(0, |v| v.len()) <= gamma {
         if let Some(indices) = rank_to_indices.get(&current_rank) {
             for &i in indices.iter() {
-                good_trials.push(trials[i]);
+                good_local.push(i);
             }
         }
         current_rank += 1;
     }
-    let hss_subset_size = gamma - good_trials.len();
+    let hss_subset_size = gamma - good_local.len();
     if hss_subset_size > 0 {
         let rank_i_loss_vals = rank_to_indices
             .get(&current_rank)
@@ -150,7 +203,7 @@ fn split_feasible_trials_for_multi_objective<'a>(
 
         let mut remaining = hss_subset_size;
         for &local in neg_inf_local.iter().take(remaining) {
-            good_trials.push(trials[rank_i_indices[local]]);
+            good_local.push(rank_i_indices[local]);
         }
         remaining = remaining.saturating_sub(neg_inf_local.len());
 
@@ -184,7 +237,7 @@ fn split_feasible_trials_for_multi_objective<'a>(
                     take,
                 );
                 for &i in selected_indices.iter() {
-                    good_trials.push(trials[i]);
+                    good_local.push(i);
                 }
                 remaining = remaining.saturating_sub(take);
             } else {
@@ -193,31 +246,40 @@ fn split_feasible_trials_for_multi_objective<'a>(
                 // which the outer guard already excluded). Defensive fallback.
                 let take = remaining.min(finite_local.len());
                 for &local in finite_local.iter().take(take) {
-                    good_trials.push(trials[rank_i_indices[local]]);
+                    good_local.push(rank_i_indices[local]);
                 }
                 remaining = remaining.saturating_sub(take);
             }
         }
 
         for &local in pos_inf_local.iter().take(remaining) {
-            good_trials.push(trials[rank_i_indices[local]]);
+            good_local.push(rank_i_indices[local]);
         }
     }
-    let good_numbers: HashSet<u32> = good_trials.iter().map(|t| t.number).collect();
-    for &trial in trials.iter() {
-        if !good_numbers.contains(&trial.number) {
-            poor_trials.push(trial);
+    let good_local_set: HashSet<usize> = good_local.iter().copied().collect();
+    for local in 0..n {
+        if !good_local_set.contains(&local) {
+            poor_local.push(local);
         }
     }
 
-    (good_trials, poor_trials)
+    (
+        good_local
+            .into_iter()
+            .map(|local| feasible_indices[local])
+            .collect(),
+        poor_local
+            .into_iter()
+            .map(|local| feasible_indices[local])
+            .collect(),
+    )
 }
 
-fn split_infeasible_trials_for_multi_objective<'a>(
-    trial_with_violations: &mut [(&'a PersistedTrial, f64)],
+fn split_infeasible_observation_indices(
+    index_violations: &mut [(usize, f64)],
     gamma: usize,
-) -> (Vec<&'a PersistedTrial>, Vec<&'a PersistedTrial>) {
-    let n = trial_with_violations.len();
+) -> (Vec<usize>, Vec<usize>) {
+    let n = index_violations.len();
     assert!(
         gamma <= n,
         "gamma must be less than or equal to the number of trials"
@@ -228,24 +290,167 @@ fn split_infeasible_trials_for_multi_objective<'a>(
     if gamma == 0 {
         return (
             Vec::new(),
-            trial_with_violations.iter().map(|&(t, _)| t).collect(),
+            index_violations.iter().map(|&(i, _)| i).collect(),
         );
     }
     if gamma == n {
         return (
-            trial_with_violations.iter().map(|&(t, _)| t).collect(),
+            index_violations.iter().map(|&(i, _)| i).collect(),
             Vec::new(),
         );
     }
 
-    trial_with_violations.select_nth_unstable_by(gamma, |(_, violation_i), (_, violation_j)| {
+    index_violations.select_nth_unstable_by(gamma, |(_, violation_i), (_, violation_j)| {
         violation_i
             .partial_cmp(violation_j)
             .expect("constraint is non-Nan value")
     });
-    let (good_trials, poor_trials) = trial_with_violations.split_at(gamma);
+    let (good_indices, poor_indices) = index_violations.split_at(gamma);
     (
-        good_trials.iter().map(|&(t, _)| t).collect(),
-        poor_trials.iter().map(|&(t, _)| t).collect(),
+        good_indices.iter().map(|&(i, _)| i).collect(),
+        poor_indices.iter().map(|&(i, _)| i).collect(),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::attr::AttrKey;
+
+    const FEASIBLE: (bool, f64) = (true, 0.0);
+
+    #[test]
+    fn split_observation_indices_returns_original_positions() {
+        let values = vec![vec![3.0], vec![1.0], vec![4.0], vec![2.0]];
+        let feasibles_violations = vec![FEASIBLE; values.len()];
+        let (good, poor) = split_observation_indices_for_multi_objective(
+            &values,
+            &feasibles_violations,
+            &[Direction::Minimize],
+            2,
+        );
+
+        assert_eq!(good, vec![1, 3]);
+        assert_eq!(poor, vec![0, 2]);
+    }
+
+    #[test]
+    fn split_observation_indices_pads_with_least_violating_infeasible() {
+        let values = vec![vec![1.0], vec![2.0], vec![3.0], vec![4.0]];
+        let feasibles_violations = vec![(false, 5.0), (true, 0.0), (false, 1.0), (false, 3.0)];
+        let (good, poor) = split_observation_indices_for_multi_objective(
+            &values,
+            &feasibles_violations,
+            &[Direction::Minimize],
+            2,
+        );
+
+        // The single feasible observation is promising; the second slot is
+        // filled by the infeasible observation with the smallest violation.
+        assert_eq!(good, vec![1, 2]);
+        assert_eq!(poor.len(), 2);
+        assert!(poor.contains(&0) && poor.contains(&3));
+    }
+
+    #[test]
+    fn split_observation_indices_all_infeasible() {
+        let values = vec![vec![1.0], vec![2.0], vec![3.0]];
+        let feasibles_violations = vec![(false, 2.0), (false, 3.0), (false, 1.0)];
+        let (good, poor) = split_observation_indices_for_multi_objective(
+            &values,
+            &feasibles_violations,
+            &[Direction::Minimize],
+            1,
+        );
+
+        assert_eq!(good, vec![2]);
+        assert_eq!(poor.len(), 2);
+        assert!(poor.contains(&0) && poor.contains(&1));
+    }
+
+    #[test]
+    fn split_observation_indices_gamma_equals_n() {
+        let values = vec![vec![3.0], vec![1.0]];
+        let feasibles_violations = vec![(true, 0.0), (false, 1.0)];
+        let (good, poor) = split_observation_indices_for_multi_objective(
+            &values,
+            &feasibles_violations,
+            &[Direction::Minimize],
+            2,
+        );
+
+        assert_eq!(good, vec![0, 1]);
+        assert!(poor.is_empty());
+    }
+
+    #[test]
+    fn split_observation_indices_empty_input() {
+        let values: Vec<Vec<f64>> = Vec::new();
+        let (good, poor) =
+            split_observation_indices_for_multi_objective(&values, &[], &[Direction::Minimize], 0);
+
+        assert!(good.is_empty());
+        assert!(poor.is_empty());
+    }
+
+    fn complete_trial(number: u32, values: Vec<f64>, constraint: Option<f64>) -> PersistedTrial {
+        let mut trial = PersistedTrial::new(number, 0, number);
+        trial.state_values = TrialStateValues::Complete(values);
+        if let Some(c) = constraint {
+            trial
+                .attrs
+                .insert(AttrKey::System("constraints:c0".into()), c.to_string());
+        }
+        trial
+    }
+
+    #[test]
+    fn split_trials_matches_index_based_split() {
+        let trials = [
+            complete_trial(0, vec![1.0, 8.0], None),
+            complete_trial(1, vec![f64::INFINITY, 1.0], Some(-1.0)),
+            complete_trial(2, vec![2.0, 2.0], Some(0.5)),
+            complete_trial(3, vec![3.0, 3.0], Some(2.0)),
+            complete_trial(4, vec![4.0, 1.0], None),
+            complete_trial(5, vec![0.5, 9.0], Some(-0.5)),
+        ];
+        let trial_refs: Vec<&PersistedTrial> = trials.iter().collect();
+        let directions = [Direction::Minimize, Direction::Minimize];
+        let gamma = 3;
+
+        let (good_trials, poor_trials) =
+            split_trials_for_multi_objective(&trial_refs, &directions, gamma).unwrap();
+
+        let values: Vec<&[f64]> = trials
+            .iter()
+            .map(|t| match &t.state_values {
+                TrialStateValues::Complete(v) => v.as_slice(),
+                _ => unreachable!(),
+            })
+            .collect();
+        let feasibles_violations: Vec<(bool, f64)> = trials
+            .iter()
+            .map(|t| {
+                let constraints = t.constraints().unwrap();
+                (
+                    constraints.values().all(|x| *x <= 0.0),
+                    constraints.values().filter(|&x| *x > 0.0).sum(),
+                )
+            })
+            .collect();
+        let (good_indices, poor_indices) = split_observation_indices_for_multi_objective(
+            &values,
+            &feasibles_violations,
+            &directions,
+            gamma,
+        );
+
+        let good_numbers: Vec<u32> = good_trials.iter().map(|t| t.number).collect();
+        let poor_numbers: Vec<u32> = poor_trials.iter().map(|t| t.number).collect();
+        let good_mapped: Vec<u32> = good_indices.iter().map(|&i| trials[i].number).collect();
+        let poor_mapped: Vec<u32> = poor_indices.iter().map(|&i| trials[i].number).collect();
+        assert_eq!(good_numbers, good_mapped);
+        assert_eq!(poor_numbers, poor_mapped);
+        assert_eq!(good_numbers.len(), gamma);
+    }
 }

--- a/rustuna_core/src/multi_objective/split.rs
+++ b/rustuna_core/src/multi_objective/split.rs
@@ -406,6 +406,9 @@ mod tests {
 
     #[test]
     fn split_trials_matches_index_based_split() {
+        // The mutually non-dominated feasible trials 0, 4, 5, and 6 form a rank-0
+        // front larger than gamma, so the promising set is completed by
+        // hypervolume subset selection rather than by whole-rank inclusion.
         let trials = [
             complete_trial(0, vec![1.0, 8.0], None),
             complete_trial(1, vec![f64::INFINITY, 1.0], Some(-1.0)),
@@ -413,6 +416,7 @@ mod tests {
             complete_trial(3, vec![3.0, 3.0], Some(2.0)),
             complete_trial(4, vec![4.0, 1.0], None),
             complete_trial(5, vec![0.5, 9.0], Some(-0.5)),
+            complete_trial(6, vec![3.0, 2.0], None),
         ];
         let trial_refs: Vec<&PersistedTrial> = trials.iter().collect();
         let directions = [Direction::Minimize, Direction::Minimize];

--- a/rustuna_pyo3/src/study.rs
+++ b/rustuna_pyo3/src/study.rs
@@ -389,12 +389,13 @@ impl PyStudy {
         })
     }
 
-    /// The optimize loop. ask/tell take the storage write lock and sampler
-    /// mutex inside rustuna_core: they run detached (see the comment on
-    /// `PyTrial::suggest_float`), which also lets other Python threads —
-    /// including concurrent optimize calls on this study — make progress
-    /// while a trial is being sampled or stored. Only the objective call,
-    /// its result conversion, and the exception classification run attached.
+    /// The optimize loop. ask/tell take the storage write lock and the
+    /// sampler-internal locks inside rustuna_core: they run detached (see
+    /// the comment on `PyTrial::suggest_float`), which also lets other
+    /// Python threads — including concurrent optimize calls on this study —
+    /// make progress while a trial is being sampled or stored. Only the
+    /// objective call, its result conversion, and the exception
+    /// classification run attached.
     #[pyo3(signature = (objective, n_trials, catch = None))]
     pub fn optimize(
         &self,

--- a/rustuna_sampler/src/tpe/sampler.rs
+++ b/rustuna_sampler/src/tpe/sampler.rs
@@ -1,6 +1,5 @@
-use core::panic;
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex, RwLock};
 
 use rand::rngs::StdRng;
@@ -39,7 +38,41 @@ impl Default for TpeConfig {
 }
 
 type SplitKey = (Vec<u32>, usize);
-type SplitValue = (Vec<u32>, Vec<u32>);
+type SplitValue = (HashSet<u32>, HashSet<u32>);
+
+/// Owned, columnar snapshot of the usable completed trials, copied out of the
+/// storage so the storage guard can be dropped before the TPE model is built.
+/// Row `i` describes one completed trial; rows are in storage order. The flat
+/// layout keeps the copy under the storage guard to a handful of allocations
+/// regardless of the trial count.
+struct TpeObservations {
+    trial_numbers: Vec<u32>,
+    /// Objective values, `n_objectives` slots per row.
+    values: Vec<f64>,
+    n_objectives: usize,
+    /// Parameter values in sorted-key order of the requested search space,
+    /// `n_params` slots per row; `None` where the trial did not observe that
+    /// parameter.
+    params: Vec<Option<f64>>,
+    n_params: usize,
+    /// Constraint feasibility and total violation of row `i`.
+    feasibles_violations: Vec<(bool, f64)>,
+}
+
+impl TpeObservations {
+    fn len(&self) -> usize {
+        self.trial_numbers.len()
+    }
+
+    fn values_row(&self, row: usize) -> &[f64] {
+        &self.values[row * self.n_objectives..(row + 1) * self.n_objectives]
+    }
+
+    fn params_row(&self, row: usize) -> &[Option<f64>] {
+        &self.params[row * self.n_params..(row + 1) * self.n_params]
+    }
+}
+
 /// Tree-structured Parzen Estimator sampler.
 ///
 /// This sampler is the Rustuna counterpart of Optuna's `TPESampler`.
@@ -146,29 +179,26 @@ impl TpeSampler {
     fn sample(
         &self,
         ctx: &Context,
-        complete_trials: &[&rustuna_core::trial::PersistedTrial],
+        observations: &TpeObservations,
         search_space: &HashMap<String, Distribution>,
     ) -> Result<HashMap<String, f64>> {
+        let n = observations.len();
         let is_multi_objective = ctx.directions.len() > 1;
 
         let (pe_good, pe_poor) = if !is_multi_objective {
-            let gamma = Self::gamma_for_single_objective(complete_trials.len());
+            let gamma = Self::gamma_for_single_objective(n);
             let direction: &Direction = &ctx.directions[0];
-            let (good_trials, poor_trials) =
-                Self::split_trials_for_single_objective(complete_trials, direction, gamma)?;
+            let (good_rows, poor_rows) =
+                Self::split_rows_for_single_objective(observations, direction, gamma);
             // Single-objective: recency ramp for both l(x) and g(x) (Optuna default_weights).
             (
-                Self::build_parzen_estimator(&good_trials, search_space, true),
-                Self::build_parzen_estimator(&poor_trials, search_space, true),
+                Self::build_parzen_estimator(observations, &good_rows, search_space, true),
+                Self::build_parzen_estimator(observations, &poor_rows, search_space, true),
             )
         } else {
             let directions: &[Direction] = &ctx.directions;
-            let gamma = Self::gamma_for_multi_objective(complete_trials.len());
-            let complete_trial_numbers = complete_trials
-                .iter()
-                .map(|t| t.number)
-                .collect::<Vec<u32>>();
-            let split_cache_key = (complete_trial_numbers.clone(), gamma);
+            let gamma = Self::gamma_for_multi_objective(n);
+            let split_cache_key = (observations.trial_numbers.clone(), gamma);
             let cached_split = self
                 .split_cache
                 .read()
@@ -180,44 +210,49 @@ impl TpeSampler {
                 })?
                 .get(&split_cache_key)
                 .cloned();
-            let (good_trials, poor_trials): (
-                Vec<&rustuna_core::trial::PersistedTrial>,
-                Vec<&rustuna_core::trial::PersistedTrial>,
-            ) = if let Some((good_nums, poor_nums)) = cached_split {
-                let good_trials = complete_trials
-                    .iter()
-                    .copied()
-                    .filter(|t| good_nums.contains(&t.number))
-                    .collect::<Vec<_>>();
-                let poor_trials = complete_trials
-                    .iter()
-                    .copied()
-                    .filter(|t| poor_nums.contains(&t.number))
-                    .collect::<Vec<_>>();
-                (good_trials, poor_trials)
-            } else {
-                let (good_trials, poor_trials) = multi_objective::split_trials_for_multi_objective(
-                    complete_trials,
-                    directions,
-                    gamma,
-                )?;
-                let good_nums = good_trials.iter().map(|t| t.number).collect();
-                let poor_nums = poor_trials.iter().map(|t| t.number).collect();
-                let mut split_cache = self.split_cache.write().map_err(|e| {
-                    Error::with_reason(
-                        ErrorKind::SamplerError,
-                        format!("Failed to acquire split cache guard: {e}"),
-                    )
-                })?;
-                split_cache.clear();
-                split_cache.insert(split_cache_key, (good_nums, poor_nums));
-                (good_trials, poor_trials)
-            };
+            let (good_rows, poor_rows): (Vec<usize>, Vec<usize>) =
+                if let Some((good_nums, poor_nums)) = cached_split {
+                    let good_rows = (0..n)
+                        .filter(|&row| good_nums.contains(&observations.trial_numbers[row]))
+                        .collect();
+                    let poor_rows = (0..n)
+                        .filter(|&row| poor_nums.contains(&observations.trial_numbers[row]))
+                        .collect();
+                    (good_rows, poor_rows)
+                } else {
+                    let value_rows = (0..n)
+                        .map(|row| observations.values_row(row))
+                        .collect::<Vec<_>>();
+                    let (good_rows, poor_rows) =
+                        multi_objective::split_observation_indices_for_multi_objective(
+                            &value_rows,
+                            &observations.feasibles_violations,
+                            directions,
+                            gamma,
+                        );
+                    let good_nums = good_rows
+                        .iter()
+                        .map(|&row| observations.trial_numbers[row])
+                        .collect();
+                    let poor_nums = poor_rows
+                        .iter()
+                        .map(|&row| observations.trial_numbers[row])
+                        .collect();
+                    let mut split_cache = self.split_cache.write().map_err(|e| {
+                        Error::with_reason(
+                            ErrorKind::SamplerError,
+                            format!("Failed to acquire split cache guard: {e}"),
+                        )
+                    })?;
+                    split_cache.clear();
+                    split_cache.insert(split_cache_key, (good_nums, poor_nums));
+                    (good_rows, poor_rows)
+                };
             // Multi-objective: uniform weights for l(x) (below), recency ramp for g(x) (above),
             // matching Optuna's multi-objective TPE.
             (
-                Self::build_parzen_estimator(&good_trials, search_space, false),
-                Self::build_parzen_estimator(&poor_trials, search_space, true),
+                Self::build_parzen_estimator(observations, &good_rows, search_space, false),
+                Self::build_parzen_estimator(observations, &poor_rows, search_space, true),
             )
         };
 
@@ -243,57 +278,37 @@ impl TpeSampler {
         Ok(samples_good[best_idx].clone())
     }
 
-    fn split_trials_for_single_objective<'a>(
-        trials: &[&'a rustuna_core::trial::PersistedTrial],
+    fn split_rows_for_single_objective(
+        observations: &TpeObservations,
         direction: &Direction,
         gamma: usize,
-    ) -> Result<(
-        Vec<&'a rustuna_core::trial::PersistedTrial>,
-        Vec<&'a rustuna_core::trial::PersistedTrial>,
-    )> {
-        let n = trials.len();
+    ) -> (Vec<usize>, Vec<usize>) {
+        let n = observations.len();
         assert!(
             gamma <= n,
             "gamma must be less than or equal to the number of trials"
         );
 
         if n == 0 {
-            return Ok((Vec::new(), Vec::new()));
+            return (Vec::new(), Vec::new());
         }
         if gamma == n {
-            return Ok((trials.to_vec(), Vec::new()));
+            return ((0..n).collect(), Vec::new());
         }
 
-        fn value_for(t: &rustuna_core::trial::PersistedTrial) -> f64 {
-            match &t.state_values {
-                TrialStateValues::Complete(v) => v[0],
-                _ => panic!("Unexpected non-complete trial found during TPE sampling"),
-            }
-        }
+        let value_for = |row: usize| observations.values_row(row)[0];
 
-        // Since `usable_complete_trials` already filtered non-completed trials,
-        // we only check feasiblity of `trial`.
-        let feasibles_violations = trials
-            .iter()
-            .map(|trial| {
-                let constraints = trial.constraints()?;
-                let feasible = constraints.values().all(|x| *x <= 0.0);
-                let violation = constraints.values().filter(|&x| *x > 0.0).sum::<f64>();
-                Ok((feasible, violation))
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        // NaN trials must always land in `poor_trials` regardless of `direction`:
+        // NaN trials must always land in `poor_rows` regardless of `direction`:
         // a NaN observation is a failed evaluation, and feeding it into the Parzen
-        // estimator would corrupt the `good_trials` model. Using
+        // estimator would corrupt the `good_rows` model. Using
         // `partial_cmp(...).unwrap_or(Equal)` would let NaN keep its original
         // position in the partial sort and so non-deterministically slip into the
         // good half. Treat NaN as strictly worse than any finite value, in both
         // directions.
         let mut idx: Vec<usize> = (0..n).collect();
-        let compare_feasibles = |i, j| {
-            let vi = value_for(trials[i]);
-            let vj = value_for(trials[j]);
+        let compare_feasibles = |i: usize, j: usize| {
+            let vi = value_for(i);
+            let vj = value_for(j);
             match (vi.is_nan(), vj.is_nan()) {
                 (true, true) => Ordering::Equal,
                 (true, false) => Ordering::Greater,
@@ -310,8 +325,8 @@ impl TpeSampler {
             }
         };
         idx.select_nth_unstable_by(gamma, |&i, &j| {
-            let (feasible_i, violation_i) = feasibles_violations[i];
-            let (feasible_j, violation_j) = feasibles_violations[j];
+            let (feasible_i, violation_i) = observations.feasibles_violations[i];
+            let (feasible_j, violation_j) = observations.feasibles_violations[j];
             match (feasible_i, feasible_j) {
                 (true, true) => compare_feasibles(i, j),
                 (true, false) => Ordering::Less,
@@ -322,15 +337,9 @@ impl TpeSampler {
             }
         });
 
-        let mut good_trials = Vec::with_capacity(gamma);
-        let mut poor_trials = Vec::with_capacity(n - gamma);
-        for &i in idx.iter().take(gamma) {
-            good_trials.push(trials[i]);
-        }
-        for &i in idx.iter().skip(gamma) {
-            poor_trials.push(trials[i]);
-        }
-        Ok((good_trials, poor_trials))
+        let good_rows = idx[..gamma].to_vec();
+        let poor_rows = idx[gamma..].to_vec();
+        (good_rows, poor_rows)
     }
 
     fn gamma_for_single_objective(n: usize) -> usize {
@@ -343,14 +352,15 @@ impl TpeSampler {
         (0.1 * n as f64).ceil() as usize
     }
 
-    /// Keep only trials whose `Complete` values are fully finite-or-±inf. Trials
-    /// carrying NaN are dropped here, before the `n_startup_trials` gate, so they
-    /// neither inflate `gamma` nor leak into `good_trials`. In the all-NaN /
-    /// finite-count-below-startup case the resulting empty / short list naturally
+    /// Counts the trials that [`Self::snapshot_usable_complete_trials`] would
+    /// keep: only trials whose `Complete` values are fully finite-or-±inf.
+    /// Trials carrying NaN are dropped here, before the `n_startup_trials`
+    /// gate, so they neither inflate `gamma` nor leak into the good rows. In
+    /// the all-NaN / finite-count-below-startup case the short count naturally
     /// falls through to the random sampler via the existing startup gate.
-    fn usable_complete_trials(
+    fn count_usable_complete_trials(
         trials: &[Option<rustuna_core::trial::PersistedTrial>],
-    ) -> Vec<&rustuna_core::trial::PersistedTrial> {
+    ) -> usize {
         trials
             .iter()
             .flatten()
@@ -358,7 +368,65 @@ impl TpeSampler {
                 TrialStateValues::Complete(v) => !v.iter().any(|x| x.is_nan()),
                 _ => false,
             })
-            .collect()
+            .count()
+    }
+
+    /// Copies the usable completed trials (the same selection as
+    /// [`Self::count_usable_complete_trials`], in storage order) into owned
+    /// observations so the storage guard can be dropped before the TPE model
+    /// is built. `n_usable` is that count, used to size the buffers up front.
+    /// Parameter values are captured in sorted-key order of `search_space`;
+    /// constraint feasibility is evaluated per trial.
+    fn snapshot_usable_complete_trials(
+        trials: &[Option<rustuna_core::trial::PersistedTrial>],
+        search_space: &HashMap<String, Distribution>,
+        n_objectives: usize,
+        n_usable: usize,
+    ) -> Result<TpeObservations> {
+        let mut sorted_keys = search_space.keys().collect::<Vec<_>>();
+        sorted_keys.sort();
+        let n_params = sorted_keys.len();
+        let mut observations = TpeObservations {
+            trial_numbers: Vec::with_capacity(n_usable),
+            values: Vec::with_capacity(n_usable * n_objectives),
+            n_objectives,
+            params: Vec::with_capacity(n_usable * n_params),
+            n_params,
+            feasibles_violations: Vec::with_capacity(n_usable),
+        };
+        for trial in trials.iter().flatten() {
+            let TrialStateValues::Complete(values) = &trial.state_values else {
+                continue;
+            };
+            if values.iter().any(|x| x.is_nan()) {
+                continue;
+            }
+            if values.len() != n_objectives {
+                return Err(Error::with_reason(
+                    ErrorKind::Unexpected,
+                    format!(
+                        "Trial {} has {} objective values but the study has {} directions",
+                        trial.number,
+                        values.len(),
+                        n_objectives
+                    ),
+                ));
+            }
+            let constraints = trial.constraints()?;
+            let feasible = constraints.values().all(|x| *x <= 0.0);
+            let violation = constraints.values().filter(|&x| *x > 0.0).sum::<f64>();
+            observations.trial_numbers.push(trial.number);
+            observations.values.extend_from_slice(values);
+            for name in &sorted_keys {
+                observations
+                    .params
+                    .push(trial.internal_params.get(*name).copied());
+            }
+            observations
+                .feasibles_violations
+                .push((feasible, violation));
+        }
+        Ok(observations)
     }
 
     fn weights_for_single_objective(x: usize) -> Vec<f64> {
@@ -390,7 +458,8 @@ impl TpeSampler {
     }
 
     fn build_parzen_estimator(
-        trials: &[&rustuna_core::trial::PersistedTrial],
+        observations: &TpeObservations,
+        rows: &[usize],
         search_space: &HashMap<String, Distribution>,
         recency_ramp: bool,
     ) -> ParzenEstimator {
@@ -398,26 +467,25 @@ impl TpeSampler {
         sorted_keys.sort();
 
         let n_params = sorted_keys.len();
-        let n_trials = trials.len();
+        let n_trials = rows.len();
+        debug_assert_eq!(n_params, observations.n_params);
 
         // Process trials in chronological (trial-number ascending) order so that the
         // recency ramp assigns the highest weights to the most recent trials, matching
         // Optuna's `default_weights`. (Uniform weights are order-invariant, so sorting is
         // harmless there; the split routines do not preserve chronological order.)
-        let mut order: Vec<usize> = (0..n_trials).collect();
-        order.sort_by_key(|&i| trials[i].number);
-        let trials: Vec<&rustuna_core::trial::PersistedTrial> =
-            order.iter().map(|&i| trials[i]).collect();
+        let mut order: Vec<usize> = rows.to_vec();
+        order.sort_by_key(|&row| observations.trial_numbers[row]);
 
         let mut observations_vec: Vec<Vec<f64>> = (0..n_params)
             .map(|_| Vec::with_capacity(n_trials))
             .collect();
         let mut active_counts: Vec<u32> = vec![0; n_trials];
 
-        for (trial_idx, t) in trials.iter().enumerate() {
-            for (param_idx, key) in sorted_keys.iter().enumerate() {
-                if let Some(&v) = t.internal_params.get(*key) {
-                    observations_vec[param_idx].push(v);
+        for (trial_idx, &row) in order.iter().enumerate() {
+            for (param_idx, param) in observations.params_row(row).iter().enumerate() {
+                if let Some(v) = param {
+                    observations_vec[param_idx].push(*v);
                     active_counts[trial_idx] += 1;
                 }
             }
@@ -430,9 +498,9 @@ impl TpeSampler {
         // below (`l(x)`) and above (`g(x)`) estimators; multi-objective uses uniform weights
         // for the below estimator and the recency ramp for the above estimator.
         let weights = if recency_ramp {
-            Self::weights_for_single_objective(trials.len())
+            Self::weights_for_single_objective(n_trials)
         } else {
-            vec![1.0; trials.len()]
+            vec![1.0; n_trials]
         };
         let active_weights: Vec<f64> = active_indices.iter().map(|&i| weights[i]).collect();
         let prior_weight = 1.0;
@@ -457,7 +525,11 @@ impl Sampler for TpeSampler {
             return distribution.get_single_value();
         }
 
-        {
+        let search_space = HashMap::from([(name.to_string(), distribution.clone())]);
+        // Hold the storage guard only while copying the observations; the TPE
+        // model construction below runs without any storage lock so concurrent
+        // trials can keep reading and writing the storage meanwhile.
+        let observations = {
             let mut guard = storage.write().map_err(|e| {
                 Error::with_reason(
                     ErrorKind::Unexpected,
@@ -465,13 +537,21 @@ impl Sampler for TpeSampler {
                 )
             })?;
             let trials = guard.get_trials(ctx.study_id)?;
-            let complete_trials: Vec<&rustuna_core::trial::PersistedTrial> =
-                Self::usable_complete_trials(trials);
-            if complete_trials.len() >= self.n_startup_trials {
-                let search_space = HashMap::from([(name.to_string(), distribution.clone())]);
-                let params = self.sample(ctx, &complete_trials, &search_space)?;
-                return Ok(params[name]);
+            let n_usable = Self::count_usable_complete_trials(trials);
+            if n_usable >= self.n_startup_trials {
+                Some(Self::snapshot_usable_complete_trials(
+                    trials,
+                    &search_space,
+                    ctx.directions.len(),
+                    n_usable,
+                )?)
+            } else {
+                None
             }
+        };
+        if let Some(observations) = observations {
+            let params = self.sample(ctx, &observations, &search_space)?;
+            return Ok(params[name]);
         }
         self.random_sampler
             .sample_independent(ctx, storage, name, distribution)
@@ -505,20 +585,30 @@ impl Sampler for TpeSampler {
             return Ok(HashMap::new());
         }
 
-        let mut guard = storage.write().map_err(|e| {
-            Error::with_reason(
-                ErrorKind::Unexpected,
-                format!("Failed to acquire storage guard: {e}"),
-            )
-        })?;
-        let trials = guard.get_trials(ctx.study_id)?;
-        let complete_trials: Vec<&rustuna_core::trial::PersistedTrial> =
-            Self::usable_complete_trials(trials);
-        if complete_trials.len() < self.n_startup_trials {
-            return Ok(HashMap::new());
-        }
+        // Hold the storage guard only while copying the observations; the TPE
+        // model construction below runs without any storage lock so concurrent
+        // trials can keep reading and writing the storage meanwhile.
+        let observations = {
+            let mut guard = storage.write().map_err(|e| {
+                Error::with_reason(
+                    ErrorKind::Unexpected,
+                    format!("Failed to acquire storage guard: {e}"),
+                )
+            })?;
+            let trials = guard.get_trials(ctx.study_id)?;
+            let n_usable = Self::count_usable_complete_trials(trials);
+            if n_usable < self.n_startup_trials {
+                return Ok(HashMap::new());
+            }
+            Self::snapshot_usable_complete_trials(
+                trials,
+                search_space,
+                ctx.directions.len(),
+                n_usable,
+            )?
+        };
 
-        self.sample(ctx, &complete_trials, search_space)
+        self.sample(ctx, &observations, search_space)
     }
 
     fn after_trial(
@@ -695,7 +785,7 @@ mod tests {
     }
 
     /// When every completed trial is NaN the sampler must not feed NaN observations
-    /// into the Parzen estimator; the entry-side `usable_complete_trials` filter
+    /// into the Parzen estimator; the entry-side snapshot filter
     /// drops NaN trials before the startup gate so the sampler falls back to random
     /// sampling cleanly.
     #[test]
@@ -933,6 +1023,82 @@ mod tests {
             result.is_ok(),
             "Optimization should complete without panicking."
         );
+    }
+
+    /// Trials that never call `set_constraints` have an empty constraint map and
+    /// count as feasible; mixing them with constrained trials in one study must
+    /// not panic or corrupt the split.
+    #[test]
+    fn test_mixed_constrained_and_unconstrained_trials() {
+        let storage = InMemoryStorage::new();
+        let directions = vec![Direction::Minimize];
+        let study = create_study(
+            "mixed-constraints",
+            storage,
+            TpeSampler::seed_from_u64(0),
+            directions,
+        )
+        .unwrap();
+        let result = study.optimize(
+            |mut t| {
+                let x = t.suggest_float("x", -10.0, 10.0)?;
+                if t.number % 2 == 0 {
+                    let c0 = x - 5.0;
+                    t.set_constraints(HashMap::from([(String::from("c0"), c0)]))?;
+                }
+                Ok(vec![x.powi(2)])
+            },
+            60,
+        );
+        assert!(
+            result.is_ok(),
+            "Optimization should complete without panicking."
+        );
+    }
+
+    /// One `TpeSampler` shared by several optimizing threads must stay
+    /// consistent: every trial completes and the total count is exact.
+    #[test]
+    fn test_shared_sampler_across_threads() {
+        let n_threads = 4;
+        let n_trials_per_thread = 30;
+        let storage = InMemoryStorage::new();
+        let directions = vec![Direction::Minimize];
+        let study = create_study(
+            "threaded-quadratic",
+            storage,
+            TpeSampler::seed_from_u64(0),
+            directions,
+        )
+        .unwrap();
+        std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..n_threads)
+                .map(|_| {
+                    let study = study.clone();
+                    scope.spawn(move || {
+                        study.optimize(
+                            |mut t| {
+                                let x = t.suggest_float("x", -10.0, 10.0)?;
+                                let y = t.suggest_float("y", -10.0, 10.0)?;
+                                Ok(vec![(x - 3.0).powi(2) + (y + 1.0).powi(2)])
+                            },
+                            n_trials_per_thread,
+                        )
+                    })
+                })
+                .collect();
+            for handle in handles {
+                handle
+                    .join()
+                    .expect("optimization thread must not panic")
+                    .unwrap();
+            }
+        });
+        let trials = study.get_trials().unwrap();
+        assert_eq!(trials.len(), n_threads * n_trials_per_thread);
+        assert!(trials
+            .iter()
+            .all(|t| matches!(t.state_values, TrialStateValues::Complete(_))));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`TpeSampler` now copies the completed trials it needs into an owned snapshot while holding the storage lock, drops the lock, and then runs the TPE model construction (trial split, Parzen estimators, candidate evaluation) without it. Previously the whole construction ran under the storage write lock, so concurrent `ask`/`tell` threads serialized on it and multi-threaded optimization did not scale.

The lightweight trial snapshot and the index-based multi-objective observation-splitting API follow the design of #200. Behavior is unchanged for fixed-seed sequential runs: bit-identical before/after, verified the same way as #220.

## Performance

Sphere objective with 10 parameters, 5,000 trials, one study shared by Python threads ([benchmark script in the comment below](https://github.com/optuna/rustuna/pull/224#issuecomment-5390405292)):

| threads | main | this branch |
| --- | --- | --- |
| 1 | 5.1s | 4.8s |
| 2 | 5.2s | 2.6s |
| 4 | 5.2s | 1.6s |
| 8 | 6.1s | 1.7s |

### How to verify behavior is unchanged

Run the [verification script in the comment below](https://github.com/optuna/rustuna/pull/224#issuecomment-5389981819) on both builds (same machine) and compare the printed digests:

```bash
# on main, then on this branch:
cd rustuna_pyo3 && uv sync --group dev --reinstall-package rustuna
uv run --no-sync python verify_bitexact.py
```

### Behavior change until the `tell` values-count fix lands

The snapshot stores objective values at a fixed stride and rejects a completed trial whose number of objective values differs from the study's direction count. `tell` can currently persist such trials (to be fixed separately); until that fix lands, a study containing one fails `ask` with an explicit error instead of being silently tolerated (as on current main).
