### PR TITLE
Fix NSGA-II generation cache sync by introducing Incremental Indexing

### DIFF
--- a/rustuna_sampler/src/nsgaii.rs
+++ b/rustuna_sampler/src/nsgaii.rs
@@ -66,6 +66,14 @@ pub struct NSGAIISampler {
     /// Cache mapping generation number to completed trial numbers in that generation.
     /// Updated incrementally in `after_trial` so `sample_joint` does not scan all trials every time.
     generation_to_numbers: RwLock<HashMap<u32, Vec<u32>>>,
+    generation_sync_state: Mutex<GenerationSyncState>,
+}
+
+#[derive(Default)]
+struct GenerationSyncState {
+    cached_study_id: Option<u32>,
+    unfinished_trial_numbers: Vec<u32>,
+    unseen_trial_start: usize,
 }
 impl Default for NSGAIISampler {
     fn default() -> Self {
@@ -94,6 +102,7 @@ impl NSGAIISampler {
             crossover_prob,
             swapping_prob,
             generation_to_numbers: RwLock::new(HashMap::new()),
+            generation_sync_state: Mutex::new(GenerationSyncState::default()),
         }
     }
     /// Creates a reproducibly seeded NSGA-II sampler.
@@ -114,6 +123,7 @@ impl NSGAIISampler {
             crossover_prob,
             swapping_prob,
             generation_to_numbers: RwLock::new(HashMap::new()),
+            generation_sync_state: Mutex::new(GenerationSyncState::default()),
         }
     }
     fn get_rng_lock(&self) -> Result<MutexGuard<'_, StdRng>> {
@@ -144,23 +154,83 @@ impl NSGAIISampler {
             )
         })
     }
