### PR TITLE
Require `after_trial` in sampler adapters

### DIFF
--- a/rustuna_pyo3/rustuna/converter/_sampler.py
+++ b/rustuna_pyo3/rustuna/converter/_sampler.py
@@ -155,10 +155,6 @@ class ToOptunaSampler(BaseSampler):
         values: Sequence[float] | None,
     ) -> None:
         """Notify the Rustuna sampler that a trial has finished."""
-        after_trial = getattr(self._sampler, "after_trial", None)
-        if after_trial is None:
-            return
-
         ctx = rustuna.samplers.SamplerContext(
             study_id=study._study_id,
             trial_number=trial.number,
@@ -166,7 +162,7 @@ class ToOptunaSampler(BaseSampler):
             directions=to_rustuna_directions(study._directions),
         )
         storage = self._get_storage(study._storage)
-        after_trial(
+        self._sampler.after_trial(
             ctx,
             storage,
             to_rustuna_state(state),

--- a/rustuna_pyo3/src/sampler/to_rust.rs
+++ b/rustuna_pyo3/src/sampler/to_rust.rs
@@ -189,15 +189,6 @@ impl Sampler for ToRustSampler {
             )
         })?;
         Python::attach(|py| {
-            if !obj.bind(py).hasattr("after_trial").map_err(|e| {
-                rustuna_core::Error::with_reason(
-                    rustuna_core::ErrorKind::SamplerError,
-                    e.to_string(),
-                )
-            })? {
-                return Ok(());
-            }
-
             let py_ctx = PySamplerContext::from(ctx.clone());
             let py_storage = ToPythonStorage::new(storage.clone());
             obj.call_method1(py, "after_trial", (py_ctx, py_storage, py_state, py_values))

--- a/rustuna_pyo3/tests/storage_tests/test_to_rustuna_storage.py
+++ b/rustuna_pyo3/tests/storage_tests/test_to_rustuna_storage.py
@@ -159,6 +159,15 @@ class DummyJointSampler:
             return 0.0
         assert False, "Unreachable code"
 
+    def after_trial(
+        self,
+        ctx: rustuna.samplers.SamplerContext,
+        storage: rustuna.storages.StorageProtocol,
+        state: rustuna.trial.TrialState,
+        values: list[float] | None = None,
+    ) -> None:
+        pass
+
 
 def test_storage_cache_joint_search_space():
     def objective(trial: rustuna.Trial) -> float:


### PR DESCRIPTION
## Summary

Follow-up #234 

Make `after_trial` a required sampler hook, consistently with `SamplerProtocol`.

- Remove the `getattr` fallback from `ToOptunaSampler`.
- Remove the `hasattr` check from `ToRustSampler`.
