### PR TITLE
Decouple Python package version from Cargo version

### DIFF
--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -46,13 +46,13 @@ jobs:
           python-version: "3.13"
           activate-environment: true
           enable-cache: false
-      - name: Compare the tag with the workspace version
+      - name: Compare the tag with the Python package version
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: |
           set -euo pipefail
-          version="$(python -c 'import pathlib, tomllib; print(tomllib.loads(pathlib.Path("Cargo.toml").read_text())["workspace"]["package"]["version"])')"
+          version="$(python -c 'import pathlib, tomllib; print(tomllib.loads(pathlib.Path("rustuna_pyo3/pyproject.toml").read_text())["project"]["version"])')"
           if [ "python-v${version}" != "${GITHUB_REF_NAME}" ]; then
-            echo "tag ${GITHUB_REF_NAME} does not match the workspace version ${version}" >&2
+            echo "tag ${GITHUB_REF_NAME} does not match the Python package version ${version}" >&2
             exit 1
           fi
 

--- a/rustuna_pyo3/pyproject.toml
+++ b/rustuna_pyo3/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
 ]
-dynamic = ["version"]
+version = "0.2.0.dev"
 
 [project.urls]
 homepage = "https://optuna.org/"


### PR DESCRIPTION
## Summary

This PR allows Python and Rust releases to use independent version numbers.

  - Define the Python package version directly in `rustuna_pyo3/pyproject.toml` because Maturin does not support reading the version from a Python attribute
  - Update the Python release workflow to compare release tags with the version specified in `pyproject.toml`