-    fn rebuild_generation_cache(&self, trials: &[Option<PersistedTrial>]) -> Result<()> {
+    fn get_generation_sync_state_lock(&self) -> Result<MutexGuard<'_, GenerationSyncState>> {
+        self.generation_sync_state.lock().map_err(|e| {
+            Error::with_reason(
+                ErrorKind::SamplerError,
+                format!("Failed to acquire generation_sync_state guard: {e}"),
+            )
+        })
+    }
+    fn sync_generation_cache(
+        &self,
+        study_id: u32,
+        trials: &[Option<PersistedTrial>],
+    ) -> Result<()> {
+        let mut sync_state = self.get_generation_sync_state_lock()?;
         let mut generation_to_numbers = self.get_generation_to_numbers_write_lock()?;
-        generation_to_numbers.clear();
-        let generation_key = AttrKey::System("generation".into());
-        for trial in trials.iter().flatten() {
-            if !matches!(trial.state_values, TrialStateValues::Complete(_)) {
+
+        if sync_state.cached_study_id != Some(study_id)
+            || trials.len() < sync_state.unseen_trial_start
+        {
+            sync_state.cached_study_id = Some(study_id);
+            generation_to_numbers.clear();
+            sync_state.unfinished_trial_numbers.clear();
+            sync_state.unseen_trial_start = 0;
+        }
+
+        let mut next_unfinished_trial_numbers = Vec::with_capacity(
+            sync_state.unfinished_trial_numbers.len()
+                + trials.len().saturating_sub(sync_state.unseen_trial_start),
+        );
+        for trial_number in sync_state.unfinished_trial_numbers.iter().copied() {
+            let Some(trial) = trials.get(trial_number as usize).and_then(Option::as_ref) else {
                 continue;
-            }
-            if let Some(gen_str) = trial.attrs.get(&generation_key) {
-                if let Ok(generation) = gen_str.parse::<u32>() {
-                    generation_to_numbers
-                        .entry(generation)
-                        .or_default()
-                        .push(trial.number);
+            };
+            match &trial.state_values {
+                TrialStateValues::Complete(_) => {
+                    if let Some(generation) = trial
+                        .attrs
+                        .get(&AttrKey::System("generation".into()))
+                        .and_then(|generation| generation.parse::<u32>().ok())
+                    {
+                        let numbers = generation_to_numbers.entry(generation).or_default();
+                        if !numbers.contains(&trial.number) {
+                            numbers.push(trial.number);
+                        }
+                    }
+                }
+                TrialStateValues::Pruned | TrialStateValues::Fail => {}
+                TrialStateValues::Running | TrialStateValues::Waiting => {
+                    next_unfinished_trial_numbers.push(trial.number);
                 }
             }
         }
+
+        for trial in trials.iter().skip(sync_state.unseen_trial_start).flatten() {
+            match &trial.state_values {
+                TrialStateValues::Complete(_) => {
+                    if let Some(generation) = trial
+                        .attrs
+                        .get(&AttrKey::System("generation".into()))
+                        .and_then(|generation| generation.parse::<u32>().ok())
+                    {
+                        let numbers = generation_to_numbers.entry(generation).or_default();
+                        if !numbers.contains(&trial.number) {
+                            numbers.push(trial.number);
+                        }
+                    }
+                }
+                TrialStateValues::Pruned | TrialStateValues::Fail => {}
+                TrialStateValues::Running | TrialStateValues::Waiting => {
+                    if !next_unfinished_trial_numbers.contains(&trial.number) {
+                        next_unfinished_trial_numbers.push(trial.number);
+                    }
+                }
+            }
+        }
+        sync_state.unfinished_trial_numbers = next_unfinished_trial_numbers;
+        sync_state.unseen_trial_start = trials.len();
         Ok(())
     }
     /// Builds the study-system-attribute key under which parent trial IDs for `generation`
@@ -249,12 +319,12 @@ impl NSGAIISampler {
         }
         Ok(elite_population_numbers)
     }
-    fn get_child_generation(&self, trials: &[Option<PersistedTrial>]) -> Result<u32> {
-        // TODO: Incrementally sync trials completed by other workers without a full rescan.
-        if self.get_generation_to_numbers_read_lock()?.is_empty() {
-            self.rebuild_generation_cache(trials)?;
-        }
-
+    fn get_child_generation(
+        &self,
+        study_id: u32,
+        trials: &[Option<PersistedTrial>],
+    ) -> Result<u32> {
+        self.sync_generation_cache(study_id, trials)?;
         let mut child_generation = 0u32;
         loop {
             let full = self
@@ -427,7 +497,7 @@ impl Sampler for NSGAIISampler {
         let (child_generation, parent_population_numbers, parent_cache_attrs) = {
             let child_generation = {
                 let trials = guard.get_trials(ctx.study_id)?;
-                self.get_child_generation(trials)?
+                self.get_child_generation(ctx.study_id, trials)?
             };
 
             let study_attrs = guard.get_study(ctx.study_id)?.attrs.clone();
@@ -562,14 +632,21 @@ impl Sampler for NSGAIISampler {
                 .write()
                 .map_err(|_e| Error::new(ErrorKind::Unexpected))?;
             let trial = guard.get_trial(ctx.trial_id)?;
-            let generation_key = AttrKey::System("generation".into());
-            if let Some(gen_str) = trial.attrs.get(&generation_key) {
-                if let Ok(generation) = gen_str.parse::<u32>() {
+            if let Some(generation) = trial
+                .attrs
+                .get(&AttrKey::System("generation".into()))
+                .and_then(|generation| generation.parse::<u32>().ok())
+            {
+                let mut sync_state = self.get_generation_sync_state_lock()?;
+                if sync_state.cached_study_id == Some(ctx.study_id) {
+                    sync_state
+                        .unfinished_trial_numbers
+                        .retain(|&number| number != trial.number);
                     let mut generation_to_numbers = self.get_generation_to_numbers_write_lock()?;
-                    generation_to_numbers
-                        .entry(generation)
-                        .or_default()
-                        .push(trial.number);
+                    let numbers = generation_to_numbers.entry(generation).or_default();
+                    if !numbers.contains(&trial.number) {
+                        numbers.push(trial.number);
+                    }
                 }
             }
         }
@@ -783,6 +860,21 @@ mod tests {
     use super::*;
     use rustuna_core::storage::InMemoryStorage;
     use rustuna_core::study::{create_study, Direction};
+
+    fn persisted_trial(
+        number: u32,
+        state_values: TrialStateValues,
+        generation: Option<u32>,
+    ) -> PersistedTrial {
+        let mut trial = PersistedTrial::new(number, 0, number);
+        trial.state_values = state_values;
+        if let Some(generation) = generation {
+            trial
+                .attrs
+                .insert(AttrKey::System("generation".into()), generation.to_string());
+        }
+        trial
+    }
     #[test]
     fn test_optimize() {
         let storage = InMemoryStorage::new();
@@ -980,6 +1072,150 @@ mod tests {
                 ta.number
             );
         }
+    }
+
+    #[test]
+    fn test_get_child_generation_indexes_newly_appended_completed_trials() {
+        let sampler = NSGAIISampler::new(2, None, 1.0, 1.0);
+        let mut trials = vec![Some(persisted_trial(
+            0,
+            TrialStateValues::Complete(vec![0.0, 0.0]),
+            Some(0),
+        ))];
+
+        assert_eq!(sampler.get_child_generation(0, &trials).unwrap(), 0);
+
+        trials.push(Some(persisted_trial(
+            1,
+            TrialStateValues::Complete(vec![1.0, 1.0]),
+            Some(0),
+        )));
+
+        assert_eq!(sampler.get_child_generation(0, &trials).unwrap(), 1);
+        assert_eq!(
+            sampler
+                .get_generation_to_numbers_read_lock()
+                .unwrap()
+                .get(&0),
+            Some(&vec![0, 1])
+        );
+    }
+
+    #[test]
+    fn test_get_child_generation_rechecks_unfinished_trials() {
+        let sampler = NSGAIISampler::new(1, None, 1.0, 1.0);
+        let mut trials = vec![Some(persisted_trial(0, TrialStateValues::Running, Some(0)))];
+
+        assert_eq!(sampler.get_child_generation(0, &trials).unwrap(), 0);
+        assert_eq!(
+            sampler
+                .get_generation_sync_state_lock()
+                .unwrap()
+                .unfinished_trial_numbers
+                .as_slice(),
+            &[0]
+        );
+
+        trials[0] = Some(persisted_trial(
+            0,
+            TrialStateValues::Complete(vec![0.0, 0.0]),
+            Some(0),
+        ));
+
+        assert_eq!(sampler.get_child_generation(0, &trials).unwrap(), 1);
+        assert!(sampler
+            .get_generation_sync_state_lock()
+            .unwrap()
+            .unfinished_trial_numbers
+            .is_empty());
+        assert_eq!(
+            sampler
+                .get_generation_to_numbers_read_lock()
+                .unwrap()
+                .get(&0),
+            Some(&vec![0])
+        );
+    }
+
+    #[test]
+    fn test_get_child_generation_resets_cache_when_trial_list_shrinks() {
+        let sampler = NSGAIISampler::new(2, None, 1.0, 1.0);
+        let full_trials = vec![
+            Some(persisted_trial(
+                0,
+                TrialStateValues::Complete(vec![0.0, 0.0]),
+                Some(0),
+            )),
+            Some(persisted_trial(
+                1,
+                TrialStateValues::Complete(vec![1.0, 1.0]),
+                Some(0),
+            )),
+        ];
+
+        assert_eq!(sampler.get_child_generation(0, &full_trials).unwrap(), 1);
+
+        let shortened_trials = vec![Some(persisted_trial(
+            0,
+            TrialStateValues::Complete(vec![0.0, 0.0]),
+            Some(0),
+        ))];
+
+        assert_eq!(
+            sampler.get_child_generation(0, &shortened_trials).unwrap(),
+            0
+        );
+        assert_eq!(
+            sampler
+                .get_generation_sync_state_lock()
+                .unwrap()
+                .unseen_trial_start,
+            1
+        );
+        assert_eq!(
+            sampler
+                .get_generation_to_numbers_read_lock()
+                .unwrap()
+                .get(&0),
+            Some(&vec![0])
+        );
+    }
+
+    #[test]
+    fn test_generation_cache_picks_up_external_completion_before_assigning_child_generation() {
+        let study = create_study(
+            "generation-cache-stale-workers",
+            InMemoryStorage::new(),
+            NSGAIISampler::new(2, None, 1.0, 1.0),
+            vec![Direction::Minimize, Direction::Minimize],
+        )
+        .unwrap();
+        let worker = rustuna_core::study::Study::from_id(
+            study.id,
+            Arc::clone(&study.storage),
+            Arc::new(NSGAIISampler::new(2, None, 1.0, 1.0)),
+        )
+        .unwrap();
+
+        let trial0 = study.ask().unwrap();
+        let trial1 = worker.ask().unwrap();
+        study
+            .tell(trial0.number, TrialStateValues::Complete(vec![0.0, 1.0]))
+            .unwrap();
+        worker
+            .tell(trial1.number, TrialStateValues::Complete(vec![1.0, 0.0]))
+            .unwrap();
+
+        let next_trial = study.ask().unwrap();
+        let mut storage = study.storage.write().unwrap();
+        assert_eq!(
+            storage
+                .get_trial(next_trial.id)
+                .unwrap()
+                .attrs
+                .get(&AttrKey::System("generation".into())),
+            Some(&"1".to_string())
+        );
     }
 
     #[test]

--- a/rustuna_sampler/src/nsgaii.rs
+++ b/rustuna_sampler/src/nsgaii.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::ops::DerefMut;
-use std::sync::{Arc, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::{Arc, Mutex, MutexGuard, RwLock};
 
 use rand::prelude::*;
 use rand::rngs::StdRng;
@@ -63,15 +63,14 @@ pub struct NSGAIISampler {
     mutation_prob: Option<f64>,
     crossover_prob: f64,
     swapping_prob: f64,
-    /// Cache mapping generation number to completed trial numbers in that generation.
-    /// Updated incrementally in `after_trial` so `sample_joint` does not scan all trials every time.
-    generation_to_numbers: RwLock<HashMap<u32, Vec<u32>>>,
     generation_sync_state: Mutex<GenerationSyncState>,
 }
 
 #[derive(Default)]
 struct GenerationSyncState {
     cached_study_id: Option<u32>,
+    generation_offset: u32,
+    generation_numbers: VecDeque<Vec<u32>>,
     unfinished_trial_numbers: Vec<u32>,
     unseen_trial_start: usize,
 }
@@ -101,7 +100,6 @@ impl NSGAIISampler {
             mutation_prob,
             crossover_prob,
             swapping_prob,
-            generation_to_numbers: RwLock::new(HashMap::new()),
             generation_sync_state: Mutex::new(GenerationSyncState::default()),
         }
     }
@@ -122,7 +120,6 @@ impl NSGAIISampler {
             mutation_prob,
             crossover_prob,
             swapping_prob,
-            generation_to_numbers: RwLock::new(HashMap::new()),
             generation_sync_state: Mutex::new(GenerationSyncState::default()),
         }
     }
@@ -131,26 +128,6 @@ impl NSGAIISampler {
             Error::with_reason(
                 ErrorKind::SamplerError,
                 format!("Failed to acquire RNG guard: {e}"),
-            )
-        })
-    }
-    fn get_generation_to_numbers_read_lock(
-        &self,
-    ) -> Result<RwLockReadGuard<'_, HashMap<u32, Vec<u32>>>> {
-        self.generation_to_numbers.read().map_err(|e| {
-            Error::with_reason(
-                ErrorKind::SamplerError,
-                format!("Failed to acquire generation_to_numbers read guard: {e}"),
-            )
-        })
-    }
-    fn get_generation_to_numbers_write_lock(
-        &self,
-    ) -> Result<RwLockWriteGuard<'_, HashMap<u32, Vec<u32>>>> {
-        self.generation_to_numbers.write().map_err(|e| {
-            Error::with_reason(
-                ErrorKind::SamplerError,
-                format!("Failed to acquire generation_to_numbers write guard: {e}"),
             )
         })
     }
@@ -166,15 +143,15 @@ impl NSGAIISampler {
         &self,
         study_id: u32,
         trials: &[Option<PersistedTrial>],
-    ) -> Result<()> {
+    ) -> Result<u32> {
         let mut sync_state = self.get_generation_sync_state_lock()?;
-        let mut generation_to_numbers = self.get_generation_to_numbers_write_lock()?;
 
         if sync_state.cached_study_id != Some(study_id)
             || trials.len() < sync_state.unseen_trial_start
         {
             sync_state.cached_study_id = Some(study_id);
-            generation_to_numbers.clear();
+            sync_state.generation_offset = 0;
+            sync_state.generation_numbers.clear();
             sync_state.unfinished_trial_numbers.clear();
             sync_state.unseen_trial_start = 0;
         }
@@ -183,7 +160,7 @@ impl NSGAIISampler {
             sync_state.unfinished_trial_numbers.len()
                 + trials.len().saturating_sub(sync_state.unseen_trial_start),
         );
-        for trial_number in sync_state.unfinished_trial_numbers.iter().copied() {
+        for trial_number in std::mem::take(&mut sync_state.unfinished_trial_numbers) {
             let Some(trial) = trials.get(trial_number as usize).and_then(Option::as_ref) else {
                 continue;
             };
@@ -194,9 +171,15 @@ impl NSGAIISampler {
                         .get(&AttrKey::System("generation".into()))
                         .and_then(|generation| generation.parse::<u32>().ok())
                     {
-                        let numbers = generation_to_numbers.entry(generation).or_default();
-                        if !numbers.contains(&trial.number) {
-                            numbers.push(trial.number);
+                        if generation >= sync_state.generation_offset {
+                            let index = (generation - sync_state.generation_offset) as usize;
+                            sync_state
+                                .generation_numbers
+                                .resize_with(index + 1, Vec::new);
+                            let numbers = &mut sync_state.generation_numbers[index];
+                            if !numbers.contains(&trial.number) {
+                                numbers.push(trial.number);
+                            }
                         }
                     }
                 }
@@ -215,9 +198,15 @@ impl NSGAIISampler {
                         .get(&AttrKey::System("generation".into()))
                         .and_then(|generation| generation.parse::<u32>().ok())
                     {
-                        let numbers = generation_to_numbers.entry(generation).or_default();
-                        if !numbers.contains(&trial.number) {
-                            numbers.push(trial.number);
+                        if generation >= sync_state.generation_offset {
+                            let index = (generation - sync_state.generation_offset) as usize;
+                            sync_state
+                                .generation_numbers
+                                .resize_with(index + 1, Vec::new);
+                            let numbers = &mut sync_state.generation_numbers[index];
+                            if !numbers.contains(&trial.number) {
+                                numbers.push(trial.number);
+                            }
                         }
                     }
                 }
@@ -231,8 +220,17 @@ impl NSGAIISampler {
         }
         sync_state.unfinished_trial_numbers = next_unfinished_trial_numbers;
         sync_state.unseen_trial_start = trials.len();
-        Ok(())
+        let full_generations = sync_state
+            .generation_numbers
+            .iter()
+            .take_while(|numbers| numbers.len() >= self.population_size)
+            .count() as u32;
+        sync_state
+            .generation_offset
+            .checked_add(full_generations)
+            .ok_or_else(|| Error::with_reason(ErrorKind::Unexpected, "NSGA-II generation overflow"))
     }
+
     /// Builds the study-system-attribute key under which parent trial IDs for `generation`
     /// are persisted.
     fn parent_cache_key(generation: u32) -> AttrKey {
@@ -324,21 +322,7 @@ impl NSGAIISampler {
         study_id: u32,
         trials: &[Option<PersistedTrial>],
     ) -> Result<u32> {
-        self.sync_generation_cache(study_id, trials)?;
-        let mut child_generation = 0u32;
-        loop {
-            let full = self
-                .get_generation_to_numbers_read_lock()?
-                .get(&child_generation)
-                .is_some_and(|numbers| numbers.len() >= self.population_size);
-            if !full {
-                break;
-            }
-            child_generation = child_generation.checked_add(1).ok_or_else(|| {
-                Error::with_reason(ErrorKind::Unexpected, "NSGA-II generation overflow")
-            })?;
-        }
-        Ok(child_generation)
+        self.sync_generation_cache(study_id, trials)
     }
 
     fn get_parent_population_numbers(
@@ -365,14 +349,35 @@ impl NSGAIISampler {
 
         // Recompute elite selection for each missing generation.
         let mut new_attrs = Attrs::new();
+        let generation_key = AttrKey::System("generation".into());
         for generation in first_missing_generation..=child_generation {
-            let population_numbers = match self
-                .get_generation_to_numbers_read_lock()?
-                .get(&(generation - 1))
-            {
-                Some(numbers) if numbers.len() >= self.population_size => numbers.clone(),
-                _ => break,
-            };
+            let target_generation = generation - 1;
+            let population_numbers = {
+                let sync_state = self.get_generation_sync_state_lock()?;
+                target_generation
+                    .checked_sub(sync_state.generation_offset)
+                    .and_then(|index| sync_state.generation_numbers.get(index as usize))
+                    .filter(|numbers| numbers.len() >= self.population_size)
+                    .cloned()
+            }
+            .unwrap_or_else(|| {
+                trials
+                    .iter()
+                    .flatten()
+                    .filter(|trial| {
+                        matches!(trial.state_values, TrialStateValues::Complete(_))
+                            && trial
+                                .attrs
+                                .get(&generation_key)
+                                .and_then(|generation| generation.parse::<u32>().ok())
+                                == Some(target_generation)
+                    })
+                    .map(|trial| trial.number)
+                    .collect()
+            });
+            if population_numbers.len() < self.population_size {
+                break;
+            }
 
             let mut candidates = population_numbers;
             candidates.append(&mut parent_population_numbers);
@@ -558,6 +563,12 @@ impl Sampler for NSGAIISampler {
         if !parent_cache_attrs.is_empty() {
             guard.set_study_attrs(ctx.study_id, parent_cache_attrs, false)?;
         }
+        let mut sync_state = self.get_generation_sync_state_lock()?;
+        let discard_count = child_generation.saturating_sub(sync_state.generation_offset) as usize;
+        let discard_count = discard_count.min(sync_state.generation_numbers.len());
+        sync_state.generation_numbers.drain(..discard_count);
+        sync_state.generation_offset = child_generation;
+        drop(sync_state);
 
         if child_generation == 0 {
             drop(guard);
@@ -642,10 +653,15 @@ impl Sampler for NSGAIISampler {
                     sync_state
                         .unfinished_trial_numbers
                         .retain(|&number| number != trial.number);
-                    let mut generation_to_numbers = self.get_generation_to_numbers_write_lock()?;
-                    let numbers = generation_to_numbers.entry(generation).or_default();
-                    if !numbers.contains(&trial.number) {
-                        numbers.push(trial.number);
+                    if generation >= sync_state.generation_offset {
+                        let index = (generation - sync_state.generation_offset) as usize;
+                        sync_state
+                            .generation_numbers
+                            .resize_with(index + 1, Vec::new);
+                        let numbers = &mut sync_state.generation_numbers[index];
+                        if !numbers.contains(&trial.number) {
+                            numbers.push(trial.number);
+                        }
                     }
                 }
             }
@@ -1092,13 +1108,9 @@ mod tests {
         )));
 
         assert_eq!(sampler.get_child_generation(0, &trials).unwrap(), 1);
-        assert_eq!(
-            sampler
-                .get_generation_to_numbers_read_lock()
-                .unwrap()
-                .get(&0),
-            Some(&vec![0, 1])
-        );
+        let sync_state = sampler.get_generation_sync_state_lock().unwrap();
+        assert_eq!(sync_state.generation_offset, 0);
+        assert_eq!(sync_state.generation_numbers, VecDeque::from([vec![0, 1]]));
     }
 
     #[test]
@@ -1128,13 +1140,61 @@ mod tests {
             .unwrap()
             .unfinished_trial_numbers
             .is_empty());
-        assert_eq!(
-            sampler
-                .get_generation_to_numbers_read_lock()
-                .unwrap()
-                .get(&0),
-            Some(&vec![0])
-        );
+        let sync_state = sampler.get_generation_sync_state_lock().unwrap();
+        assert_eq!(sync_state.generation_offset, 0);
+        assert_eq!(sync_state.generation_numbers, VecDeque::from([vec![0]]));
+    }
+
+    #[test]
+    fn test_late_completion_from_discarded_generation_does_not_move_frontier() {
+        let study = create_study(
+            "generation-frontier-late-completion",
+            InMemoryStorage::new(),
+            NSGAIISampler::new(2, None, 1.0, 1.0),
+            vec![Direction::Minimize, Direction::Minimize],
+        )
+        .unwrap();
+        let make_worker = || {
+            rustuna_core::study::Study::from_id(
+                study.id,
+                Arc::clone(&study.storage),
+                Arc::new(NSGAIISampler::new(2, None, 1.0, 1.0)),
+            )
+            .unwrap()
+        };
+        let worker = make_worker();
+        let late_worker = make_worker();
+
+        let trial0 = study.ask().unwrap();
+        let trial1 = worker.ask().unwrap();
+        let late_trial = late_worker.ask().unwrap();
+        study
+            .tell(trial0.number, TrialStateValues::Complete(vec![0.0, 1.0]))
+            .unwrap();
+        worker
+            .tell(trial1.number, TrialStateValues::Complete(vec![1.0, 0.0]))
+            .unwrap();
+        let first_child = study.ask().unwrap();
+
+        late_worker
+            .tell(
+                late_trial.number,
+                TrialStateValues::Complete(vec![0.5, 0.5]),
+            )
+            .unwrap();
+        let second_child = study.ask().unwrap();
+
+        let mut storage = study.storage.write().unwrap();
+        for child in [first_child, second_child] {
+            assert_eq!(
+                storage
+                    .get_trial(child.id)
+                    .unwrap()
+                    .attrs
+                    .get(&AttrKey::System("generation".into())),
+                Some(&"1".to_string())
+            );
+        }
     }
 
     #[test]
@@ -1172,13 +1232,9 @@ mod tests {
                 .unseen_trial_start,
             1
         );
-        assert_eq!(
-            sampler
-                .get_generation_to_numbers_read_lock()
-                .unwrap()
-                .get(&0),
-            Some(&vec![0])
-        );
+        let sync_state = sampler.get_generation_sync_state_lock().unwrap();
+        assert_eq!(sync_state.generation_offset, 0);
+        assert_eq!(sync_state.generation_numbers, VecDeque::from([vec![0]]));
     }
 
     #[test]

--- a/rustuna_sampler/src/nsgaii.rs
+++ b/rustuna_sampler/src/nsgaii.rs
@@ -69,8 +69,8 @@ pub struct NSGAIISampler {
 #[derive(Default)]
 struct GenerationSyncState {
     cached_study_id: Option<u32>,
-    generation_offset: u32,
-    generation_numbers: VecDeque<Vec<u32>>,
+    cached_child_generation: u32,
+    cached_children: VecDeque<Vec<u32>>,
     unfinished_trial_numbers: Vec<u32>,
     unseen_trial_start: usize,
 }
@@ -139,7 +139,7 @@ impl NSGAIISampler {
             )
         })
     }
-    fn sync_generation_frontier(
+    fn sync_child_generation(
         &self,
         study_id: u32,
         trials: &[Option<PersistedTrial>],
@@ -150,8 +150,8 @@ impl NSGAIISampler {
             || trials.len() < sync_state.unseen_trial_start
         {
             sync_state.cached_study_id = Some(study_id);
-            sync_state.generation_offset = 0;
-            sync_state.generation_numbers.clear();
+            sync_state.cached_child_generation = 0;
+            sync_state.cached_children.clear();
             sync_state.unfinished_trial_numbers.clear();
             sync_state.unseen_trial_start = 0;
         }
@@ -178,12 +178,10 @@ impl NSGAIISampler {
                         .get(&AttrKey::System("generation".into()))
                         .and_then(|generation| generation.parse::<u32>().ok())
                     {
-                        if generation >= sync_state.generation_offset {
-                            let index = (generation - sync_state.generation_offset) as usize;
-                            sync_state
-                                .generation_numbers
-                                .resize_with(index + 1, Vec::new);
-                            let numbers = &mut sync_state.generation_numbers[index];
+                        if generation >= sync_state.cached_child_generation {
+                            let index = (generation - sync_state.cached_child_generation) as usize;
+                            sync_state.cached_children.resize_with(index + 1, Vec::new);
+                            let numbers = &mut sync_state.cached_children[index];
                             if !numbers.contains(&trial.number) {
                                 numbers.push(trial.number);
                             }
@@ -205,12 +203,12 @@ impl NSGAIISampler {
         sync_state.unfinished_trial_numbers = unfinished_trial_numbers;
         sync_state.unseen_trial_start = trials.len();
         let full_generations = sync_state
-            .generation_numbers
+            .cached_children
             .iter()
             .take_while(|numbers| numbers.len() >= self.population_size)
             .count() as u32;
         sync_state
-            .generation_offset
+            .cached_child_generation
             .checked_add(full_generations)
             .ok_or_else(|| Error::with_reason(ErrorKind::Unexpected, "NSGA-II generation overflow"))
     }
@@ -331,8 +329,8 @@ impl NSGAIISampler {
             let population_numbers = {
                 let sync_state = self.get_generation_sync_state_lock()?;
                 target_generation
-                    .checked_sub(sync_state.generation_offset)
-                    .and_then(|index| sync_state.generation_numbers.get(index as usize))
+                    .checked_sub(sync_state.cached_child_generation)
+                    .and_then(|index| sync_state.cached_children.get(index as usize))
                     .filter(|numbers| numbers.len() >= self.population_size)
                     .cloned()
             }
@@ -478,7 +476,7 @@ impl Sampler for NSGAIISampler {
         let (child_generation, parent_population_numbers, parent_cache_attrs) = {
             let child_generation = {
                 let trials = guard.get_trials(ctx.study_id)?;
-                self.sync_generation_frontier(ctx.study_id, trials)?
+                self.sync_child_generation(ctx.study_id, trials)?
             };
 
             let study_attrs = guard.get_study(ctx.study_id)?.attrs.clone();
@@ -486,7 +484,7 @@ impl Sampler for NSGAIISampler {
             let cached_parent = if child_generation == 0 {
                 None
             } else {
-                // sync_generation_frontier follows get_trials above, which synchronizes this study's
+                // sync_child_generation follows get_trials above, which synchronizes this study's
                 // trials into the storage cache. Resolve only the persisted parent IDs from that
                 // cache instead of rebuilding an ID-to-number map from every completed trial.
                 let mut cached_parent = None;
@@ -540,10 +538,11 @@ impl Sampler for NSGAIISampler {
             guard.set_study_attrs(ctx.study_id, parent_cache_attrs, false)?;
         }
         let mut sync_state = self.get_generation_sync_state_lock()?;
-        let discard_count = child_generation.saturating_sub(sync_state.generation_offset) as usize;
-        let discard_count = discard_count.min(sync_state.generation_numbers.len());
-        sync_state.generation_numbers.drain(..discard_count);
-        sync_state.generation_offset = child_generation;
+        let discard_count =
+            child_generation.saturating_sub(sync_state.cached_child_generation) as usize;
+        let discard_count = discard_count.min(sync_state.cached_children.len());
+        sync_state.cached_children.drain(..discard_count);
+        sync_state.cached_child_generation = child_generation;
         drop(sync_state);
 
         if child_generation == 0 {
@@ -629,12 +628,10 @@ impl Sampler for NSGAIISampler {
                     sync_state
                         .unfinished_trial_numbers
                         .retain(|&number| number != trial.number);
-                    if generation >= sync_state.generation_offset {
-                        let index = (generation - sync_state.generation_offset) as usize;
-                        sync_state
-                            .generation_numbers
-                            .resize_with(index + 1, Vec::new);
-                        let numbers = &mut sync_state.generation_numbers[index];
+                    if generation >= sync_state.cached_child_generation {
+                        let index = (generation - sync_state.cached_child_generation) as usize;
+                        sync_state.cached_children.resize_with(index + 1, Vec::new);
+                        let numbers = &mut sync_state.cached_children[index];
                         if !numbers.contains(&trial.number) {
                             numbers.push(trial.number);
                         }

--- a/rustuna_sampler/src/nsgaii.rs
+++ b/rustuna_sampler/src/nsgaii.rs
@@ -301,14 +301,6 @@ impl NSGAIISampler {
         }
         Ok(elite_population_numbers)
     }
-    fn get_child_generation(
-        &self,
-        study_id: u32,
-        trials: &[Option<PersistedTrial>],
-    ) -> Result<u32> {
-        self.sync_generation_frontier(study_id, trials)
-    }
-
     fn get_parent_population_numbers(
         &self,
         ctx: &Context,
@@ -486,7 +478,7 @@ impl Sampler for NSGAIISampler {
         let (child_generation, parent_population_numbers, parent_cache_attrs) = {
             let child_generation = {
                 let trials = guard.get_trials(ctx.study_id)?;
-                self.get_child_generation(ctx.study_id, trials)?
+                self.sync_generation_frontier(ctx.study_id, trials)?
             };
 
             let study_attrs = guard.get_study(ctx.study_id)?.attrs.clone();
@@ -494,7 +486,7 @@ impl Sampler for NSGAIISampler {
             let cached_parent = if child_generation == 0 {
                 None
             } else {
-                // get_child_generation calls get_trials above, which synchronizes this study's
+                // sync_generation_frontier follows get_trials above, which synchronizes this study's
                 // trials into the storage cache. Resolve only the persisted parent IDs from that
                 // cache instead of rebuilding an ID-to-number map from every completed trial.
                 let mut cached_parent = None;
@@ -861,20 +853,6 @@ mod tests {
     use rustuna_core::storage::InMemoryStorage;
     use rustuna_core::study::{create_study, Direction};
 
-    fn persisted_trial(
-        number: u32,
-        state_values: TrialStateValues,
-        generation: Option<u32>,
-    ) -> PersistedTrial {
-        let mut trial = PersistedTrial::new(number, 0, number);
-        trial.state_values = state_values;
-        if let Some(generation) = generation {
-            trial
-                .attrs
-                .insert(AttrKey::System("generation".into()), generation.to_string());
-        }
-        trial
-    }
     #[test]
     fn test_optimize() {
         let storage = InMemoryStorage::new();
@@ -1072,190 +1050,6 @@ mod tests {
                 ta.number
             );
         }
-    }
-
-    #[test]
-    fn test_get_child_generation_indexes_newly_appended_completed_trials() {
-        let sampler = NSGAIISampler::new(2, None, 1.0, 1.0);
-        let mut trials = vec![Some(persisted_trial(
-            0,
-            TrialStateValues::Complete(vec![0.0, 0.0]),
-            Some(0),
-        ))];
-
-        assert_eq!(sampler.get_child_generation(0, &trials).unwrap(), 0);
-
-        trials.push(Some(persisted_trial(
-            1,
-            TrialStateValues::Complete(vec![1.0, 1.0]),
-            Some(0),
-        )));
-
-        assert_eq!(sampler.get_child_generation(0, &trials).unwrap(), 1);
-        let sync_state = sampler.get_generation_sync_state_lock().unwrap();
-        assert_eq!(sync_state.generation_offset, 0);
-        assert_eq!(sync_state.generation_numbers, VecDeque::from([vec![0, 1]]));
-    }
-
-    #[test]
-    fn test_get_child_generation_rechecks_unfinished_trials() {
-        let sampler = NSGAIISampler::new(1, None, 1.0, 1.0);
-        let mut trials = vec![Some(persisted_trial(0, TrialStateValues::Running, Some(0)))];
-
-        assert_eq!(sampler.get_child_generation(0, &trials).unwrap(), 0);
-        assert_eq!(
-            sampler
-                .get_generation_sync_state_lock()
-                .unwrap()
-                .unfinished_trial_numbers
-                .as_slice(),
-            &[0]
-        );
-
-        trials[0] = Some(persisted_trial(
-            0,
-            TrialStateValues::Complete(vec![0.0, 0.0]),
-            Some(0),
-        ));
-
-        assert_eq!(sampler.get_child_generation(0, &trials).unwrap(), 1);
-        assert!(sampler
-            .get_generation_sync_state_lock()
-            .unwrap()
-            .unfinished_trial_numbers
-            .is_empty());
-        let sync_state = sampler.get_generation_sync_state_lock().unwrap();
-        assert_eq!(sync_state.generation_offset, 0);
-        assert_eq!(sync_state.generation_numbers, VecDeque::from([vec![0]]));
-    }
-
-    #[test]
-    fn test_late_completion_from_discarded_generation_does_not_move_frontier() {
-        let study = create_study(
-            "generation-frontier-late-completion",
-            InMemoryStorage::new(),
-            NSGAIISampler::new(2, None, 1.0, 1.0),
-            vec![Direction::Minimize, Direction::Minimize],
-        )
-        .unwrap();
-        let make_worker = || {
-            rustuna_core::study::Study::from_id(
-                study.id,
-                Arc::clone(&study.storage),
-                Arc::new(NSGAIISampler::new(2, None, 1.0, 1.0)),
-            )
-            .unwrap()
-        };
-        let worker = make_worker();
-        let late_worker = make_worker();
-
-        let trial0 = study.ask().unwrap();
-        let trial1 = worker.ask().unwrap();
-        let late_trial = late_worker.ask().unwrap();
-        study
-            .tell(trial0.number, TrialStateValues::Complete(vec![0.0, 1.0]))
-            .unwrap();
-        worker
-            .tell(trial1.number, TrialStateValues::Complete(vec![1.0, 0.0]))
-            .unwrap();
-        let first_child = study.ask().unwrap();
-
-        late_worker
-            .tell(
-                late_trial.number,
-                TrialStateValues::Complete(vec![0.5, 0.5]),
-            )
-            .unwrap();
-        let second_child = study.ask().unwrap();
-
-        let mut storage = study.storage.write().unwrap();
-        for child in [first_child, second_child] {
-            assert_eq!(
-                storage
-                    .get_trial(child.id)
-                    .unwrap()
-                    .attrs
-                    .get(&AttrKey::System("generation".into())),
-                Some(&"1".to_string())
-            );
-        }
-    }
-
-    #[test]
-    fn test_get_child_generation_resets_cache_when_trial_list_shrinks() {
-        let sampler = NSGAIISampler::new(2, None, 1.0, 1.0);
-        let full_trials = vec![
-            Some(persisted_trial(
-                0,
-                TrialStateValues::Complete(vec![0.0, 0.0]),
-                Some(0),
-            )),
-            Some(persisted_trial(
-                1,
-                TrialStateValues::Complete(vec![1.0, 1.0]),
-                Some(0),
-            )),
-        ];
-
-        assert_eq!(sampler.get_child_generation(0, &full_trials).unwrap(), 1);
-
-        let shortened_trials = vec![Some(persisted_trial(
-            0,
-            TrialStateValues::Complete(vec![0.0, 0.0]),
-            Some(0),
-        ))];
-
-        assert_eq!(
-            sampler.get_child_generation(0, &shortened_trials).unwrap(),
-            0
-        );
-        assert_eq!(
-            sampler
-                .get_generation_sync_state_lock()
-                .unwrap()
-                .unseen_trial_start,
-            1
-        );
-        let sync_state = sampler.get_generation_sync_state_lock().unwrap();
-        assert_eq!(sync_state.generation_offset, 0);
-        assert_eq!(sync_state.generation_numbers, VecDeque::from([vec![0]]));
-    }
-
-    #[test]
-    fn test_generation_cache_picks_up_external_completion_before_assigning_child_generation() {
-        let study = create_study(
-            "generation-cache-stale-workers",
-            InMemoryStorage::new(),
-            NSGAIISampler::new(2, None, 1.0, 1.0),
-            vec![Direction::Minimize, Direction::Minimize],
-        )
-        .unwrap();
-        let worker = rustuna_core::study::Study::from_id(
-            study.id,
-            Arc::clone(&study.storage),
-            Arc::new(NSGAIISampler::new(2, None, 1.0, 1.0)),
-        )
-        .unwrap();
-
-        let trial0 = study.ask().unwrap();
-        let trial1 = worker.ask().unwrap();
-        study
-            .tell(trial0.number, TrialStateValues::Complete(vec![0.0, 1.0]))
-            .unwrap();
-        worker
-            .tell(trial1.number, TrialStateValues::Complete(vec![1.0, 0.0]))
-            .unwrap();
-
-        let next_trial = study.ask().unwrap();
-        let mut storage = study.storage.write().unwrap();
-        assert_eq!(
-            storage
-                .get_trial(next_trial.id)
-                .unwrap()
-                .attrs
-                .get(&AttrKey::System("generation".into())),
-            Some(&"1".to_string())
-        );
     }
 
     #[test]

--- a/rustuna_sampler/src/nsgaii.rs
+++ b/rustuna_sampler/src/nsgaii.rs
@@ -139,7 +139,7 @@ impl NSGAIISampler {
             )
         })
     }
-    fn sync_generation_cache(
+    fn sync_generation_frontier(
         &self,
         study_id: u32,
         trials: &[Option<PersistedTrial>],
@@ -156,12 +156,19 @@ impl NSGAIISampler {
             sync_state.unseen_trial_start = 0;
         }
 
-        let mut next_unfinished_trial_numbers = Vec::with_capacity(
-            sync_state.unfinished_trial_numbers.len()
-                + trials.len().saturating_sub(sync_state.unseen_trial_start),
-        );
-        for trial_number in std::mem::take(&mut sync_state.unfinished_trial_numbers) {
-            let Some(trial) = trials.get(trial_number as usize).and_then(Option::as_ref) else {
+        let unseen_trial_start = sync_state.unseen_trial_start;
+        let mut unfinished_trial_numbers = std::mem::take(&mut sync_state.unfinished_trial_numbers);
+        let unfinished_count = unfinished_trial_numbers.len();
+        let changed_trial_count =
+            unfinished_count + trials.len().saturating_sub(unseen_trial_start);
+        let mut next_unfinished_count = 0;
+        for position in 0..changed_trial_count {
+            let trial_index = if position < unfinished_count {
+                unfinished_trial_numbers[position] as usize
+            } else {
+                unseen_trial_start + position - unfinished_count
+            };
+            let Some(trial) = trials.get(trial_index).and_then(Option::as_ref) else {
                 continue;
             };
             match &trial.state_values {
@@ -185,40 +192,17 @@ impl NSGAIISampler {
                 }
                 TrialStateValues::Pruned | TrialStateValues::Fail => {}
                 TrialStateValues::Running | TrialStateValues::Waiting => {
-                    next_unfinished_trial_numbers.push(trial.number);
+                    if next_unfinished_count < unfinished_trial_numbers.len() {
+                        unfinished_trial_numbers[next_unfinished_count] = trial.number;
+                    } else {
+                        unfinished_trial_numbers.push(trial.number);
+                    }
+                    next_unfinished_count += 1;
                 }
             }
         }
-
-        for trial in trials.iter().skip(sync_state.unseen_trial_start).flatten() {
-            match &trial.state_values {
-                TrialStateValues::Complete(_) => {
-                    if let Some(generation) = trial
-                        .attrs
-                        .get(&AttrKey::System("generation".into()))
-                        .and_then(|generation| generation.parse::<u32>().ok())
-                    {
-                        if generation >= sync_state.generation_offset {
-                            let index = (generation - sync_state.generation_offset) as usize;
-                            sync_state
-                                .generation_numbers
-                                .resize_with(index + 1, Vec::new);
-                            let numbers = &mut sync_state.generation_numbers[index];
-                            if !numbers.contains(&trial.number) {
-                                numbers.push(trial.number);
-                            }
-                        }
-                    }
-                }
-                TrialStateValues::Pruned | TrialStateValues::Fail => {}
-                TrialStateValues::Running | TrialStateValues::Waiting => {
-                    if !next_unfinished_trial_numbers.contains(&trial.number) {
-                        next_unfinished_trial_numbers.push(trial.number);
-                    }
-                }
-            }
-        }
-        sync_state.unfinished_trial_numbers = next_unfinished_trial_numbers;
+        unfinished_trial_numbers.truncate(next_unfinished_count);
+        sync_state.unfinished_trial_numbers = unfinished_trial_numbers;
         sync_state.unseen_trial_start = trials.len();
         let full_generations = sync_state
             .generation_numbers
@@ -322,7 +306,7 @@ impl NSGAIISampler {
         study_id: u32,
         trials: &[Option<PersistedTrial>],
     ) -> Result<u32> {
-        self.sync_generation_cache(study_id, trials)
+        self.sync_generation_frontier(study_id, trials)
     }
 
     fn get_parent_population_numbers(


### PR DESCRIPTION
## Motivation

After #238, persisted parent populations are refreshed from storage, but the child-generation index remains local to each sampler instance. A worker can therefore miss trials already completed by another worker when assigning the next generation.

## Description of change

PR #133 introduced `generation_to_numbers: HashMap<u32, Vec<u32>>` in commit `4ccf0a85` to avoid repeatedly scanning every trial. It retained trial numbers for every completed generation and searched from generation zero when determining the next generation.

This PR removes:

- The unbounded `generation_to_numbers` map.
- Its separate `RwLock` and read/write lock helpers.
- The generation-zero-based search on every child-generation lookup.

It replaces them with a bounded incremental index:

- Synchronize newly added trials and recheck unfinished trials before assigning a generation.
- Store only the active children generation frontier in `VecDeque<Vec<u32>>`.
- Remove generation buckets after their parent populations have been persisted.
- Ignore late completions from generations older than the persisted frontier.

Incremental indexing is therefore retained, but its memory and lookup cost no longer grow with the number of completed generations.

## Benchmark and scripts

Compared with the previous #238-based implementation that retained all generation indexes:

| Benchmark | Previous | #244 | Improvement |
| --- | ---: | ---: | ---: |
| `(x, 1-x)`, 10,000 trials | 0.294s | 0.240s | 18.4% |
| Dense 40 parameters, 10,000 trials | 1.161s | 1.108s | 4.6% |
| WFG4 40 parameters, 100,000 trials | 58.858s | 46.963s | 20.2% |

### Rust benchmark

```rust
use std::env;
use std::time::Instant;

use rustuna_core::storage::InMemoryStorage;
use rustuna_core::study::{create_study, Direction};
use rustuna_sampler::nsgaii::NSGAIISampler;

fn main() -> rustuna_core::Result<()> {
    let mode = env::args().nth(1).unwrap_or_else(|| "simple".to_string());
    let study = create_study(
        "nsgaii-bench",
        InMemoryStorage::new(),
        NSGAIISampler::seed_from_u64(1, 50, None, 0.9, 0.5),
        vec![Direction::Minimize, Direction::Maximize],
    )?;
    let start = Instant::now();
    match mode.as_str() {
        "simple" => study.optimize(
            |mut trial| {
                let x = trial.suggest_float("x", 0.0, 1.0)?;
                Ok(vec![x, 1.0 - x])
            },
            10_000,
        )?,
        "dense40" => study.optimize(
            |mut trial| {
                let mut v0 = 0.0;
                let mut v1 = 0.0;
                for i in 0..40 {
                    let x = trial.suggest_float(&format!("x{i}"), 0.0, 1.0)?;
                    v0 += x * x;
                    v1 += (1.0 - x) * (1.0 - x);
                }
                Ok(vec![v0, v1])
            },
            10_000,
        )?,
        _ => panic!("unknown mode: {mode}"),
    }
    println!("mode={mode} elapsed={:.3}", start.elapsed().as_secs_f64());
    Ok(())
}
```


### WFG benchmark

```python
import os
import time

import optunahub
import rustuna

wfg = optunahub.load_module("benchmarks/wfg")
problem = wfg.Problem(function_id=4, n_objectives=2, dimension=40, k=2)
sampler = rustuna.samplers.NSGAIISampler(seed=1)
study = rustuna.create_study(
    sampler=sampler,
    directions=["minimize", "minimize"],
)


def objective(trial):
    params = {
        name: trial.suggest_float(name, distribution.low, distribution.high)
        for name, distribution in problem.search_space.items()
    }
    return list(problem.evaluate(params))


start = time.perf_counter()
study.optimize(objective, n_trials=int(os.environ.get("N_TRIALS", "10000")))
print(f"elapsed={time.perf_counter() - start:.3f}")
```
