### PR TITLE
add set_constraint API in pyo3 interface

### DIFF
--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -166,6 +166,19 @@ class Trial:
         Args:
             attrs: A dictionary object.
         """
+    def set_constraint(self, key: str, value: float) -> None:
+        """Set a constraint to the trial.
+
+        See [Trial.set_constraints][rustuna.trial.Trial.set_constraints] for the detailed
+        behavior of the constraints.
+
+        Args:
+            key: A key string of the constraint.
+            value: A value of the constraint.
+
+        Raises:
+            RuntimeError: If `value` is NaN. Nothing is recorded in that case.
+        """
     def set_constraints(self, constraints: dict[str, float]) -> None:
         """Set constraints to the trial.
 

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -372,6 +372,15 @@ impl PyTrial {
         })?;
         Ok(())
     }
+    #[pyo3(signature = (key, value))]
+    pub fn set_constraint(&mut self, key: &str, value: f64) -> PyResult<()> {
+        let constraint = HashMap::from([(String::from(key), value)]);
+        self.trial
+            .set_constraints(constraint)
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to set constraints: {e}")))?;
+
+        Ok(())
+    }
     #[pyo3(signature = (constraints))]
     pub fn set_constraints(&mut self, constraints: Py<PyAny>) -> PyResult<()> {
         let constraints: HashMap<String, f64> =

--- a/rustuna_pyo3/tests/test_trial.py
+++ b/rustuna_pyo3/tests/test_trial.py
@@ -107,6 +107,17 @@ def test_persisted_trial_new_value_and_values_error() -> None:
         )
 
 
+def test_set_constraint() -> None:
+    study = rustuna.create_study()
+
+    def objective(trial: rustuna.Trial) -> float:
+        trial.set_constraint("c0", 5.0)
+        return 0.0
+
+    study.optimize(objective, n_trials=1)
+    assert study.trials[0].constraints["c0"] == 5.0
+
+
 def test_constraints() -> None:
     study = rustuna.create_study()
 


### PR DESCRIPTION
I added `set_constraint` API in pyo3 interface, which adds a single constraint.
This is added for providing the consistent method to set constraints as Optuna (see https://optuna.readthedocs.io/en/latest/reference/generated/optuna.trial.Trial.html#optuna.trial.Trial.set_constraint).