### PR TITLE
fix deadlock in PyToRustStorage

### DIFF
--- a/rustuna_pyo3/src/storage/to_rust.rs
+++ b/rustuna_pyo3/src/storage/to_rust.rs
@@ -819,15 +819,21 @@ impl PyToRustStorage {
 
     #[pyo3(signature = (study_id, *, states = None))]
     fn get_trials(
-        &mut self,
+        &self,
+        py: Python<'_>,
         study_id: u32,
         states: Option<Vec<PyTrialState>>,
     ) -> PyResult<Vec<PyPersistedTrial>> {
         let storage: Arc<RwLock<dyn Storage>> = self.storage.clone();
-        let mut guard = storage.write().map_err(|e| {
-            PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
+        let trials = py.detach(|| -> PyResult<Vec<Option<PersistedTrial>>> {
+            let mut guard = storage.write().map_err(|e| {
+                PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
+            })?;
+            Ok(guard
+                .get_trials(study_id)
+                .map_err(err_to_exceptions)?
+                .clone())
         })?;
-        let trials = guard.get_trials(study_id).map_err(err_to_exceptions)?;
         let py_trials: Vec<PyPersistedTrial> = trials
             .iter()
             .flatten()
@@ -841,15 +847,22 @@ impl PyToRustStorage {
     }
 
     #[pyo3(signature = (study_id, *, states = None))]
-    fn get_n_trials(&mut self, study_id: u32, states: Option<Vec<PyTrialState>>) -> PyResult<u32> {
+    fn get_n_trials(
+        &self,
+        py: Python<'_>,
+        study_id: u32,
+        states: Option<Vec<PyTrialState>>,
+    ) -> PyResult<u32> {
         let storage: Arc<RwLock<dyn Storage>> = self.storage.clone();
-        let mut guard = storage.write().map_err(|e| {
-            PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
-        })?;
         let states =
             states.map(|states| states.into_iter().map(TrialState::from).collect::<Vec<_>>());
-        guard
-            .get_n_trials(study_id, states.as_deref())
-            .map_err(err_to_exceptions)
+        py.detach(|| {
+            let mut guard = storage.write().map_err(|e| {
+                PyRuntimeError::new_err(format!("Failed to acquire the storage guard: {e:?}"))
+            })?;
+            guard
+                .get_n_trials(study_id, states.as_deref())
+                .map_err(err_to_exceptions)
+        })
     }
 }


### PR DESCRIPTION
Fixed deadlock in PyToRustStrorage.

I checked that this script causes deadlock before this fix, but does not cause deadlock after this fix.

```python
"""Check that ToRustStorage does not deadlock when optimizing from several threads.

    $ cd rustuna_pyo3 && uv run python check_deadlock.py

A thread deadlocked on the storage lock keeps the GIL, so the interpreter freezes
and can no longer report anything itself. faulthandler's watchdog is a C thread
that does not need the GIL: it dumps every stack and exits 1 from the frozen
process.
"""

import faulthandler
import threading

import optuna

import rustuna
from rustuna.converter import ToOptunaSampler

faulthandler.dump_traceback_later(60, exit=True)
optuna.logging.set_verbosity(optuna.logging.WARNING)

study = optuna.create_study(
    sampler=ToOptunaSampler(
        rustuna.samplers.TPESampler(n_startup_trials=1, multivariate=True)
    )
)


def objective(trial: optuna.Trial) -> float:
    return trial.suggest_float("x", -5, 5) ** 2 + trial.suggest_float("y", -5, 5) ** 2


workers = [
    threading.Thread(target=lambda: study.optimize(objective, n_trials=100))
    for _ in range(4)
]
for worker in workers:
    worker.start()
for worker in workers:
    worker.join()

print(f"no deadlock: {len(study.trials)} trials")

```