### PR TITLE
Add `before_trial` methods in `SamplerProtocol`

### DIFF
--- a/rustuna_core/src/sampler.rs
+++ b/rustuna_core/src/sampler.rs
@@ -38,6 +38,14 @@ pub struct Context {
 /// A sampler can be shared by multiple optimization threads. Implementations must synchronize
 /// mutable state internally and keep immutable sampling work outside critical sections.
 pub trait Sampler: Send + Sync {
+    /// Hook called after a trial is created and before its search space is inferred.
+    ///
+    /// This corresponds to Optuna's `before_trial` hook. The trial can be retrieved from
+    /// `storage` with `ctx.trial_id`, and the study can be retrieved with `ctx.study_id`.
+    fn before_trial(&self, _ctx: &Context, _storage: Arc<RwLock<dyn Storage>>) -> Result<()> {
+        Ok(())
+    }
+
     /// Samples a single parameter independently.
     ///
     /// This method is used for parameters that are not covered by joint sampling. It is suitable

--- a/rustuna_core/src/study.rs
+++ b/rustuna_core/src/study.rs
@@ -221,6 +221,14 @@ impl Study {
                 )
             };
 
+        let ctx = SamplerContext {
+            study_id: self.id,
+            trial_number,
+            trial_id,
+            directions: self.directions.clone(),
+        };
+        self.sampler.before_trial(&ctx, self.storage.clone())?;
+
         let joint_params: HashMap<String, (Distribution, f64)> =
             if self.sampler.support_joint_sampling() {
                 let joint_search_space = self
@@ -234,12 +242,6 @@ impl Study {
                     })?
                     .get_joint_search_space(self.id)?;
 
-                let ctx = SamplerContext {
-                    study_id: self.id,
-                    trial_number,
-                    trial_id,
-                    directions: self.directions.clone(),
-                };
                 let params =
                     self.sampler
                         .sample_joint(&ctx, self.storage.clone(), &joint_search_space)?;

--- a/rustuna_pyo3/rustuna/_protocols.py
+++ b/rustuna_pyo3/rustuna/_protocols.py
@@ -39,6 +39,21 @@ class SamplerProtocol(Protocol):
             Suggested parameter values (Optuna's internal representation).
         """
 
+    def before_trial(
+        self,
+        ctx: SamplerContext,
+        storage: StorageProtocol,
+    ) -> None:
+        """Run sampler pre-processing before search-space inference.
+
+        The newly created trial is available as ``storage.get_trial(ctx.trial_id)``.
+        The target study is available as ``storage.get_study(ctx.study_id)``.
+
+        Args:
+            ctx: Sampler context.
+            storage: Storage object.
+        """
+
     def sample_independent(
         self,
         ctx: SamplerContext,

--- a/rustuna_pyo3/rustuna/_rustuna.pyi
+++ b/rustuna_pyo3/rustuna/_rustuna.pyi
@@ -1229,6 +1229,11 @@ class RandomSampler:
         name: str,
         distribution: Distribution,
     ) -> float: ...
+    def before_trial(
+        self,
+        ctx: SamplerContext,
+        storage: StorageProtocol,
+    ) -> None: ...
     def after_trial(
         self,
         ctx: SamplerContext,
@@ -1324,6 +1329,11 @@ class TPESampler:
         name: str,
         distribution: Distribution,
     ) -> float: ...
+    def before_trial(
+        self,
+        ctx: SamplerContext,
+        storage: StorageProtocol,
+    ) -> None: ...
     def after_trial(
         self,
         ctx: SamplerContext,
@@ -1406,6 +1416,11 @@ class NSGAIISampler:
         name: str,
         distribution: Distribution,
     ) -> float: ...
+    def before_trial(
+        self,
+        ctx: SamplerContext,
+        storage: StorageProtocol,
+    ) -> None: ...
     def after_trial(
         self,
         ctx: SamplerContext,
@@ -1449,6 +1464,11 @@ class CmaEsSampler:
         name: str,
         distribution: Distribution,
     ) -> float: ...
+    def before_trial(
+        self,
+        ctx: SamplerContext,
+        storage: StorageProtocol,
+    ) -> None: ...
     def after_trial(
         self,
         ctx: SamplerContext,

--- a/rustuna_pyo3/rustuna/converter/_sampler.py
+++ b/rustuna_pyo3/rustuna/converter/_sampler.py
@@ -94,6 +94,17 @@ class ToOptunaSampler(BaseSampler):
             external_params[param_name] = external_param_value
         return external_params
 
+    def before_trial(self, study: Study, trial: FrozenTrial) -> None:
+        """Run pre-processing in the Rustuna sampler before search-space inference."""
+        ctx = rustuna.samplers.SamplerContext(
+            study_id=study._study_id,
+            trial_number=trial.number,
+            trial_id=trial._trial_id,
+            directions=to_rustuna_directions(study._directions),
+        )
+        storage = self._get_storage(study._storage)
+        self._sampler.before_trial(ctx, storage)
+
     def sample_independent(
         self,
         study: Study,

--- a/rustuna_pyo3/src/sampler/cmaes.rs
+++ b/rustuna_pyo3/src/sampler/cmaes.rs
@@ -343,6 +343,11 @@ impl PyCmaEsSampler {
         })
     }
 
+    fn before_trial(&self, ctx: &PySamplerContext, storage: Py<PyAny>) -> PyResult<()> {
+        let _ = (ctx, storage);
+        Ok(())
+    }
+
     #[pyo3(signature = (ctx, storage, state, values = None))]
     fn after_trial(
         &self,

--- a/rustuna_pyo3/src/sampler/nsgaii.rs
+++ b/rustuna_pyo3/src/sampler/nsgaii.rs
@@ -96,6 +96,11 @@ impl PyNSGAIISampler {
         })
     }
 
+    fn before_trial(&self, ctx: &PySamplerContext, storage: Py<PyAny>) -> PyResult<()> {
+        let _ = (ctx, storage);
+        Ok(())
+    }
+
     #[pyo3(signature = (ctx, storage, state, values = None))]
     fn after_trial(
         &self,

--- a/rustuna_pyo3/src/sampler/random.rs
+++ b/rustuna_pyo3/src/sampler/random.rs
@@ -66,6 +66,11 @@ impl PyRandomSampler {
         Ok(HashMap::new())
     }
 
+    fn before_trial(&self, ctx: &PySamplerContext, storage: Py<PyAny>) -> PyResult<()> {
+        let _ = (ctx, storage);
+        Ok(())
+    }
+
     #[pyo3(signature = (ctx, storage, state, values = None))]
     fn after_trial(
         &self,

--- a/rustuna_pyo3/src/sampler/to_rust.rs
+++ b/rustuna_pyo3/src/sampler/to_rust.rs
@@ -28,6 +28,31 @@ impl ToRustSampler {
     }
 }
 impl Sampler for ToRustSampler {
+    fn before_trial(
+        &self,
+        ctx: &SamplerContext,
+        storage: Arc<std::sync::RwLock<dyn rustuna_core::storage::Storage>>,
+    ) -> rustuna_core::Result<()> {
+        let obj = self.obj.lock().map_err(|e| {
+            rustuna_core::Error::with_reason(
+                rustuna_core::ErrorKind::SamplerError,
+                format!("Failed to acquire sampler object guard: {e}"),
+            )
+        })?;
+        Python::attach(|py| {
+            let py_ctx = PySamplerContext::from(ctx.clone());
+            let py_storage = ToPythonStorage::new(storage);
+            obj.call_method1(py, "before_trial", (py_ctx, py_storage))
+                .map_err(|e| {
+                    rustuna_core::Error::with_reason(
+                        rustuna_core::ErrorKind::SamplerError,
+                        e.to_string(),
+                    )
+                })?;
+            Ok(())
+        })
+    }
+
     fn sample_independent(
         &self,
         ctx: &SamplerContext,

--- a/rustuna_pyo3/src/sampler/tpe.rs
+++ b/rustuna_pyo3/src/sampler/tpe.rs
@@ -84,6 +84,11 @@ impl PyTpeSampler {
         })
     }
 
+    fn before_trial(&self, ctx: &PySamplerContext, storage: Py<PyAny>) -> PyResult<()> {
+        let _ = (ctx, storage);
+        Ok(())
+    }
+
     #[pyo3(signature = (ctx, storage, state, values = None))]
     fn after_trial(
         &self,

--- a/rustuna_pyo3/tests/storage_tests/test_to_rustuna_storage.py
+++ b/rustuna_pyo3/tests/storage_tests/test_to_rustuna_storage.py
@@ -112,15 +112,21 @@ class DummyJointSampler:
     def support_joint_sampling(self) -> bool:
         return True
 
+    def before_trial(
+        self,
+        ctx: rustuna.samplers.SamplerContext,
+        storage: rustuna.storages.StorageProtocol,
+    ) -> None:
+        return None
+
     def sample_joint(
         self,
         ctx: rustuna.samplers.SamplerContext,
         storage: rustuna.storages.StorageProtocol,
         search_space: dict[str, Distribution],
     ) -> dict[str, float]:
+        # TODO(c-bata): Avoid calling sample_joint if the search space is empty.
         if ctx.trial_number == 0:
-            # Even if search space is empty, rustuna calls sample_joint method.
-            # Since sample_joint() may be used as a replacement of before_trial() method.
             return {}
 
         self.sample_joint_is_called = True

--- a/rustuna_pyo3/tests/test_optuna_samplers.py
+++ b/rustuna_pyo3/tests/test_optuna_samplers.py
@@ -63,9 +63,17 @@ class RecordingSampler:
         return False
 
     def __init__(self) -> None:
+        self.before_trial_calls: list[tuple[int, int]] = []
         self.after_trial_calls: list[
             tuple[int, int, rustuna.trial.TrialState, list[float] | None]
         ] = []
+
+    def before_trial(
+        self,
+        ctx: rustuna.samplers.SamplerContext,
+        storage: rustuna.storages.StorageProtocol,
+    ) -> None:
+        self.before_trial_calls.append((ctx.study_id, ctx.trial_number))
 
     def sample_joint(
         self,
@@ -132,6 +140,18 @@ def test_to_optuna_sampler_after_trial_is_called() -> None:
         assert state == rustuna.trial.TrialState.COMPLETE
         assert values is not None
         assert len(values) == 1
+
+
+def test_to_optuna_sampler_before_trial_is_called() -> None:
+    sampler = RecordingSampler()
+    study = optuna.create_study(sampler=ToOptunaSampler(sampler), direction="minimize")
+
+    study.optimize(lambda trial: trial.suggest_float("x", -1.0, 1.0), n_trials=2)
+
+    assert sampler.before_trial_calls == [
+        (study._study_id, 0),
+        (study._study_id, 1),
+    ]
 
 
 def test_to_optuna_sampler_after_trial_failure_still_persists_trial() -> None:

--- a/rustuna_pyo3/tests/test_samplers.py
+++ b/rustuna_pyo3/tests/test_samplers.py
@@ -18,6 +18,13 @@ class DummyIndependentSampler:
     def support_joint_sampling(self) -> bool:
         return False
 
+    def before_trial(
+        self,
+        ctx: rustuna.samplers.SamplerContext,
+        storage: rustuna.storages.StorageProtocol,
+    ) -> None:
+        return None
+
     def sample_joint(
         self,
         ctx: rustuna.samplers.SamplerContext,
@@ -59,6 +66,13 @@ class DummyJointSampler:
     @property
     def support_joint_sampling(self) -> bool:
         return True
+
+    def before_trial(
+        self,
+        ctx: rustuna.samplers.SamplerContext,
+        storage: rustuna.storages.StorageProtocol,
+    ) -> None:
+        return None
 
     def sample_joint(
         self,
@@ -107,9 +121,18 @@ class DummyJointSampler:
 
 class RecordingSampler(DummyIndependentSampler):
     def __init__(self) -> None:
+        self.before_trial_calls: list[tuple[int, int, rustuna.trial.TrialState]] = []
         self.after_trial_calls: list[
             tuple[int, int, rustuna.trial.TrialState, list[float] | None]
         ] = []
+
+    def before_trial(
+        self,
+        ctx: rustuna.samplers.SamplerContext,
+        storage: rustuna.storages.StorageProtocol,
+    ) -> None:
+        trial = storage.get_trial(ctx.trial_id)
+        self.before_trial_calls.append((ctx.study_id, ctx.trial_number, trial.state))
 
     def after_trial(
         self,
@@ -175,6 +198,19 @@ def test_custom_sampler_after_trial_is_called() -> None:
         assert state == rustuna.trial.TrialState.COMPLETE
         assert values is not None
         assert len(values) == 1
+
+
+def test_custom_sampler_before_trial_is_called() -> None:
+    sampler = RecordingSampler()
+
+    study = rustuna.create_study(sampler=sampler)
+    study.optimize(lambda trial: trial.suggest_float("x", -1.0, 1.0), n_trials=3)
+
+    assert len(sampler.before_trial_calls) == 3
+    for study_id, trial_number, state in sampler.before_trial_calls:
+        assert study_id == study._study_id
+        assert trial_number >= 0
+        assert state == rustuna.trial.TrialState.RUNNING
 
 
 def test_custom_sampler_after_trial_failure_still_persists_trial() -> None:


### PR DESCRIPTION
## Summary

This provides the Rust counterpart of Optuna's `BaseSampler.before_trial` hook.

- Add a `before_trial` hook to the `rustuna_core::sampler::Sampler` trait.
- Invoke the hook in `Study::ask` after a trial is created and before inferring the joint search space.
- Add before_trial methods in SamplerProtocol
