### PR TITLE
Add `before_trial` method in `rustuna_core::sampler::Sampler` trait

### DIFF
--- a/rustuna_core/src/sampler.rs
+++ b/rustuna_core/src/sampler.rs
@@ -38,6 +38,14 @@ pub struct Context {
 /// A sampler can be shared by multiple optimization threads. Implementations must synchronize
 /// mutable state internally and keep immutable sampling work outside critical sections.
 pub trait Sampler: Send + Sync {
+    /// Hook called after a trial is created and before its search space is inferred.
+    ///
+    /// This corresponds to Optuna's `before_trial` hook. The trial can be retrieved from
+    /// `storage` with `ctx.trial_id`, and the study can be retrieved with `ctx.study_id`.
+    fn before_trial(&self, _ctx: &Context, _storage: Arc<RwLock<dyn Storage>>) -> Result<()> {
+        Ok(())
+    }
+
     /// Samples a single parameter independently.
     ///
     /// This method is used for parameters that are not covered by joint sampling. It is suitable

--- a/rustuna_core/src/study.rs
+++ b/rustuna_core/src/study.rs
@@ -221,6 +221,14 @@ impl Study {
                 )
             };
 
+        let ctx = SamplerContext {
+            study_id: self.id,
+            trial_number,
+            trial_id,
+            directions: self.directions.clone(),
+        };
+        self.sampler.before_trial(&ctx, self.storage.clone())?;
+
         let joint_params: HashMap<String, (Distribution, f64)> =
             if self.sampler.support_joint_sampling() {
                 let joint_search_space = self
@@ -234,12 +242,6 @@ impl Study {
                     })?
                     .get_joint_search_space(self.id)?;
 
-                let ctx = SamplerContext {
-                    study_id: self.id,
-                    trial_number,
-                    trial_id,
-                    directions: self.directions.clone(),
-                };
                 let params =
                     self.sampler
                         .sample_joint(&ctx, self.storage.clone(), &joint_search_space)?;


### PR DESCRIPTION
## Summary

This provides the Rust counterpart of Optuna's `BaseSampler.before_trial` hook.

- Add a `before_trial` hook to the `rustuna_core::sampler::Sampler` trait.
- Invoke the hook in `Study::ask` after a trial is created and before inferring the joint search space.
- Keep a default no-op implementation for existing Rust samplers.

~~This PR only updates `rustuna_core`. The Python bindings, including `SamplerProtocol` and the Rust/Python sampler adapters in `rustuna_pyo3`, will be updated in a follow-up PR~~ On second thought, these changes can be reviewed at the same time.