### PR TITLE
Expose Optuna categorical choices as study attributes

### DIFF
--- a/rustuna_pyo3/tests/storage_tests/test_schema_compatibility.py
+++ b/rustuna_pyo3/tests/storage_tests/test_schema_compatibility.py
@@ -46,6 +46,10 @@ class Suite(typing.Protocol):
         trials: list[optuna.trial.FrozenTrial] | list[rustuna.trial.PersistedTrial],
     ) -> None: ...
 
+    def assert_before_resume(
+        self, trials: list[rustuna.trial.PersistedTrial]
+    ) -> None: ...
+
 
 class SuiteAttr:
     directions = ["minimize"]
@@ -75,6 +79,9 @@ class SuiteAttr:
                 assert trial.user_attrs["rustuna"] == "foo"
                 assert trial.system_attrs["rustuna"] == "bar"
 
+    def assert_before_resume(self, trials: list[rustuna.trial.PersistedTrial]) -> None:
+        pass
+
 
 class SuiteSingleObjective:
     directions = ["minimize"]
@@ -99,6 +106,9 @@ class SuiteSingleObjective:
             assert isinstance(x, (int, float))
             assert 1.0 <= x <= 10.0
             assert trial.values == [x]
+
+    def assert_before_resume(self, trials: list[rustuna.trial.PersistedTrial]) -> None:
+        pass
 
 
 class TestSuiteParam:
@@ -144,6 +154,14 @@ class TestSuiteParam:
                     "green",
                 ]
 
+    def assert_before_resume(self, trials: list[rustuna.trial.PersistedTrial]) -> None:
+        for trial in trials:
+            distribution = typing.cast(typing.Any, trial.distributions["z"])
+            assert distribution.to_dict()["choices"] == [
+                "red",
+                "green",
+            ]
+
 
 class TestSuiteMultiObjective:
     directions = ["minimize", "maximize"]
@@ -176,6 +194,9 @@ class TestSuiteMultiObjective:
             assert len(trial.values) == 2
             assert trial.values[0] == x
             assert trial.values[1] == y
+
+    def assert_before_resume(self, trials: list[rustuna.trial.PersistedTrial]) -> None:
+        pass
 
 
 parametrize_test_suite = pytest.mark.parametrize(
@@ -385,6 +406,7 @@ def test_optuna_to_rustuna_resume(suite: Suite, backend: str) -> None:
             sampler=rustuna.samplers.RandomSampler(),
         )
         assert_rustuna_directions(rustuna_study.directions, suite)
+        suite.assert_before_resume(rustuna_study.trials)
         optuna_trial_count = len(optuna_study.trials)
         rustuna_study.optimize(suite.objective, n_trials=10)
 

--- a/rustuna_storage/src/sqlite3.rs
+++ b/rustuna_storage/src/sqlite3.rs
@@ -2,7 +2,9 @@ use crate::cache::{CachedStorageBackend, DiscardedTrialsDiff};
 use rusqlite::{
     params, Connection, Error as RusqliteError, OptionalExtension, TransactionBehavior,
 };
-use rustuna_core::attr::{get_category_labels, AttrKey, Attrs, CategoryLabel};
+use rustuna_core::attr::{
+    category_labels_to_attrs, get_category_labels, AttrKey, Attrs, CategoryLabel,
+};
 use rustuna_core::distribution::Distribution;
 use rustuna_core::internal::datetime::now_naive_utc;
 use rustuna_core::study::{Direction, PersistedStudy};
@@ -954,6 +956,47 @@ impl CachedStorageBackend for SQLite3Storage {
                     )
                 })?;
                 attrs.insert(AttrKey::System(key.into()), value);
+            }
+
+            // Optuna stores categorical labels in each distribution JSON, whereas Rustuna's
+            // Storage API exposes them through study system attributes. Materialize that native
+            // representation when an Optuna-created database is opened.
+            let mut categorical_stmt = guard
+                .prepare(
+                    "SELECT DISTINCT tp.param_name, tp.distribution_json \
+                     FROM trial_params AS tp \
+                     JOIN trials AS t ON t.trial_id = tp.trial_id \
+                     WHERE t.study_id = ?",
+                )
+                .map_err(|e| {
+                    Error::with_reason(
+                        ErrorKind::StorageError,
+                        format!("Database query failed: {e}"),
+                    )
+                })?;
+            let categorical_rows = categorical_stmt
+                .query_map(params![study_id], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })
+                .map_err(|e| {
+                    Error::with_reason(
+                        ErrorKind::StorageError,
+                        format!("Database query failed: {e}"),
+                    )
+                })?;
+            for row in categorical_rows {
+                let (param_name, distribution_json) = row.map_err(|e| {
+                    Error::with_reason(
+                        ErrorKind::StorageError,
+                        format!("Database query failed: {e}"),
+                    )
+                })?;
+                let (_, labels) = json_to_distribution(&distribution_json)?;
+                if let Some(labels) = labels {
+                    for (key, value) in category_labels_to_attrs(&param_name, &labels) {
+                        attrs.entry(key).or_insert(value);
+                    }
+                }
             }
 
             let study = PersistedStudy::new_with_attrs(study_id, study_name, directions, attrs);
@@ -2666,6 +2709,39 @@ mod tests {
         assert_eq!(
             distribution["attributes"]["choices"],
             json!(["red", 2, true, Value::Null, 1.5])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn optuna_categorical_labels_are_exposed_as_study_attrs() -> Result<()> {
+        let mut storage = SQLite3Storage::new(":memory:")?;
+        storage.create_database()?;
+        let study_id = storage
+            .create_new_study("example", vec![Direction::Minimize])?
+            .id;
+        let trial_id = storage.create_new_trial(study_id)?.id;
+        let labels = vec![
+            CategoryLabel::String("red".to_string()),
+            CategoryLabel::Int(2),
+        ];
+        let distribution = Distribution::new_categorical(labels.len());
+        let distribution_json = distribution_to_json(&distribution, Some(&labels));
+        storage
+            .conn
+            .lock()
+            .map_err(|_| Error::new(ErrorKind::StorageError))?
+            .execute(
+                "INSERT INTO trial_params (trial_id, param_name, param_value, distribution_json) \
+                 VALUES (?, 'color', 0, ?)",
+                params![trial_id, distribution_json],
+            )
+            .map_err(|e| Error::with_reason(ErrorKind::StorageError, e.to_string()))?;
+
+        let study = storage.get_study(study_id)?;
+        assert_eq!(
+            rustuna_core::attr::get_category_labels(&study.attrs, "color", 2),
+            Some(labels)
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary

* Optuna stores categorical labels in each distribution JSON, whereas Rustuna's Storage API exposes them through study system attributes.
* Materialize that native representation when an Optuna-created database is opened.