### PR TITLE
Restrict Rustuna internal modules from the public API

### DIFF
--- a/rustuna_core/src/attr.rs
+++ b/rustuna_core/src/attr.rs
@@ -85,7 +85,7 @@ impl CategoryLabel {
 }
 
 /// Returns the internal system-attribute key used to store a categorical label.
-pub fn system_key_category_label(param_name: &str, choice_idx: usize) -> AttrKey {
+pub(crate) fn system_key_category_label(param_name: &str, choice_idx: usize) -> AttrKey {
     AttrKey::System(format!("category_labels:{param_name}:{choice_idx}").into())
 }
 
@@ -118,12 +118,12 @@ pub fn get_category_labels(
 }
 
 /// Returns the internal system-attribute key used for queued fixed parameters.
-pub fn system_key_fixed_param(param_name: &str) -> AttrKey {
+pub(crate) fn system_key_fixed_param(param_name: &str) -> AttrKey {
     AttrKey::System(format!("fixed_params:{param_name}").into())
 }
 
 /// Encodes fixed parameter values into trial attributes.
-pub fn fixed_params_to_attrs(params: &HashMap<String, CategoryLabel>) -> Attrs {
+pub(crate) fn fixed_params_to_attrs(params: &HashMap<String, CategoryLabel>) -> Attrs {
     let mut attrs = Attrs::new();
     for (name, value) in params {
         let key = system_key_fixed_param(name);
@@ -132,14 +132,8 @@ pub fn fixed_params_to_attrs(params: &HashMap<String, CategoryLabel>) -> Attrs {
     attrs
 }
 
-/// Returns a fixed parameter value stored in attributes.
-pub fn get_fixed_param(attrs: &Attrs, param_name: &str) -> Option<CategoryLabel> {
-    let key = system_key_fixed_param(param_name);
-    attrs.get(&key).and_then(|s| CategoryLabel::deserialize(s))
-}
-
 /// Extracts all fixed parameters stored in trial attributes.
-pub fn extract_fixed_params(attrs: &Attrs) -> HashMap<String, CategoryLabel> {
+pub(crate) fn extract_fixed_params(attrs: &Attrs) -> HashMap<String, CategoryLabel> {
     let mut params = HashMap::new();
     for (key, value) in attrs {
         if let AttrKey::System(s) = key {

--- a/rustuna_core/src/lib.rs
+++ b/rustuna_core/src/lib.rs
@@ -7,7 +7,6 @@
 pub use error::{Error, ErrorKind};
 
 pub mod attr;
-pub mod datetime;
 pub mod distribution;
 pub mod multi_objective; // TODO(kAIto47802): Move this into the `internal` module.
 pub mod sampler;
@@ -17,6 +16,7 @@ pub mod transform;
 pub mod trial;
 pub mod trial_queue;
 
+mod datetime;
 mod error;
 mod parzen_estimator;
 mod string_interner;
@@ -34,6 +34,9 @@ pub mod internal {
     }
     pub mod study_cache {
         pub use crate::study_cache::StudyCache;
+    }
+    pub mod datetime {
+        pub use crate::datetime::now_naive_utc;
     }
 }
 

--- a/rustuna_core/src/lib.rs
+++ b/rustuna_core/src/lib.rs
@@ -12,15 +12,15 @@ pub mod distribution;
 pub mod multi_objective; // TODO(kAIto47802): Move this into the `internal` module.
 pub mod sampler;
 pub mod storage;
-pub mod string_interner;
 pub mod study;
-pub mod study_cache;
 pub mod transform;
 pub mod trial;
 pub mod trial_queue;
 
 mod error;
 mod parzen_estimator;
+mod string_interner;
+mod study_cache;
 
 /// Implementation details shared by Rustuna crates.
 ///
@@ -31,6 +31,9 @@ mod parzen_estimator;
 pub mod internal {
     pub mod parzen_estimator {
         pub use crate::parzen_estimator::*;
+    }
+    pub mod study_cache {
+        pub use crate::study_cache::StudyCache;
     }
 }
 

--- a/rustuna_pyo3/src/trial.rs
+++ b/rustuna_pyo3/src/trial.rs
@@ -160,7 +160,7 @@ pub fn py_create_trial(
         system_attrs.unwrap_or_default(),
     );
 
-    let now = rustuna_core::datetime::now_naive_utc();
+    let now = rustuna_core::internal::datetime::now_naive_utc();
     if matches!(state, PyTrialState::WAITING) {
         trial.datetime_start = None;
         trial.datetime_complete = None;

--- a/rustuna_storage/src/cache.rs
+++ b/rustuna_storage/src/cache.rs
@@ -4,8 +4,8 @@ use rustuna_core::attr::{
     category_labels_to_attrs, get_category_labels, AttrKey, Attrs, CategoryLabel,
 };
 use rustuna_core::distribution::Distribution;
+use rustuna_core::internal::study_cache::StudyCache;
 use rustuna_core::study::{Direction, PersistedStudy};
-use rustuna_core::study_cache::StudyCache;
 use rustuna_core::trial::{PersistedTrial, TrialState, TrialStateValues};
 use rustuna_core::{Error, ErrorKind, Result};
 

--- a/rustuna_storage/src/datetime.rs
+++ b/rustuna_storage/src/datetime.rs
@@ -5,7 +5,7 @@
 //! matching Optuna, because a log entry is JSON and can spell out the offset without the schema
 //! concerns a database column has.
 
-use rustuna_core::datetime::now_naive_utc;
+use rustuna_core::internal::datetime::now_naive_utc;
 
 /// Width of the `YYYY-MM-DDTHH:MM:SS` prefix every journal datetime starts with.
 const DATE_TIME_LEN: usize = 19;

--- a/rustuna_storage/src/journal/storage.rs
+++ b/rustuna_storage/src/journal/storage.rs
@@ -10,9 +10,9 @@ use rustuna_core::attr::{
     category_labels_to_attrs, get_category_labels, AttrKey, Attrs, CategoryLabel,
 };
 use rustuna_core::distribution::Distribution;
+use rustuna_core::internal::study_cache::StudyCache;
 use rustuna_core::storage::Storage;
 use rustuna_core::study::{Direction, PersistedStudy};
-use rustuna_core::study_cache::StudyCache;
 use rustuna_core::trial::{PersistedTrial, TrialState, TrialStateValues};
 use rustuna_core::{Error, ErrorKind, Result};
 

--- a/rustuna_storage/src/lib.rs
+++ b/rustuna_storage/src/lib.rs
@@ -6,11 +6,12 @@
 //! `rustuna_core::storage::Storage` and `rustuna_core::trial_queue::TrialQueue` traits.
 
 pub mod cache;
-pub mod datetime;
 pub mod directory_queue;
 pub mod journal;
 pub mod sqlite3;
 pub mod sqlite3_queue;
+
+mod datetime;
 
 #[cfg(test)]
 mod test_utils;

--- a/rustuna_storage/src/sqlite3.rs
+++ b/rustuna_storage/src/sqlite3.rs
@@ -3,8 +3,8 @@ use rusqlite::{
     params, Connection, Error as RusqliteError, OptionalExtension, TransactionBehavior,
 };
 use rustuna_core::attr::{get_category_labels, AttrKey, Attrs, CategoryLabel};
-use rustuna_core::datetime::now_naive_utc;
 use rustuna_core::distribution::Distribution;
+use rustuna_core::internal::datetime::now_naive_utc;
 use rustuna_core::study::{Direction, PersistedStudy};
 use rustuna_core::trial::{PersistedTrial, TrialState, TrialStateValues};
 use rustuna_core::{Error, ErrorKind, Result};


### PR DESCRIPTION
## Motivation

refs #231 

These modules and helper functions are implementation details and should not be treated as stable public APIs. Hiding them reduces the accidental API surface and makes future internal refactoring easier.

## Summary

- Hide internal modules such as `datetime`, `string_interner`,  and`study_cache` from the public API
- Restrict internal attribute helpers to crate visibility
- Remove the unused public `get_fixed_param` helper
- Update `rustuna_storage` and `rustuna_pyo3` to use the internal paths
- Make `rustuna_storage::datetime` private as well
