### PR TITLE
Persist categorical choices in SQLite distributions

### DIFF
--- a/rustuna_storage/src/sqlite3.rs
+++ b/rustuna_storage/src/sqlite3.rs
@@ -2,7 +2,7 @@ use crate::cache::{CachedStorageBackend, DiscardedTrialsDiff};
 use rusqlite::{
     params, Connection, Error as RusqliteError, OptionalExtension, TransactionBehavior,
 };
-use rustuna_core::attr::{AttrKey, Attrs, CategoryLabel};
+use rustuna_core::attr::{get_category_labels, AttrKey, Attrs, CategoryLabel};
 use rustuna_core::datetime::now_naive_utc;
 use rustuna_core::distribution::Distribution;
 use rustuna_core::study::{Direction, PersistedStudy};
@@ -652,9 +652,9 @@ impl CachedStorageBackend for SQLite3Storage {
             .conn
             .lock()
             .map_err(|_| Error::new(ErrorKind::StorageError))?;
-        let exists: Option<u32> = guard
+        let study_id: Option<u32> = guard
             .query_row(
-                "SELECT trial_id FROM trials WHERE trial_id = ?",
+                "SELECT study_id FROM trials WHERE trial_id = ?",
                 params![trial_id],
                 |row| row.get(0),
             )
@@ -665,11 +665,15 @@ impl CachedStorageBackend for SQLite3Storage {
                     format!("Database query failed: {e}"),
                 )
             })?;
-        if exists.is_none() {
-            return Err(Error::new(ErrorKind::TrialNotFound));
-        }
+        let study_id = study_id.ok_or_else(|| Error::new(ErrorKind::TrialNotFound))?;
 
-        let distribution_json = distribution_to_json(distribution, None);
+        let labels = match distribution {
+            Distribution::Categorical { cardinality } => {
+                read_category_labels(&guard, study_id, name, *cardinality)?
+            }
+            _ => None,
+        };
+        let distribution_json = distribution_to_json(distribution, labels.as_deref());
         guard
             .execute(
                 "INSERT INTO trial_params (trial_id, param_name, param_value, distribution_json) \
@@ -1811,6 +1815,50 @@ fn distribution_to_json(distribution: &Distribution, labels: Option<&[CategoryLa
     .to_string()
 }
 
+fn read_category_labels(
+    conn: &Connection,
+    study_id: u32,
+    param_name: &str,
+    cardinality: usize,
+) -> Result<Option<Vec<CategoryLabel>>> {
+    if cardinality == 0 {
+        return Ok(Some(Vec::new()));
+    }
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT key, value_json FROM study_system_attributes \
+             WHERE study_id = ? AND key LIKE 'category_labels:%'",
+        )
+        .map_err(|e| {
+            Error::with_reason(
+                ErrorKind::StorageError,
+                format!("Database query failed: {e}"),
+            )
+        })?;
+    let rows = stmt
+        .query_map(params![study_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .map_err(|e| {
+            Error::with_reason(
+                ErrorKind::StorageError,
+                format!("Database query failed: {e}"),
+            )
+        })?;
+    let mut attrs = Attrs::new();
+    for row in rows {
+        let (key, value) = row.map_err(|e| {
+            Error::with_reason(
+                ErrorKind::StorageError,
+                format!("Database query failed: {e}"),
+            )
+        })?;
+        attrs.insert(AttrKey::System(key.into()), value);
+    }
+    Ok(get_category_labels(&attrs, param_name, cardinality))
+}
+
 fn category_label_to_value(label: &CategoryLabel) -> Value {
     match label {
         CategoryLabel::Float(f) => Number::from_f64(*f)
@@ -2577,6 +2625,48 @@ mod tests {
         assert_eq!(trial.internal_params["float"], 0.5);
         assert_eq!(trial.internal_params["int"], 5.0);
         assert_eq!(trial.internal_params["cat"], 1.0);
+        Ok(())
+    }
+
+    #[test]
+    fn suggest_categorical_enum_persists_categorical_choices() -> Result<()> {
+        let dir = TempDir::new().map_err(|_| Error::new(ErrorKind::Unexpected))?;
+        let path = dir.path().join("storage.sqlite3");
+        let path = path.to_string_lossy().to_string();
+        let storage = open_file_storage(&path, false)?;
+        let study = create_study(
+            "example",
+            storage,
+            RandomSampler::new(),
+            vec![Direction::Minimize],
+        )?;
+        let choices = vec![
+            CategoryLabel::String("red".to_string()),
+            CategoryLabel::Int(2),
+            CategoryLabel::Bool(true),
+            CategoryLabel::None,
+            CategoryLabel::Float(1.5),
+        ];
+        let mut trial = study.ask()?;
+        trial.suggest_categorical_enum("color", &choices)?;
+
+        let storage = SQLite3Storage::new(&path)?;
+        let distribution_json: String = storage
+            .conn
+            .lock()
+            .map_err(|_| Error::new(ErrorKind::StorageError))?
+            .query_row(
+                "SELECT distribution_json FROM trial_params WHERE trial_id = ?",
+                params![trial.id],
+                |row| row.get(0),
+            )
+            .map_err(|e| Error::with_reason(ErrorKind::StorageError, e.to_string()))?;
+        let distribution: Value = serde_json::from_str(&distribution_json)
+            .map_err(|e| Error::with_reason(ErrorKind::StorageError, e.to_string()))?;
+        assert_eq!(
+            distribution["attributes"]["choices"],
+            json!(["red", 2, true, Value::Null, 1.5])
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- Persist actual categorical choices in SQLite `distribution_json`
- Load category labels from study system attributes using the `category_labels:%` prefix
- Preserve the existing numeric-index fallback when labels are unavailable
- Add an end-to-end unit test using `CachedStorage` and `suggest_categorical_enum`

## Motivation

Rustuna stores categorical distributions internally by cardinality, but Optuna-compatible SQLite records require the actual `choices` values in `distribution_json`.

Previously, categorical parameters were persisted as numeric indices (`[0, 1, ...]`), which could lose the original choice types and values when the database was consumed by Optuna.
