### PR TITLE
Backport #247: Call `discard_trials` in `CmaEsSampler`

### DIFF
--- a/.github/workflows/checks_python.yml
+++ b/.github/workflows/checks_python.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - main
+      - release-python-v0.1.0
 
 permissions:
   contents: read

--- a/rustuna_pyo3/src/sampler/cmaes.rs
+++ b/rustuna_pyo3/src/sampler/cmaes.rs
@@ -202,11 +202,10 @@ impl CmaEsSamplerState {
         };
         if solutions.len() >= population_size {
             self.tell(solutions)?;
-            // TODO(c-bata): Consider calling discard_trials here.
-            // let mut guard = storage
-            //     .write()
-            //     .map_err(|_| Error::new(ErrorKind::Unexpected))?;
-            // guard.discard_trials(&self.solution_trial_ids)?;
+            let mut guard = storage
+                .write()
+                .map_err(|_| Error::new(ErrorKind::Unexpected))?;
+            guard.discard_trials(&self.solution_trial_ids)?;
             self.solution_trial_ids.clear();
         }
 

--- a/rustuna_pyo3/tests/sampler_tests/test_cmaes.py
+++ b/rustuna_pyo3/tests/sampler_tests/test_cmaes.py
@@ -4,11 +4,14 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 
 import rustuna
+from rustuna.trial import TrialState
 
 
-def test_cmaes_sampler() -> None:
+@pytest.mark.parametrize("apply_discard", [True, False])
+def test_cmaes_sampler(apply_discard: bool) -> None:
+    storage = rustuna.storages.InMemoryStorage(apply_discard=apply_discard)
     sampler = rustuna.samplers.CmaEsSampler(seed=1, popsize=4)
-    study = rustuna.create_study(sampler=sampler)
+    study = rustuna.create_study(sampler=sampler, storage=storage)
 
     def objective(trial: rustuna.Trial) -> float:
         x = trial.suggest_float("x", -10, 10)
@@ -17,10 +20,8 @@ def test_cmaes_sampler() -> None:
 
     study.optimize(objective, n_trials=10)
 
-    assert len(study.trials) == 10
-    assert all(
-        trial.state == rustuna.trial.TrialState.COMPLETE for trial in study.trials
-    )
+    if not apply_discard:
+        assert len(study.get_trials(states=[TrialState.COMPLETE])) == 10
 
 
 def test_cmaes_sampler_samples_independently_from_multiple_threads() -> None:


### PR DESCRIPTION
## Summary

- This PR backports #247 to `release-python-v0.1.0` branch.