### PR TITLE
Preserve empty study names in `ToOptunaStorage`

### DIFF
--- a/rustuna_pyo3/rustuna/converter/_storage.py
+++ b/rustuna_pyo3/rustuna/converter/_storage.py
@@ -286,7 +286,8 @@ class ToOptunaStorage(BaseStorage):
             else:
                 raise ValueError("Unexpected Study Direction")
 
-        study_name = study_name or DEFAULT_STUDY_NAME_PREFIX + str(uuid.uuid4())
+        if study_name is None:
+            study_name = DEFAULT_STUDY_NAME_PREFIX + str(uuid.uuid4())
         try:
             study = self._storage.create_new_study(study_name, rustuna_directions)
         except rustuna.exceptions.DuplicatedStudyError as e:


### PR DESCRIPTION
## Summary

- Preserve explicitly supplied empty study names in `ToOptunaStorage`.
- Generate an automatic study name only when `study_name` is `None`.

This aligns Rustuna with the updated Optuna storage contract described in [optuna/optuna#6818](https://github.com/optuna/optuna/pull/6818).