### PR TITLE
Avoid cloning in `probability_distributions.rs`

### DIFF
--- a/rustuna_core/src/parzen_estimator/probability_distributions.rs
+++ b/rustuna_core/src/parzen_estimator/probability_distributions.rs
@@ -293,18 +293,13 @@ impl MixtureOfProductDistribution {
             .map(|&w| if w > 0.0 { w.ln() } else { f64::NEG_INFINITY })
             .collect::<Vec<_>>();
 
-        let alias = WeightedAliasIndex::new(weights.clone())
-            .expect("weights must be non-empty and non-negative");
-
-        let mut param_names: Vec<String> = distributions_map.keys().cloned().collect();
-        param_names.sort();
-
-        let mut distributions: Vec<Distributions> = Vec::with_capacity(param_names.len());
-        for name in param_names.iter() {
-            distributions.push(distributions_map.get(name).unwrap().clone());
-        }
-
         let n_kernels = weights.len();
+        let alias =
+            WeightedAliasIndex::new(weights).expect("weights must be non-empty and non-negative");
+
+        let mut entries: Vec<_> = distributions_map.into_iter().collect();
+        entries.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        let (param_names, distributions) = entries.into_iter().unzip();
 
         MixtureOfProductDistribution {
             param_names,


### PR DESCRIPTION
Remove unnecessary clones in `probability_distributions.rs`. This will improve performance by several percentage points.

## Benchmark

- master

```
n_params  n_trials    total [ms]  per trial [us]
      40       500         219.6         439.3
      40      1000         617.3         617.3
      40      2000        2174.3        1087.1
```

- PR

```
n_params  n_trials    total [ms]  per trial [us]
      40       500         211.3         422.6
      40      1000         598.2         598.2
      40      2000        2099.1        1049.6
```

<details>

```rust
use std::hint::black_box;
use std::time::{Duration, Instant};

use rustuna_core::storage::InMemoryStorage;
use rustuna_core::study::{create_study, Direction};
use rustuna_core::Result;
use rustuna_sampler::tpe::TpeSampler;

const N_TRIALS: [usize; 3] = [500, 1000, 2000];
const N_PARAMS: [usize; 1] = [40];

fn run_study(n_trials: usize, n_params: usize) -> Result<Duration> {
    let storage = InMemoryStorage::new();
    let study = create_study(
        "tpe-benchmark",
        storage,
        TpeSampler::seed_from_u64(0),
        vec![Direction::Minimize],
    )?;

    let start = Instant::now();
    study.optimize(
        |mut trial| {
            let mut value = 0.0;
            for i in 0..n_params {
                let x = trial.suggest_float(&format!("x{i}"), -10.0, 10.0)?;
                value += x * x;
            }
            Ok(vec![black_box(value)])
        },
        n_trials,
    )?;
    Ok(start.elapsed())
}

fn main() -> Result<()> {
    println!(
        "{:>8}  {:>8}  {:>12}  {:>12}",
        "n_params", "n_trials", "total [ms]", "per trial [us]"
    );
    for n_params in N_PARAMS {
        for n_trials in N_TRIALS {
            let duration = run_study(n_trials, n_params)?;
            println!(
                "{:>8}  {:>8}  {:>12.1}  {:>12.1}",
                n_params,
                n_trials,
                duration.as_secs_f64() * 1e3,
                duration.as_secs_f64() * 1e6 / n_trials as f64,
            );
        }
    }
    Ok(())
}
```

</details>